### PR TITLE
Integrate Markdown rendering for first prompt in ChatBody component

### DIFF
--- a/src/components/chat/chat-body/chat-body.tsx
+++ b/src/components/chat/chat-body/chat-body.tsx
@@ -90,7 +90,6 @@ export default function ChatBody({
       </div>
     );
   }
-  console.log(activeWorkspace?.firstPrompt);
   if (messages.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-full p-8 text-center">


### PR DESCRIPTION
- Added ReactMarkdown and remark-gfm to render the first prompt with Markdown support.
- Updated the display logic to conditionally show the first prompt in a styled container.