### PR TITLE
fix: ci test failure and deploy-dev environment

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -12,5 +12,5 @@ jobs:
   deploy:
     uses: ./.github/workflows/deploy.yml
     with:
-      environment: dev
+      environment: develop
     secrets: inherit

--- a/src/domains/notifications/__tests__/mapper.spec.ts
+++ b/src/domains/notifications/__tests__/mapper.spec.ts
@@ -1,12 +1,36 @@
 import { describe, expect, it } from 'vitest';
 
-import { mapNotificationDtoToModel, mapNotificationsEnvelopeDto } from '@/domains/notifications/mapper';
+import {
+  mapNotificationDtoToModel,
+  mapNotificationsEnvelopeDto,
+} from '@/domains/notifications/mapper';
 import { NotificationType } from '@/domains/notifications/model';
+import { NotificationSchema as notificationSchema } from '@/domains/notifications/schemas';
 
 describe('notifications mapper', () => {
   it('normalizes type from number and string', () => {
-    const n1 = mapNotificationDtoToModel({ id: '1', notificationType: 1, description: 'a', workSpaceId: null, threadId: null, createdBy: 'u', createdAt: '2024', dismissedAt: null, avatar: null } as any);
-    const n2 = mapNotificationDtoToModel({ id: '2', notificationType: '2', description: 'b', workSpaceId: null, threadId: null, createdBy: 'u', createdAt: '2024', dismissedAt: null, avatar: null } as any);
+    const n1 = mapNotificationDtoToModel({
+      id: '1',
+      notificationType: 1,
+      description: 'a',
+      workSpaceId: null,
+      threadId: null,
+      createdBy: 'u',
+      createdAt: '2024',
+      dismissedAt: null,
+      avatar: null,
+    } as any);
+    const n2 = mapNotificationDtoToModel({
+      id: '2',
+      notificationType: '2',
+      description: 'b',
+      workSpaceId: null,
+      threadId: null,
+      createdBy: 'u',
+      createdAt: '2024',
+      dismissedAt: null,
+      avatar: null,
+    } as any);
     expect(n1.notificationType).toBe(NotificationType.MessageThreadUpdated);
     expect(n2.notificationType).toBe(NotificationType.CommentUpdated);
   });
@@ -114,7 +138,11 @@ describe('notifications mapper', () => {
   });
 
   it('maps envelope with counts', () => {
-    const env = mapNotificationsEnvelopeDto({ data: [], total: 5, totalUnread: 2 } as any);
+    const env = mapNotificationsEnvelopeDto({
+      data: [],
+      total: 5,
+      totalUnread: 2,
+    } as any);
     expect(env.totalCount).toBe(5);
     expect(env.unreadCount).toBe(2);
   });


### PR DESCRIPTION
## Summary
- Add missing `NotificationSchema` import in `mapper.spec.ts` — fixes 6 failing CI tests
- Point `deploy-dev.yml` at the `develop` GitHub environment (which has the storage secret configured) instead of `dev`

## Test plan
- [ ] CI quality checks pass (lint, typecheck, tests, build)
- [ ] Deploy to dev succeeds after `AZURE_STORAGE_CONNECTION_STRING` secret is confirmed in the `develop` environment