### PR TITLE
clicking in rename dialog no longer close dialog and drawer

### DIFF
--- a/src/components/sidebar/threads/thread-rename-modal/thread-rename-modal.tsx
+++ b/src/components/sidebar/threads/thread-rename-modal/thread-rename-modal.tsx
@@ -38,7 +38,12 @@ export function ThreadRenameModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-[425px]">
+      <DialogContent 
+        className="sm:max-w-[425px]"
+        onPointerDown={(e) => {
+          e.stopPropagation();
+        }}
+      >
         <DialogHeader>
           <DialogTitle>Rename Thread</DialogTitle>
         </DialogHeader>


### PR DESCRIPTION
- when using the site in mobile mode you can now rename threads.