### PR TITLE
ci: dispatch Smartspace-app build after dev deploy

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -14,3 +14,14 @@ jobs:
     with:
       environment: develop
     secrets: inherit
+
+  trigger-smartspace-app-build:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Smartspace-app Docker build
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.SMARTSPACE_APP_DISPATCH_TOKEN }}
+          repository: Smartspace-ai/Smartspace-app
+          event-type: app-public-updated

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -19,9 +19,18 @@ jobs:
     needs: deploy
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CI_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.CI_DISPATCH_APP_PRIVATE_KEY }}
+          owner: Smartspace-ai
+          repositories: Smartspace-app
+
       - name: Trigger Smartspace-app Docker build
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.SMARTSPACE_APP_DISPATCH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           repository: Smartspace-ai/Smartspace-app
           event-type: app-public-updated


### PR DESCRIPTION
## Summary
- After a successful dev deploy, dispatch a `repository_dispatch` event to Smartspace-ai/Smartspace-app so it rebuilds its Docker image with the latest web UI
- Uses a GitHub App token (via `actions/create-github-app-token@v1`) for secure cross-repo dispatch

**Companion PR:** Smartspace-ai/Smartspace-app#1295 — adds the dispatch listener

## Setup required
1. Create the **SmartSpace CI Dispatch** GitHub App in the Smartspace-ai org (see PR description for details)
2. Install the app on the **Smartspace-app** repo
3. Add two secrets to **this repo**:
   - `CI_DISPATCH_APP_ID` — the app's ID
   - `CI_DISPATCH_APP_PRIVATE_KEY` — the app's private key

## Test plan
- [ ] Merge companion PR in Smartspace-app first
- [x] Create and install the GitHub App
- [x] Add the secrets to this repo
- [ ] Merge this PR and verify Smartspace-app build triggers