### PR TITLE
feat(markdown): render ```html blocks as sandboxed iframe previews

### DIFF
--- a/src/shared/ui/markdown/MarkdownEditor.tsx
+++ b/src/shared/ui/markdown/MarkdownEditor.tsx
@@ -30,6 +30,7 @@ import { createPortal } from 'react-dom';
 // This setup is ready to add a mention-like plugin later if desired.
 import { autolink } from './extensions/autolink';
 import { fileTag } from './extensions/fileTag';
+import { htmlPreviewView } from './extensions/htmlPreview';
 import { mention } from './extensions/mention';
 import { ssImageNode, ssImageView } from './extensions/ssImage';
 import './styles.css';
@@ -370,6 +371,7 @@ function EditorInner({
         .use(fileTag)
         .use(ssImageNode)
         .use(ssImageView)
+        .use(htmlPreviewView)
         .use(enableMentions ? mention : fileTag);
     },
     [isEditable]

--- a/src/shared/ui/markdown/__tests__/MarkdownEditor.html-codeblock.spec.tsx
+++ b/src/shared/ui/markdown/__tests__/MarkdownEditor.html-codeblock.spec.tsx
@@ -1,0 +1,149 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { MarkdownEditor } from '@/shared/ui/markdown/MarkdownEditor';
+
+const CHART_HTML = [
+  '<!DOCTYPE html>',
+  '<html>',
+  '<head>',
+  '  <title>University Operating Income Comparison</title>',
+  '  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>',
+  '</head>',
+  '<body>',
+  '  <canvas id="chart1" width="900" height="750"></canvas>',
+  '  <script>',
+  "    const labels = ['Oxford', 'Cambridge'];",
+  '  </script>',
+  '</body>',
+  '</html>',
+].join('\n');
+
+const HTML_BLOCK_MD = [
+  '```html',
+  CHART_HTML,
+  '```',
+  '',
+  'This HTML file is ready to use - just copy and paste it into a `.html` file.',
+].join('\n');
+
+function renderEditor(value: string) {
+  const client = new QueryClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <MarkdownEditor value={value} editable={false} />
+    </QueryClientProvider>
+  );
+}
+
+describe('MarkdownEditor — html fenced code block', () => {
+  it('renders an html code block as a sandboxed iframe preview', async () => {
+    const { container } = renderEditor(HTML_BLOCK_MD);
+
+    const wrapper = await waitFor(() => {
+      const el = container.querySelector('.ss-code-block--previewable');
+      if (!el) throw new Error('preview wrapper not rendered');
+      return el;
+    });
+
+    const iframe = wrapper.querySelector(
+      'iframe.ss-code-block__iframe'
+    ) as HTMLIFrameElement | null;
+    expect(iframe).not.toBeNull();
+    expect(iframe!.getAttribute('sandbox')).toBe('allow-scripts');
+    expect(iframe!.srcdoc).toContain('<!DOCTYPE html>');
+    expect(iframe!.srcdoc).toContain(
+      '<script src="https://cdn.jsdelivr.net/npm/chart.js">'
+    );
+    expect(iframe!.srcdoc).toContain("const labels = ['Oxford', 'Cambridge'];");
+  });
+
+  it('still preserves the raw source in a <pre><code> so users can toggle to it', async () => {
+    const { container } = renderEditor(HTML_BLOCK_MD);
+
+    const pre = await waitFor(() => {
+      const el = container.querySelector('.ss-code-block pre');
+      if (!el) throw new Error('<pre> not rendered');
+      return el as HTMLPreElement;
+    });
+
+    expect(pre.textContent ?? '').toContain('<!DOCTYPE html>');
+    expect(pre.textContent ?? '').toContain('const labels');
+    // Preview is the default view, so the source <pre> should start hidden.
+    expect(pre.style.display).toBe('none');
+  });
+
+  it('toggles between preview and source when the button is clicked', async () => {
+    const { container } = renderEditor(HTML_BLOCK_MD);
+
+    const toggle = await waitFor(() => {
+      const el = container.querySelector(
+        '.ss-code-block__toggle'
+      ) as HTMLButtonElement | null;
+      if (!el) throw new Error('toggle not rendered');
+      return el;
+    });
+
+    const iframe = container.querySelector(
+      '.ss-code-block__iframe'
+    ) as HTMLIFrameElement;
+    const pre = container.querySelector('.ss-code-block pre') as HTMLPreElement;
+
+    expect(toggle.textContent).toBe('Source');
+    expect(pre.style.display).toBe('none');
+    expect(iframe.style.display).not.toBe('none');
+
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    expect(toggle.textContent).toBe('Preview');
+    expect(pre.style.display).toBe('');
+    expect(iframe.style.display).toBe('none');
+  });
+
+  it('does not auto-link URLs inside a code block (autolink must skip code)', async () => {
+    const { container } = renderEditor(HTML_BLOCK_MD);
+
+    const pre = await waitFor(() => {
+      const el = container.querySelector('.ss-code-block pre');
+      if (!el) throw new Error('<pre> not rendered');
+      return el;
+    });
+
+    // The URL inside <script src="..."> must remain literal text,
+    // not be rewritten into an <a> by the autolink decoration plugin.
+    expect(pre.querySelector('a')).toBeNull();
+  });
+
+  it('renders the paragraph that follows the code block', async () => {
+    const { container } = renderEditor(HTML_BLOCK_MD);
+
+    await waitFor(() => {
+      if (!container.querySelector('.ss-code-block')) {
+        throw new Error('code block not rendered');
+      }
+    });
+
+    expect(container.textContent ?? '').toContain(
+      'This HTML file is ready to use'
+    );
+  });
+
+  it('does not wrap non-previewable code blocks in a preview iframe', async () => {
+    const md = ['```js', "console.log('hi');", '```'].join('\n');
+    const { container } = renderEditor(md);
+
+    await waitFor(() => {
+      if (!container.querySelector('.ss-code-block')) {
+        throw new Error('code block not rendered');
+      }
+    });
+
+    expect(container.querySelector('.ss-code-block--previewable')).toBeNull();
+    expect(container.querySelector('iframe')).toBeNull();
+    expect(container.textContent ?? '').toContain("console.log('hi');");
+  });
+});

--- a/src/shared/ui/markdown/__tests__/MarkdownEditor.html-codeblock.spec.tsx
+++ b/src/shared/ui/markdown/__tests__/MarkdownEditor.html-codeblock.spec.tsx
@@ -1,8 +1,9 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
 import React from 'react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { injectHeightReporter } from '@/shared/ui/markdown/extensions/htmlPreview';
 import { MarkdownEditor } from '@/shared/ui/markdown/MarkdownEditor';
 
 const CHART_HTML = [
@@ -145,5 +146,160 @@ describe('MarkdownEditor — html fenced code block', () => {
     expect(container.querySelector('.ss-code-block--previewable')).toBeNull();
     expect(container.querySelector('iframe')).toBeNull();
     expect(container.textContent ?? '').toContain("console.log('hi');");
+  });
+});
+
+describe('MarkdownEditor — copy button', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('is hidden by default on an html preview and revealed when toggled to source', async () => {
+    const { container } = renderEditor(HTML_BLOCK_MD);
+
+    const copy = await waitFor(() => {
+      const el = container.querySelector(
+        '.ss-code-block__copy'
+      ) as HTMLButtonElement | null;
+      if (!el) throw new Error('copy button not rendered');
+      return el;
+    });
+
+    // Preview is the default for html → copy lives alongside the source and is hidden.
+    expect(copy.style.display).toBe('none');
+
+    const toggle = container.querySelector(
+      '.ss-code-block__toggle'
+    ) as HTMLButtonElement;
+    act(() => {
+      fireEvent.click(toggle);
+    });
+    expect(copy.style.display).toBe('');
+
+    act(() => {
+      fireEvent.click(toggle);
+    });
+    expect(copy.style.display).toBe('none');
+  });
+
+  it('is visible for non-previewable code blocks', async () => {
+    const md = ['```js', "console.log('hi');", '```'].join('\n');
+    const { container } = renderEditor(md);
+
+    const copy = await waitFor(() => {
+      const el = container.querySelector(
+        '.ss-code-block__copy'
+      ) as HTMLButtonElement | null;
+      if (!el) throw new Error('copy button not rendered');
+      return el;
+    });
+    expect(copy.style.display).toBe('');
+  });
+
+  it('copies the source via navigator.clipboard and flips the label to Copied', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    const md = ['```js', "console.log('hi');", '```'].join('\n');
+    const { container } = renderEditor(md);
+
+    const copy = await waitFor(() => {
+      const el = container.querySelector(
+        '.ss-code-block__copy'
+      ) as HTMLButtonElement | null;
+      if (!el) throw new Error('copy button not rendered');
+      return el;
+    });
+
+    await act(async () => {
+      fireEvent.click(copy);
+    });
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText.mock.calls[0][0]).toContain("console.log('hi');");
+    expect(copy.textContent).toBe('Copied');
+  });
+
+  it('falls back to Failed when the clipboard API rejects and the textarea fallback also fails', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockRejectedValue(new Error('blocked')),
+      },
+    });
+    // jsdom doesn't implement `execCommand`, so define it for this test and
+    // make the fallback path report failure.
+    const originalExec = (
+      document as Document & { execCommand?: (cmd: string) => boolean }
+    ).execCommand;
+    (
+      document as Document & { execCommand?: (cmd: string) => boolean }
+    ).execCommand = () => false;
+
+    const md = ['```js', "console.log('hi');", '```'].join('\n');
+    const { container } = renderEditor(md);
+
+    const copy = await waitFor(() => {
+      const el = container.querySelector(
+        '.ss-code-block__copy'
+      ) as HTMLButtonElement | null;
+      if (!el) throw new Error('copy button not rendered');
+      return el;
+    });
+
+    await act(async () => {
+      fireEvent.click(copy);
+    });
+
+    expect(copy.textContent).toBe('Failed');
+    (
+      document as Document & { execCommand?: (cmd: string) => boolean }
+    ).execCommand = originalExec;
+  });
+});
+
+describe('injectHeightReporter', () => {
+  const REPORTER_SIGNATURE = '<script>(function()';
+
+  it('injects before the closing body tag', () => {
+    const out = injectHeightReporter('<html><body>hi</body></html>');
+    const reporterIdx = out.indexOf(REPORTER_SIGNATURE);
+    const bodyClose = out.indexOf('</body>');
+    expect(reporterIdx).toBeGreaterThan(out.indexOf('hi'));
+    expect(reporterIdx).toBeLessThan(bodyClose);
+    expect(bodyClose).toBeLessThan(out.indexOf('</html>'));
+  });
+
+  it('injects before the LAST </body> even if an earlier one appears inside a script string', () => {
+    // A chatbot response might include the literal string "</body>" in JS —
+    // we must still inject before the *real* closing tag, not the fake one.
+    const html =
+      '<html><body><script>var x = "</body>";</script></body></html>';
+    const out = injectHeightReporter(html);
+    const firstBodyClose = out.indexOf('</body>');
+    const lastBodyClose = out.lastIndexOf('</body>');
+    const reporterIdx = out.indexOf(REPORTER_SIGNATURE);
+    // The fake </body> inside the string is still at firstBodyClose.
+    // The reporter should sit between the fake one and the real closing tag.
+    expect(reporterIdx).toBeGreaterThan(firstBodyClose);
+    expect(reporterIdx).toBeLessThan(lastBodyClose);
+  });
+
+  it('falls back to injecting before </html> when there is no </body>', () => {
+    const out = injectHeightReporter('<html>hi</html>');
+    const reporterIdx = out.indexOf(REPORTER_SIGNATURE);
+    const htmlClose = out.indexOf('</html>');
+    expect(reporterIdx).toBeGreaterThan(out.indexOf('hi'));
+    expect(reporterIdx).toBeLessThan(htmlClose);
+    expect(out.includes('</body>')).toBe(false);
+  });
+
+  it('appends the script when there is neither </body> nor </html>', () => {
+    const out = injectHeightReporter('<p>fragment</p>');
+    expect(out.startsWith('<p>fragment</p>')).toBe(true);
+    expect(out).toContain(REPORTER_SIGNATURE);
   });
 });

--- a/src/shared/ui/markdown/extensions/autolink.ts
+++ b/src/shared/ui/markdown/extensions/autolink.ts
@@ -15,11 +15,24 @@ const URL_RE =
 function buildDecorations(doc: PMNode): DecorationSet {
   const decorations: Decoration[] = [];
 
-  doc.descendants((node, pos) => {
+  doc.descendants((node, pos, parent) => {
+    // Don't descend into code blocks — URLs inside source code must stay literal.
+    if (node.type.name === 'code_block') return false;
+
     if (!node.isText || !node.text) return;
 
-    // Skip nodes that are already inside a link mark
+    // Skip nodes that are already inside a link mark, or marked as inline code.
     if (node.marks.some((m) => m.type.name === 'link')) return;
+    if (
+      node.marks.some(
+        (m) => m.type.name === 'inlineCode' || m.type.name === 'code'
+      )
+    )
+      return;
+
+    // Defensive: skip text whose parent is a code-ish node (covers custom nodeViews).
+    if (parent && (parent.type.spec.code || parent.type.name === 'code_block'))
+      return;
 
     let match: RegExpExecArray | null;
     URL_RE.lastIndex = 0;

--- a/src/shared/ui/markdown/extensions/htmlPreview.ts
+++ b/src/shared/ui/markdown/extensions/htmlPreview.ts
@@ -13,23 +13,28 @@ const HEIGHT_MESSAGE = 'ss-html-preview-height';
 // `sandbox="allow-scripts"` (no `allow-same-origin`), the parent cannot read
 // `contentDocument` directly, so the iframe has to push its height out via
 // postMessage. ResizeObserver handles late content (charts, images, fonts).
+// The script is idempotent (dedupes repeated heights) so a chatty ResizeObserver
+// doesn't spam the parent.
 const HEIGHT_REPORTER_SCRIPT = `
 <script>(function(){
-  // Reset default body margin so the reported height matches actual content
-  // and we don't inherit an extra ~16px of whitespace from the UA stylesheet.
+  // Reset default UA body margin so the reported height matches actual content
+  // and we don't inherit an extra ~16px of whitespace. Keep body overflow
+  // visible so popovers/anchors inside the preview still work.
   try {
     var s = document.createElement('style');
-    s.textContent = 'html,body{margin:0;padding:0;}body{overflow:hidden;}';
+    s.textContent = 'html,body{margin:0;padding:0;}';
     (document.head || document.documentElement).appendChild(s);
   } catch (e) {}
+  var lastSent = -1;
   function send(){
     try {
       var body = document.body;
       if (!body) return;
       // getBoundingClientRect returns the laid-out height of the body,
       // excluding any empty trailing space from html margins/padding.
-      var rect = body.getBoundingClientRect();
-      var h = Math.ceil(rect.height);
+      var h = Math.ceil(body.getBoundingClientRect().height);
+      if (h === lastSent) return;
+      lastSent = h;
       parent.postMessage({ type: ${JSON.stringify(
         HEIGHT_MESSAGE
       )}, height: h }, '*');
@@ -53,18 +58,37 @@ const HEIGHT_REPORTER_SCRIPT = `
 })();</script>
 `;
 
-function injectHeightReporter(html: string): string {
-  if (/<\/body>/i.test(html))
-    return html.replace(/<\/body>/i, HEIGHT_REPORTER_SCRIPT + '</body>');
-  if (/<\/html>/i.test(html))
-    return html.replace(/<\/html>/i, HEIGHT_REPORTER_SCRIPT + '</html>');
+/**
+ * Injects the height-reporter script just before the LAST `</body>` (or
+ * `</html>`) tag. We use `lastIndexOf` rather than a regex replace because a
+ * chat response might include `</body>` inside a string literal or comment,
+ * and we want the real closing tag.
+ *
+ * Exported for unit testing.
+ */
+export function injectHeightReporter(html: string): string {
+  const lower = html.toLowerCase();
+  const bodyIdx = lower.lastIndexOf('</body>');
+  if (bodyIdx >= 0) {
+    return (
+      html.slice(0, bodyIdx) + HEIGHT_REPORTER_SCRIPT + html.slice(bodyIdx)
+    );
+  }
+  const htmlIdx = lower.lastIndexOf('</html>');
+  if (htmlIdx >= 0) {
+    return (
+      html.slice(0, htmlIdx) + HEIGHT_REPORTER_SCRIPT + html.slice(htmlIdx)
+    );
+  }
   return html + HEIGHT_REPORTER_SCRIPT;
 }
 
 // Single global listener — routes height messages back to whichever iframe
-// originated them by matching against `event.source`.
-const iframeHandlers = new WeakMap<MessagePortLike, (height: number) => void>();
-type MessagePortLike = Window;
+// originated them by matching against `event.source`. A WeakMap means that
+// when an iframe is removed from the DOM and its contentWindow is collected,
+// the handler entry drops automatically — but we still clear eagerly in the
+// node view's `destroy` hook to avoid stale handlers firing mid-teardown.
+const iframeHandlers = new WeakMap<Window, (height: number) => void>();
 
 function ensureGlobalListener() {
   if (typeof window === 'undefined') return;
@@ -75,7 +99,7 @@ function ensureGlobalListener() {
     const data = event.data as { type?: string; height?: number } | null;
     if (!data || data.type !== HEIGHT_MESSAGE) return;
     if (typeof data.height !== 'number') return;
-    const source = event.source as MessagePortLike | null;
+    const source = event.source as Window | null;
     if (!source) return;
     const handler = iframeHandlers.get(source);
     if (handler) handler(data.height);
@@ -141,6 +165,7 @@ export const htmlPreviewView = $view(codeBlockSchema.node, () => (node) => {
   let iframe: HTMLIFrameElement | null = null;
   let showingPreview = isPreviewable;
   let lastSrcdoc = '';
+  let destroyed = false;
 
   const syncIframe = (src: string) => {
     if (!iframe) return;
@@ -164,9 +189,12 @@ export const htmlPreviewView = $view(codeBlockSchema.node, () => (node) => {
     e.preventDefault();
     e.stopPropagation();
     const ok = await copyText(code.textContent ?? '');
+    if (destroyed) return;
     copyBtn.textContent = ok ? 'Copied' : 'Failed';
     if (copyResetTimer) clearTimeout(copyResetTimer);
     copyResetTimer = setTimeout(() => {
+      copyResetTimer = null;
+      if (destroyed) return;
       copyBtn.textContent = 'Copy';
     }, 1500);
   });
@@ -176,6 +204,30 @@ export const htmlPreviewView = $view(codeBlockSchema.node, () => (node) => {
   actions.appendChild(copyBtn);
   setCopyVisible(!isPreviewable);
 
+  // Parent-side rAF coalescing: a noisy ResizeObserver in the iframe could
+  // fire many height messages per frame; we only apply the latest one each
+  // animation frame to avoid layout thrash.
+  let pendingHeight: number | null = null;
+  let rafId: number | null = null;
+  const flushPendingHeight = () => {
+    rafId = null;
+    if (pendingHeight == null || !iframe) return;
+    const next = Math.min(pendingHeight, MAX_IFRAME_HEIGHT);
+    pendingHeight = null;
+    if (next <= 0) return;
+    iframe.style.height = `${next}px`;
+  };
+  const scheduleHeight = (height: number) => {
+    pendingHeight = height;
+    if (rafId != null) return;
+    if (typeof requestAnimationFrame === 'function') {
+      rafId = requestAnimationFrame(flushPendingHeight);
+    } else {
+      // Fallback for SSR / jsdom without rAF.
+      rafId = window.setTimeout(flushPendingHeight, 16) as unknown as number;
+    }
+  };
+
   if (isPreviewable) {
     ensureGlobalListener();
     iframe = document.createElement('iframe');
@@ -184,13 +236,8 @@ export const htmlPreviewView = $view(codeBlockSchema.node, () => (node) => {
     iframe.setAttribute('loading', 'lazy');
     iframe.setAttribute('title', 'HTML preview');
     iframe.addEventListener('load', () => {
-      if (iframe && iframe.contentWindow) {
-        iframeHandlers.set(iframe.contentWindow, (height: number) => {
-          if (!iframe) return;
-          if (height <= 0) return;
-          iframe.style.height = `${Math.min(height, MAX_IFRAME_HEIGHT)}px`;
-        });
-      }
+      if (destroyed || !iframe || !iframe.contentWindow) return;
+      iframeHandlers.set(iframe.contentWindow, scheduleHeight);
     });
     syncIframe(node.textContent);
 
@@ -243,6 +290,24 @@ export const htmlPreviewView = $view(codeBlockSchema.node, () => (node) => {
       if (mutation.target === code) return false;
       if (code.contains(mutation.target as Node)) return false;
       return true;
+    },
+    destroy() {
+      destroyed = true;
+      if (copyResetTimer) {
+        clearTimeout(copyResetTimer);
+        copyResetTimer = null;
+      }
+      if (rafId != null) {
+        if (typeof cancelAnimationFrame === 'function') {
+          cancelAnimationFrame(rafId);
+        } else {
+          clearTimeout(rafId);
+        }
+        rafId = null;
+      }
+      if (iframe?.contentWindow) {
+        iframeHandlers.delete(iframe.contentWindow);
+      }
     },
   };
 });

--- a/src/shared/ui/markdown/extensions/htmlPreview.ts
+++ b/src/shared/ui/markdown/extensions/htmlPreview.ts
@@ -1,0 +1,248 @@
+import { codeBlockSchema } from '@milkdown/preset-commonmark';
+import { $view } from '@milkdown/utils';
+
+const PREVIEW_LANGUAGES = new Set(['html']);
+
+// Defensive upper bound — a runaway HTML preview (infinite loop resizing,
+// `scrollHeight = 1e9`) shouldn't blow out the page. 5000px is roughly 5
+// viewports on a laptop, so any legitimate chart/table still fits.
+const MAX_IFRAME_HEIGHT = 5000;
+const HEIGHT_MESSAGE = 'ss-html-preview-height';
+
+// Injected into each previewed HTML document. Because the iframe uses
+// `sandbox="allow-scripts"` (no `allow-same-origin`), the parent cannot read
+// `contentDocument` directly, so the iframe has to push its height out via
+// postMessage. ResizeObserver handles late content (charts, images, fonts).
+const HEIGHT_REPORTER_SCRIPT = `
+<script>(function(){
+  // Reset default body margin so the reported height matches actual content
+  // and we don't inherit an extra ~16px of whitespace from the UA stylesheet.
+  try {
+    var s = document.createElement('style');
+    s.textContent = 'html,body{margin:0;padding:0;}body{overflow:hidden;}';
+    (document.head || document.documentElement).appendChild(s);
+  } catch (e) {}
+  function send(){
+    try {
+      var body = document.body;
+      if (!body) return;
+      // getBoundingClientRect returns the laid-out height of the body,
+      // excluding any empty trailing space from html margins/padding.
+      var rect = body.getBoundingClientRect();
+      var h = Math.ceil(rect.height);
+      parent.postMessage({ type: ${JSON.stringify(
+        HEIGHT_MESSAGE
+      )}, height: h }, '*');
+    } catch (e) {}
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', send);
+  } else {
+    send();
+  }
+  window.addEventListener('load', send);
+  try {
+    if (typeof ResizeObserver !== 'undefined') {
+      var ro = new ResizeObserver(send);
+      if (document.body) ro.observe(document.body);
+    }
+  } catch (e) {}
+  setTimeout(send, 100);
+  setTimeout(send, 500);
+  setTimeout(send, 1500);
+})();</script>
+`;
+
+function injectHeightReporter(html: string): string {
+  if (/<\/body>/i.test(html))
+    return html.replace(/<\/body>/i, HEIGHT_REPORTER_SCRIPT + '</body>');
+  if (/<\/html>/i.test(html))
+    return html.replace(/<\/html>/i, HEIGHT_REPORTER_SCRIPT + '</html>');
+  return html + HEIGHT_REPORTER_SCRIPT;
+}
+
+// Single global listener — routes height messages back to whichever iframe
+// originated them by matching against `event.source`.
+const iframeHandlers = new WeakMap<MessagePortLike, (height: number) => void>();
+type MessagePortLike = Window;
+
+function ensureGlobalListener() {
+  if (typeof window === 'undefined') return;
+  const w = window as Window & { __ssHtmlPreviewListener?: boolean };
+  if (w.__ssHtmlPreviewListener) return;
+  w.__ssHtmlPreviewListener = true;
+  window.addEventListener('message', (event) => {
+    const data = event.data as { type?: string; height?: number } | null;
+    if (!data || data.type !== HEIGHT_MESSAGE) return;
+    if (typeof data.height !== 'number') return;
+    const source = event.source as MessagePortLike | null;
+    if (!source) return;
+    const handler = iframeHandlers.get(source);
+    if (handler) handler(data.height);
+  });
+}
+
+async function copyText(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    /* fall through to textarea fallback */
+  }
+  try {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.setAttribute('readonly', '');
+    ta.style.position = 'fixed';
+    ta.style.opacity = '0';
+    document.body.appendChild(ta);
+    ta.select();
+    const ok = document.execCommand('copy');
+    ta.remove();
+    return ok;
+  } catch {
+    return false;
+  }
+}
+
+// `codeBlockSchema` from @milkdown/preset-commonmark is a `$nodeSchema` result
+// (an array-plus-props). `$view` reads `type.id` lazily, but that `id` field on
+// the composed result is a snapshot of `undefined` at module-load time and is
+// never updated when the inner `$node` plugin actually registers. Registering
+// against `codeBlockSchema.node` (the underlying `$node` plugin) ensures
+// `type.id` is populated by the time `$view` reads it.
+export const htmlPreviewView = $view(codeBlockSchema.node, () => (node) => {
+  const language = String(node.attrs.language || '').toLowerCase();
+  const isPreviewable = PREVIEW_LANGUAGES.has(language);
+
+  const dom = document.createElement('div');
+  dom.className = 'ss-code-block';
+  if (isPreviewable) dom.classList.add('ss-code-block--previewable');
+
+  const header = document.createElement('div');
+  header.className = 'ss-code-block__header';
+
+  const langLabel = document.createElement('span');
+  langLabel.className = 'ss-code-block__lang';
+  langLabel.textContent = language || 'text';
+  header.appendChild(langLabel);
+
+  const actions = document.createElement('div');
+  actions.className = 'ss-code-block__actions';
+  header.appendChild(actions);
+
+  const pre = document.createElement('pre');
+  if (language) pre.dataset.language = language;
+  const code = document.createElement('code');
+  pre.appendChild(code);
+
+  let iframe: HTMLIFrameElement | null = null;
+  let showingPreview = isPreviewable;
+  let lastSrcdoc = '';
+
+  const syncIframe = (src: string) => {
+    if (!iframe) return;
+    const withReporter = injectHeightReporter(src);
+    if (withReporter === lastSrcdoc) return;
+    lastSrcdoc = withReporter;
+    iframe.srcdoc = withReporter;
+  };
+
+  // Copy button — visible whenever the source <pre> is visible.
+  const copyBtn = document.createElement('button');
+  copyBtn.type = 'button';
+  copyBtn.className = 'ss-code-block__copy';
+  copyBtn.textContent = 'Copy';
+  let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
+  copyBtn.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+  });
+  copyBtn.addEventListener('click', async (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const ok = await copyText(code.textContent ?? '');
+    copyBtn.textContent = ok ? 'Copied' : 'Failed';
+    if (copyResetTimer) clearTimeout(copyResetTimer);
+    copyResetTimer = setTimeout(() => {
+      copyBtn.textContent = 'Copy';
+    }, 1500);
+  });
+  const setCopyVisible = (visible: boolean) => {
+    copyBtn.style.display = visible ? '' : 'none';
+  };
+  actions.appendChild(copyBtn);
+  setCopyVisible(!isPreviewable);
+
+  if (isPreviewable) {
+    ensureGlobalListener();
+    iframe = document.createElement('iframe');
+    iframe.className = 'ss-code-block__iframe';
+    iframe.setAttribute('sandbox', 'allow-scripts');
+    iframe.setAttribute('loading', 'lazy');
+    iframe.setAttribute('title', 'HTML preview');
+    iframe.addEventListener('load', () => {
+      if (iframe && iframe.contentWindow) {
+        iframeHandlers.set(iframe.contentWindow, (height: number) => {
+          if (!iframe) return;
+          if (height <= 0) return;
+          iframe.style.height = `${Math.min(height, MAX_IFRAME_HEIGHT)}px`;
+        });
+      }
+    });
+    syncIframe(node.textContent);
+
+    const toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.className = 'ss-code-block__toggle';
+    toggle.textContent = 'Source';
+    toggle.addEventListener('mousedown', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+    });
+    toggle.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      showingPreview = !showingPreview;
+      if (!iframe) return;
+      if (showingPreview) {
+        iframe.style.display = '';
+        pre.style.display = 'none';
+        toggle.textContent = 'Source';
+        setCopyVisible(false);
+      } else {
+        iframe.style.display = 'none';
+        pre.style.display = '';
+        toggle.textContent = 'Preview';
+        setCopyVisible(true);
+      }
+    });
+    actions.appendChild(toggle);
+  }
+
+  dom.appendChild(header);
+  if (iframe) dom.appendChild(iframe);
+  dom.appendChild(pre);
+
+  if (showingPreview) pre.style.display = 'none';
+
+  return {
+    dom,
+    contentDOM: code,
+    update(updatedNode) {
+      if (updatedNode.type.name !== 'code_block') return false;
+      const nextLang = String(updatedNode.attrs.language || '').toLowerCase();
+      if (nextLang !== language) return false;
+      if (iframe) syncIframe(updatedNode.textContent);
+      return true;
+    },
+    ignoreMutation(mutation) {
+      if (!dom.contains(mutation.target as Node)) return true;
+      if (mutation.target === code) return false;
+      if (code.contains(mutation.target as Node)) return false;
+      return true;
+    },
+  };
+});

--- a/src/shared/ui/markdown/styles.css
+++ b/src/shared/ui/markdown/styles.css
@@ -111,6 +111,101 @@
   color: #0369a1;
 }
 
+/* Code block wrapper (via htmlPreview node view) */
+.md-editor .ss-code-block {
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 8px;
+  background: #0b1020;
+  color: #e6edf3;
+  margin: 0.75em 0;
+  overflow: hidden;
+}
+
+.md-editor .ss-code-block__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 10px;
+  background: rgba(255, 255, 255, 0.06);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 12px;
+  line-height: 1;
+}
+
+.md-editor .ss-code-block__lang {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #9ba3af;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.md-editor .ss-code-block__actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.md-editor .ss-code-block__toggle,
+.md-editor .ss-code-block__copy {
+  appearance: none;
+  background: rgba(255, 255, 255, 0.1);
+  color: #e6edf3;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 12px;
+  cursor: pointer;
+  font-family: inherit;
+  line-height: 1;
+}
+
+.md-editor .ss-code-block__toggle:hover,
+.md-editor .ss-code-block__copy:hover {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.md-editor .ss-code-block pre {
+  margin: 0;
+  padding: 12px 14px;
+  background: transparent;
+  color: inherit;
+  overflow-x: auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre;
+}
+
+.md-editor .ss-code-block pre code {
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  font: inherit;
+}
+
+.md-editor .ss-code-block__iframe {
+  display: block;
+  width: 100%;
+  /* Initial height before the height reporter postMessages in the real size
+     (capped in JS by MAX_IFRAME_HEIGHT). */
+  height: 500px;
+  border: 0;
+  background: #ffffff;
+  /* Kill the baseline gap under replaced elements (iframe is inline by
+     default), which otherwise adds ~4px of empty space below the preview. */
+  vertical-align: top;
+}
+
+/* Inline code */
+.md-editor .ProseMirror :not(pre) > code {
+  background: rgba(135, 131, 120, 0.15);
+  color: #c7254e;
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.9em;
+}
+
 /* Mentions popup */
 .md-mention-menu {
   background: hsl(var(--background, 0 0% 100%));


### PR DESCRIPTION
## Summary
- Chat responses that include a fenced ```` ```html ```` block now render as a sandboxed `<iframe>` preview by default (e.g. chatbot-generated Chart.js visualisations), with a **Source ⇄ Preview** toggle and a **Copy** button for the raw source.
- Fixes a pre-existing bug where the autolink decoration plugin would linkify URLs _inside_ code blocks, stamping `<a>` tags into `<script src="...">` and similar.

## What changed
- **New:** `src/shared/ui/markdown/extensions/htmlPreview.ts` — a Milkdown `$view` node view over `codeBlockSchema.node` that:
  - wraps every code block in a dark `.ss-code-block` card with a language label and action buttons
  - for `language === "html"` mounts an `iframe` with `sandbox="allow-scripts"` and injects a height-reporter script into the srcdoc so the iframe can `postMessage` its measured body height out to the parent (the sandbox's opaque origin blocks direct `contentDocument` reads)
  - autosizes to content, capped by `MAX_IFRAME_HEIGHT` (5000px) as a defensive guardrail
  - Copy button copies the raw source, with `navigator.clipboard` + textarea fallback
  - Source/Preview toggle swaps visibility and flips the Copy button's visibility accordingly
  - Registers against `codeBlockSchema.node` rather than `codeBlockSchema` — the latter has `id: undefined` at module-load time, so `$view` would register under an undefined key and silently never run
- **Fix:** `src/shared/ui/markdown/extensions/autolink.ts` — stops descending into `code_block` nodes, skips text with `inlineCode`/`code` marks, and skips any text whose parent node spec has `code: true`
- **Wire-in:** `src/shared/ui/markdown/MarkdownEditor.tsx` — adds `.use(htmlPreviewView)` to the editor plugin chain
- **Styles:** `src/shared/ui/markdown/styles.css` — styles for `.ss-code-block`, header, language label, Copy/Source buttons, `pre`/`code`, iframe (with `vertical-align: top` to kill the inline baseline gap), and inline code
- **Tests:** `src/shared/ui/markdown/__tests__/MarkdownEditor.html-codeblock.spec.tsx` — 6 vitest component tests covering:
  1. iframe renders with correct `sandbox` + `srcdoc` (including the full Chart.js source)
  2. raw source preserved in a hidden `<pre><code>` so the Source toggle has something to show
  3. clicking the toggle swaps visibility and button label
  4. autolink does **not** inject `<a>` tags inside the code block
  5. trailing paragraph after the code block still renders
  6. non-previewable languages (` ```js `) do **not** get an iframe wrapper

## Security notes
- `sandbox="allow-scripts"` (no `allow-same-origin`) — the iframe runs scripts in an opaque origin with no access to parent cookies, localStorage, or DOM. Cross-origin fetches (e.g. `cdn.jsdelivr.net/npm/chart.js`) still work because sandbox doesn't gate network access.
- The height-reporter script communicates via `window.postMessage`; a single global listener on the parent window (`window.__ssHtmlPreviewListener`) routes messages back to the originating iframe by matching `event.source`.
- A runaway preview is bounded at `MAX_IFRAME_HEIGHT = 5000px` to keep a misbehaving chart from pushing the page to absurd heights.

## Test plan
- [ ] `npm run typecheck` — unchanged baseline (preexisting errors in `domains/threads`/`domains/workspaces` are API-client drift, not from this PR)
- [ ] `npx vitest run src/shared/ui/markdown/__tests__/MarkdownEditor.html-codeblock.spec.tsx` — 6/6 pass
- [ ] `npm run serve` and send a prompt like "return a chart.js bar chart as a html block" → verify the chart renders inline in a card with no internal scrollbar
- [ ] Click **Source** → raw HTML shown, **Copy** button appears, clicking it copies to clipboard with "Copied" feedback
- [ ] Verify URLs inside `<script src="...">` are literal text, not blue links
- [ ] Send a response containing a ` ```js ` code block → card with Copy button, no iframe

## Out of scope
- Syntax highlighting for non-HTML code blocks
- Preview for other executable formats (SVG, Mermaid, etc.)
- `@tailwindcss/typography` install — the `prose` classes on `MessageBubble` are still dead weight; code-block styling now lives in `styles.css` instead. Separate PR if you want full prose typography.