### PR TITLE
fix: load user profile pictures in notifications panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@mui/system": "^6.5.0",
         "@radix-ui/react-scroll-area": "^1.2.10",
         "@radix-ui/react-slot": "^1.2.4",
-        "@smartspace/api-client": "^0.1.0-pr.720.d01a9a4",
+        "@smartspace/api-client": "^0.1.0-dev.793b98c",
         "@tanstack/react-query": "^5.96.2",
         "@tanstack/react-router": "^1.168.10",
         "@types/jwt-decode": "^2.2.1",
@@ -6717,9 +6717,9 @@
       }
     },
     "node_modules/@smartspace/api-client": {
-      "version": "0.1.0-pr.720.d01a9a4",
-      "resolved": "https://registry.npmjs.org/@smartspace/api-client/-/api-client-0.1.0-pr.720.d01a9a4.tgz",
-      "integrity": "sha512-WGs03Z6jQ8YYtTwxkjSeMuKjYrZEFnCp4OaXGNFyMmneIg6amlyfW5K39AryvpHQdm89HZD6P6vLbM5XEBldFQ==",
+      "version": "0.1.0-dev.793b98c",
+      "resolved": "https://registry.npmjs.org/@smartspace/api-client/-/api-client-0.1.0-dev.793b98c.tgz",
+      "integrity": "sha512-S2EgutrA8oxodp82qBYEYd02E5ETufWqoKha8bDDEACOCnE9x6mZxvwJENUEM2nxle2p0KgZOT56VMZUMdRVig==",
       "peerDependencies": {
         "axios": ">=1.0.0",
         "zod": "^4.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@mui/system": "^6.5.0",
         "@radix-ui/react-scroll-area": "^1.2.10",
         "@radix-ui/react-slot": "^1.2.4",
-        "@smartspace/api-client": "^0.1.0-dev.bdaf06f",
+        "@smartspace/api-client": "^0.1.0-pr.720.d01a9a4",
         "@tanstack/react-query": "^5.96.2",
         "@tanstack/react-router": "^1.168.10",
         "@types/jwt-decode": "^2.2.1",
@@ -6717,9 +6717,9 @@
       }
     },
     "node_modules/@smartspace/api-client": {
-      "version": "0.1.0-dev.bdaf06f",
-      "resolved": "https://registry.npmjs.org/@smartspace/api-client/-/api-client-0.1.0-dev.bdaf06f.tgz",
-      "integrity": "sha512-AaOWOlX749DkxSwJIVFJ3oOHAX+aYzs0jatGhuXHJRgZfeAXjCxMjUUyUuUaWtqXSpri0zJeC356qO0PfJnWkw==",
+      "version": "0.1.0-pr.720.d01a9a4",
+      "resolved": "https://registry.npmjs.org/@smartspace/api-client/-/api-client-0.1.0-pr.720.d01a9a4.tgz",
+      "integrity": "sha512-WGs03Z6jQ8YYtTwxkjSeMuKjYrZEFnCp4OaXGNFyMmneIg6amlyfW5K39AryvpHQdm89HZD6P6vLbM5XEBldFQ==",
       "peerDependencies": {
         "axios": ">=1.0.0",
         "zod": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@mui/system": "^6.5.0",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-slot": "^1.2.4",
-    "@smartspace/api-client": "^0.1.0-pr.720.d01a9a4",
+    "@smartspace/api-client": "^0.1.0-dev.793b98c",
     "@tanstack/react-query": "^5.96.2",
     "@tanstack/react-router": "^1.168.10",
     "@types/jwt-decode": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@mui/system": "^6.5.0",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-slot": "^1.2.4",
-    "@smartspace/api-client": "^0.1.0-dev.bdaf06f",
+    "@smartspace/api-client": "^0.1.0-pr.720.d01a9a4",
     "@tanstack/react-query": "^5.96.2",
     "@tanstack/react-router": "^1.168.10",
     "@types/jwt-decode": "^2.2.1",

--- a/src/domains/notifications/mapper.ts
+++ b/src/domains/notifications/mapper.ts
@@ -40,9 +40,9 @@ export function mapNotificationDtoToModel(dto: NotificationDto): Notification {
     workSpaceId: dto.workSpaceId ?? undefined,
     threadId: dto.threadId ?? undefined,
     createdBy: dto.createdBy ?? '',
+    createdByUserId: dto.createdByUserId ?? undefined,
     createdAt: dto.createdAt ? utcDate(dto.createdAt) : new Date(0),
     dismissedAt: dto.dismissedAt ?? undefined,
-    avatar: undefined,
   };
 }
 

--- a/src/domains/notifications/model.ts
+++ b/src/domains/notifications/model.ts
@@ -11,13 +11,7 @@ export type Notification = {
   workSpaceId?: string | null;
   threadId?: string | null;
   createdBy: string;
+  createdByUserId?: string | null;
   createdAt: Date;
   dismissedAt?: string | null;
-  avatar?: string | null;
 };
-
-
-
-
-
-

--- a/src/ui/header/notifications-panel.tsx
+++ b/src/ui/header/notifications-panel.tsx
@@ -21,6 +21,7 @@ import { ScrollArea } from '@/shared/ui/mui-compat/scroll-area';
 import { Switch } from '@/shared/ui/mui-compat/switch';
 import { getInitials } from '@/shared/utils/initials';
 import { parseDateTimeHuman } from '@/shared/utils/parseDateTime';
+import { getUserPhotoUrl } from '@/shared/utils/userPhoto';
 import { cn } from '@/shared/utils/utils';
 
 export function NotificationPanel() {
@@ -202,7 +203,7 @@ export function NotificationPanel() {
                       >
                         <Avatar className="h-8 w-8 rounded-full">
                           <AvatarImage
-                            src={notification.avatar || '/placeholder.svg'}
+                            src={getUserPhotoUrl(notification.createdByUserId)}
                             alt={notification.createdBy}
                           />
                           <AvatarFallback className="text-xs font-medium">

--- a/src/ui/header/notifications-panel.tsx
+++ b/src/ui/header/notifications-panel.tsx
@@ -205,10 +205,11 @@ export function NotificationPanel() {
                           <AvatarImage
                             src={getUserPhotoUrl(notification.createdByUserId)}
                             alt={notification.createdBy}
-                          />
-                          <AvatarFallback className="text-xs font-medium">
-                            {getInitials(notification.createdBy || '')}
-                          </AvatarFallback>
+                          >
+                            <AvatarFallback className="text-xs font-medium">
+                              {getInitials(notification.createdBy || '')}
+                            </AvatarFallback>
+                          </AvatarImage>
                         </Avatar>
 
                         <div className="flex-1 min-w-0">


### PR DESCRIPTION
## Summary
- Bumps @smartspace/api-client to the build that adds `createdByUserId` to the notification response.
- Notifications domain model/mapper now pass `createdByUserId` through, replacing the unused `avatar` field.
- Notifications panel builds the avatar URL via `getUserPhotoUrl(createdByUserId)`, matching how messages and comments load profile photos.

## Test plan
- [ ] Open the notifications panel and verify each notification shows the sender's profile photo.
- [ ] Confirm initials fallback still renders when a user has no photo or `createdByUserId` is missing.
- [ ] Click a notification with a thread and verify navigation still works.