### PR TITLE
feat: switch SDK to npmjs.com and rename scope to @smartspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  packages: read
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -28,10 +27,6 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: package-lock.json
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@smartspace-ai'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGE_TOKEN }}
 
       - name: Install
         run: npm ci

--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -28,10 +28,6 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: package-lock.json
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@smartspace-ai'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGE_TOKEN }}
 
       - name: Check that AZURE_STORAGE_CONNECTION_STRING secret exists
         run: |

--- a/.github/workflows/sdk-bump.yml
+++ b/.github/workflows/sdk-bump.yml
@@ -1,0 +1,41 @@
+# Auto-bump @smartspace/api-client when a new SDK version is published.
+# Triggered via repository_dispatch from Smartspace-app-api SDK publish workflows.
+
+name: Bump SDK version
+
+on:
+  repository_dispatch:
+    types: [sdk-published]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    name: Bump api-client to ${{ github.event.client_payload.version }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.target_branch }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Update SDK version
+        run: npm install @smartspace/api-client@${{ github.event.client_payload.version }} --save-exact
+
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: chore/sdk-bump-${{ github.event.client_payload.version }}
+          base: ${{ github.event.client_payload.target_branch }}
+          title: "chore: bump api-client to ${{ github.event.client_payload.version }}"
+          commit-message: "chore: bump api-client to ${{ github.event.client_payload.version }}"
+          body: |
+            Automated SDK version bump triggered by `@smartspace/api-client@${{ github.event.client_payload.version }}` publish.

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-@smartspace-ai:registry=https://npm.pkg.github.com
+@smartspace:registry=https://registry.npmjs.org

--- a/Readme.md
+++ b/Readme.md
@@ -52,7 +52,7 @@ Ensure you have the following installed:
 
 ### GitHub Packages Authentication
 
-This project depends on `@smartspace-ai/api-client`, published to [GitHub Packages](https://github.com/orgs/Smartspace-ai/packages).
+This project depends on `@smartspace/api-client`, published to [npmjs.com](https://www.npmjs.com/package/@smartspace/api-client).
 
 - **Public stable releases** work out of the box — no extra setup needed.
 - **Pre-release versions** (auto-published per backend PR) require a GitHub Personal Access Token with the `read:packages` scope. Add it to your **user-level** `~/.npmrc`:

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@mui/system": "^6.5.0",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-slot": "^1.2.4",
-    "@smartspace-ai/api-client": "^0.1.0-dev.825ee49",
+    "@smartspace/api-client": "^0.1.0-dev.825ee49",
     "@tanstack/react-query": "^5.96.2",
     "@tanstack/react-router": "^1.168.10",
     "@types/jwt-decode": "^2.2.1",

--- a/src/domains/comments/__tests__/service.spec.ts
+++ b/src/domains/comments/__tests__/service.spec.ts
@@ -5,7 +5,7 @@ const { mockGetComments, mockPostComments } = vi.hoisted(() => ({
   mockPostComments: vi.fn(),
 }));
 
-vi.mock('@smartspace-ai/api-client', () => ({
+vi.mock('@smartspace/api-client', () => ({
   ChatApi: {
     getSmartSpaceChatAPI: () => ({
       getMessageThreadsIdComments: mockGetComments,

--- a/src/domains/comments/mapper.ts
+++ b/src/domains/comments/mapper.ts
@@ -1,4 +1,4 @@
-import { ChatZod } from '@smartspace-ai/api-client';
+import { ChatZod } from '@smartspace/api-client';
 import type { z } from 'zod';
 
 import { utcDate } from '@/shared/utils/dateFromApi';

--- a/src/domains/comments/service.ts
+++ b/src/domains/comments/service.ts
@@ -1,4 +1,4 @@
-import { ChatApi, ChatZod } from '@smartspace-ai/api-client';
+import { ChatApi, ChatZod } from '@smartspace/api-client';
 
 import { parseOrThrow } from '@/platform/validation';
 

--- a/src/domains/files/__tests__/service.spec.ts
+++ b/src/domains/files/__tests__/service.spec.ts
@@ -7,7 +7,7 @@ const { mockPostFiles, mockGetFilesId } = vi.hoisted(() => ({
   mockGetFilesId: vi.fn(),
 }));
 
-vi.mock('@smartspace-ai/api-client', () => ({
+vi.mock('@smartspace/api-client', () => ({
   ChatApi: {
     getSmartSpaceChatAPI: () => ({
       postFiles: mockPostFiles,

--- a/src/domains/files/mapper.ts
+++ b/src/domains/files/mapper.ts
@@ -1,4 +1,4 @@
-import { ChatZod } from '@smartspace-ai/api-client';
+import { ChatZod } from '@smartspace/api-client';
 import type { z } from 'zod';
 
 import { FileInfo } from './model';

--- a/src/domains/files/service.ts
+++ b/src/domains/files/service.ts
@@ -1,4 +1,4 @@
-import { ChatApi, ChatZod } from '@smartspace-ai/api-client';
+import { ChatApi, ChatZod } from '@smartspace/api-client';
 
 import { api } from '@/platform/api';
 import { parseOrThrow } from '@/platform/validation';

--- a/src/domains/flowruns/__tests__/service.spec.ts
+++ b/src/domains/flowruns/__tests__/service.spec.ts
@@ -6,7 +6,7 @@ const { mockGetFlowRunsIdVariables } = vi.hoisted(() => ({
   mockGetFlowRunsIdVariables: vi.fn(),
 }));
 
-vi.mock('@smartspace-ai/api-client', () => ({
+vi.mock('@smartspace/api-client', () => ({
   ChatApi: {
     getSmartSpaceChatAPI: () => ({
       getFlowRunsIdVariables: mockGetFlowRunsIdVariables,

--- a/src/domains/flowruns/service.ts
+++ b/src/domains/flowruns/service.ts
@@ -1,4 +1,4 @@
-import { ChatApi, ChatZod } from '@smartspace-ai/api-client';
+import { ChatApi, ChatZod } from '@smartspace/api-client';
 
 import { api } from '@/platform/api';
 import { parseOrThrow } from '@/platform/validation';

--- a/src/domains/messages/__tests__/service.spec.ts
+++ b/src/domains/messages/__tests__/service.spec.ts
@@ -7,7 +7,7 @@ const { mockGetMessages, mockMessageElementParse } = vi.hoisted(() => ({
   mockMessageElementParse: vi.fn((data: unknown) => data),
 }));
 
-vi.mock('@smartspace-ai/api-client', () => ({
+vi.mock('@smartspace/api-client', () => ({
   ChatApi: {
     getSmartSpaceChatAPI: () => ({
       getMessageThreadsIdMessages: mockGetMessages,

--- a/src/domains/messages/mapper.ts
+++ b/src/domains/messages/mapper.ts
@@ -1,4 +1,4 @@
-import { ChatZod } from '@smartspace-ai/api-client';
+import { ChatZod } from '@smartspace/api-client';
 import type { z } from 'zod';
 
 import { utcDate } from '@/shared/utils/dateFromApi';

--- a/src/domains/messages/service.ts
+++ b/src/domains/messages/service.ts
@@ -1,4 +1,4 @@
-import { ChatApi, ChatZod } from '@smartspace-ai/api-client';
+import { ChatApi, ChatZod } from '@smartspace/api-client';
 import { Subject } from 'rxjs';
 
 import { api } from '@/platform/api';

--- a/src/domains/models/__tests__/service.spec.ts
+++ b/src/domains/models/__tests__/service.spec.ts
@@ -5,7 +5,7 @@ const { mockGetModels, mockGetModelsId } = vi.hoisted(() => ({
   mockGetModelsId: vi.fn(),
 }));
 
-vi.mock('@smartspace-ai/api-client', () => ({
+vi.mock('@smartspace/api-client', () => ({
   ChatApi: {
     getSmartSpaceChatAPI: () => ({
       getModels: mockGetModels,

--- a/src/domains/models/mapper.ts
+++ b/src/domains/models/mapper.ts
@@ -1,4 +1,4 @@
-import { ChatZod } from '@smartspace-ai/api-client';
+import { ChatZod } from '@smartspace/api-client';
 import type { z } from 'zod';
 
 import { utcDate } from '@/shared/utils/dateFromApi';

--- a/src/domains/models/service.ts
+++ b/src/domains/models/service.ts
@@ -1,4 +1,4 @@
-import { ChatApi, ChatZod } from '@smartspace-ai/api-client';
+import { ChatApi, ChatZod } from '@smartspace/api-client';
 
 import { parseOrThrow } from '@/platform/validation';
 

--- a/src/domains/threads/mapper.ts
+++ b/src/domains/threads/mapper.ts
@@ -1,4 +1,4 @@
-import { ChatZod } from '@smartspace-ai/api-client';
+import { ChatZod } from '@smartspace/api-client';
 import type { z } from 'zod';
 
 import { utcDate } from '@/shared/utils/dateFromApi';

--- a/src/domains/threads/service.ts
+++ b/src/domains/threads/service.ts
@@ -1,4 +1,4 @@
-import { ChatApi, ChatZod } from '@smartspace-ai/api-client';
+import { ChatApi, ChatZod } from '@smartspace/api-client';
 
 import { parseOrThrow } from '@/platform/validation';
 

--- a/src/domains/workspaces/mapper.ts
+++ b/src/domains/workspaces/mapper.ts
@@ -1,4 +1,4 @@
-import { ChatZod } from '@smartspace-ai/api-client';
+import { ChatZod } from '@smartspace/api-client';
 import type { z } from 'zod';
 
 import { utcDate } from '@/shared/utils/dateFromApi';

--- a/src/domains/workspaces/service.ts
+++ b/src/domains/workspaces/service.ts
@@ -1,5 +1,5 @@
 // src/domains/workspaces/service.ts
-import { ChatApi, ChatZod } from '@smartspace-ai/api-client';
+import { ChatApi, ChatZod } from '@smartspace/api-client';
 
 import { parseOrThrow } from '@/platform/validation';
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,7 @@ import {
   EventType,
 } from '@azure/msal-browser';
 import { MsalProvider } from '@azure/msal-react';
-import { ChatApi } from '@smartspace-ai/api-client';
+import { ChatApi } from '@smartspace/api-client';
 import { RouterProvider, createRouter } from '@tanstack/react-router';
 import { TanStackRouterDevtools } from '@tanstack/router-devtools';
 import { StrictMode } from 'react';

--- a/src/platform/api/configureApiClient.ts
+++ b/src/platform/api/configureApiClient.ts
@@ -1,4 +1,4 @@
-import { AXIOS_INSTANCE } from '@smartspace-ai/api-client';
+import { AXIOS_INSTANCE } from '@smartspace/api-client';
 import { AxiosHeaders } from 'axios';
 
 import { AuthRequiredError } from '@/platform/auth/errors';

--- a/src/platform/router/context.ts
+++ b/src/platform/router/context.ts
@@ -1,4 +1,4 @@
-import type { ChatApi } from '@smartspace-ai/api-client';
+import type { ChatApi } from '@smartspace/api-client';
 import type { QueryClient } from '@tanstack/react-query';
 
 export interface RouterContext {


### PR DESCRIPTION
## Summary
- Switch all `@smartspace-ai/api-client` references to `@smartspace/api-client` (new npm org)
- Point `.npmrc` to `registry.npmjs.org` instead of GitHub Packages
- Remove `GH_PACKAGE_TOKEN` from CI and deploy workflows (no longer needed for npm)
- Add `sdk-bump.yml` workflow for automated SDK version bumps via `repository_dispatch`

## Dependencies
- Requires Smartspace-ai/Smartspace-app-api#707 to be merged first (publishes SDK to npmjs.com)
- CI will fail until `@smartspace/api-client` is first published to npmjs.com

## Test plan
- [ ] Merge app-api PR first → SDK publishes to npmjs.com
- [ ] Verify `npm view @smartspace/api-client` resolves
- [ ] Then merge this PR → CI should pass