### PR TITLE
fix(messages): use react-markdown for read-only message rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "react-virtualized-auto-sizer": "^1.0.26",
         "react-virtuoso": "^4.18.4",
         "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "6.0.0",
         "remark-gfm": "^4.0.1",
         "rxjs": "^7.8.2",
         "sonner": "^2.0.7",
@@ -14798,6 +14799,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -20547,6 +20563,20 @@
         "@types/hast": "^3.0.0",
         "hast-util-raw": "^9.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "react-virtualized-auto-sizer": "^1.0.26",
     "react-virtuoso": "^4.18.4",
     "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "6.0.0",
     "remark-gfm": "^4.0.1",
     "rxjs": "^7.8.2",
     "sonner": "^2.0.7",

--- a/src/domains/files/service.ts
+++ b/src/domains/files/service.ts
@@ -14,6 +14,23 @@ const {
 } = ChatZod;
 const chatApi = ChatApi.getSmartSpaceChatAPI();
 
+// The API returns `null` for `createdByUserId` / `modifiedByUserId` on file
+// upload responses, but the SDK's generated Zod schema marks them as required
+// non-nullable strings. The mapper doesn't use these fields, so coerce nulls
+// to empty strings before validation rather than forking the SDK.
+const coerceFileUploadResponse = (data: unknown): unknown => {
+  if (!Array.isArray(data)) return data;
+  return data.map((item) => {
+    if (!item || typeof item !== 'object') return item;
+    const r = item as Record<string, unknown>;
+    return {
+      ...r,
+      createdByUserId: r.createdByUserId ?? '',
+      modifiedByUserId: r.modifiedByUserId ?? '',
+    };
+  });
+};
+
 const uploadFileInChunks = async (
   file: File,
   scope: FileScope,
@@ -45,7 +62,7 @@ const uploadFileInChunks = async (
     if (i === totalChunks - 1) {
       const parsed = parseOrThrow(
         filesResponseSchema,
-        response.data,
+        coerceFileUploadResponse(response.data),
         'POST /files (chunked)'
       );
       return mapFileInfoDtoToModel(parsed[0]);
@@ -78,7 +95,7 @@ export const uploadFiles = async (
       });
       const parsed = parseOrThrow(
         filesResponseSchema,
-        response.data,
+        coerceFileUploadResponse(response.data),
         'POST /files'
       );
       fileInfo = mapFileInfoDtoToModel(parsed[0]);

--- a/src/shared/ui/markdown/MessageMarkdown.tsx
+++ b/src/shared/ui/markdown/MessageMarkdown.tsx
@@ -6,6 +6,7 @@ import rehypeRaw from 'rehype-raw';
 import rehypeSanitize from 'rehype-sanitize';
 import remarkGfm from 'remark-gfm';
 
+import { remarkFileTag } from './plugins/remarkFileTag';
 import { CodeBlock } from './renderers/CodeBlock';
 import { HtmlPreview } from './renderers/HtmlPreview';
 import { SsImage } from './renderers/SsImage';
@@ -18,7 +19,7 @@ const rehypePlugins: React.ComponentProps<
 
 const remarkPlugins: React.ComponentProps<
   typeof ReactMarkdown
->['remarkPlugins'] = [remarkGfm];
+>['remarkPlugins'] = [remarkGfm, remarkFileTag];
 
 // react-markdown's default urlTransform strips any URL whose protocol isn't
 // in its built-in safelist (http, https, mailto, etc). The chat backend uses

--- a/src/shared/ui/markdown/MessageMarkdown.tsx
+++ b/src/shared/ui/markdown/MessageMarkdown.tsx
@@ -1,0 +1,94 @@
+import ReactMarkdown, {
+  type Components,
+  defaultUrlTransform,
+} from 'react-markdown';
+import rehypeRaw from 'rehype-raw';
+import rehypeSanitize from 'rehype-sanitize';
+import remarkGfm from 'remark-gfm';
+
+import { CodeBlock } from './renderers/CodeBlock';
+import { HtmlPreview } from './renderers/HtmlPreview';
+import { SsImage } from './renderers/SsImage';
+import { messageSanitizeSchema } from './sanitizeSchema';
+import './styles.css';
+
+const rehypePlugins: React.ComponentProps<
+  typeof ReactMarkdown
+>['rehypePlugins'] = [rehypeRaw, [rehypeSanitize, messageSanitizeSchema]];
+
+const remarkPlugins: React.ComponentProps<
+  typeof ReactMarkdown
+>['remarkPlugins'] = [remarkGfm];
+
+// react-markdown's default urlTransform strips any URL whose protocol isn't
+// in its built-in safelist (http, https, mailto, etc). The chat backend uses
+// a custom `ss-file:` scheme for inline file references — without this
+// override the src is replaced with an empty string and the SsImage renderer
+// never sees the file id.
+const urlTransform: React.ComponentProps<
+  typeof ReactMarkdown
+>['urlTransform'] = (value) => {
+  if (typeof value === 'string' && value.startsWith('ss-file:')) {
+    return value;
+  }
+  return defaultUrlTransform(value);
+};
+
+const components: Components = {
+  code({ className, children }) {
+    const source = String(children ?? '').replace(/\n$/, '');
+    const match = /language-(\w+)/.exec(className ?? '');
+    const language = match?.[1] ?? '';
+    // react-markdown v9 dropped the `inline` prop. A fenced/indented code
+    // block in hast is always `<pre><code>`, so we detect "block" by the
+    // presence of a language class or a newline in the source. Bare inline
+    // `<code>` without either renders via the default inline code path.
+    const isBlock = !!language || source.includes('\n');
+    if (!isBlock) {
+      return <code className={className}>{children}</code>;
+    }
+    if (language === 'html') {
+      return <HtmlPreview source={source} />;
+    }
+    return <CodeBlock language={language} source={source} />;
+  },
+  // Override the default `pre` wrapper so our `code` component can emit its
+  // own wrapper. Without this, react-markdown wraps our CodeBlock/HtmlPreview
+  // in an extra `<pre>` element from its default renderer.
+  pre({ children }) {
+    return <>{children}</>;
+  },
+  a({ href, children, ...rest }) {
+    return (
+      <a href={href} target="_blank" rel="noreferrer noopener" {...rest}>
+        {children}
+      </a>
+    );
+  },
+  img: SsImage,
+};
+
+type MessageMarkdownProps = {
+  value: string;
+  className?: string;
+};
+
+/** Read-only markdown renderer for chat messages. Uses react-markdown +
+ *  rehype-raw so mixed markdown/HTML rebalances via parse5, which fixes
+ *  cases like `<details>` wrapping a fenced code block. Shares the
+ *  `ss-code-block` CSS scope with the Milkdown editor via the
+ *  `ss-markdown` wrapper class (see `styles.css`). */
+export function MessageMarkdown({ value, className }: MessageMarkdownProps) {
+  return (
+    <div className={className ? `ss-markdown ${className}` : 'ss-markdown'}>
+      <ReactMarkdown
+        remarkPlugins={remarkPlugins}
+        rehypePlugins={rehypePlugins}
+        urlTransform={urlTransform}
+        components={components}
+      >
+        {value}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/src/shared/ui/markdown/__tests__/MessageMarkdown.spec.tsx
+++ b/src/shared/ui/markdown/__tests__/MessageMarkdown.spec.tsx
@@ -1,0 +1,73 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { MessageMarkdown } from '@/shared/ui/markdown/MessageMarkdown';
+
+describe('MessageMarkdown', () => {
+  it('renders <details> wrapping a fenced SQL code block as a real disclosure with the code inside', () => {
+    const md = [
+      '<details>',
+      '<summary>SQL Query</summary>',
+      '',
+      '```sql',
+      'SELECT 1',
+      '```',
+      '',
+      '</details>',
+    ].join('\n');
+
+    const { container } = render(<MessageMarkdown value={md} />);
+
+    const details = container.querySelector('details');
+    expect(details).not.toBeNull();
+    const summary = details?.querySelector('summary');
+    expect(summary?.textContent).toBe('SQL Query');
+    // The SQL fenced block should become a real <code class="language-sql">
+    // living inside the <details> disclosure, not raw text after it.
+    const code = details?.querySelector('code.language-sql');
+    expect(code).not.toBeNull();
+    expect(code?.textContent).toContain('SELECT 1');
+  });
+
+  it('renders a raw <a target="_blank"> inside a list item as a clickable anchor', () => {
+    const md = [
+      '### Tables',
+      '- <a href="https://example.com" target="_blank">example.table</a>',
+    ].join('\n');
+
+    const { container } = render(<MessageMarkdown value={md} />);
+
+    const anchor = container.querySelector('ul li a');
+    expect(anchor).not.toBeNull();
+    expect(anchor?.getAttribute('href')).toBe('https://example.com');
+    // All anchors get target=_blank + a safe rel in the renderer.
+    expect(anchor?.getAttribute('target')).toBe('_blank');
+    expect(anchor?.getAttribute('rel')).toContain('noopener');
+    expect(anchor?.textContent).toBe('example.table');
+  });
+
+  it('renders ```html fenced blocks via the sandboxed iframe preview', () => {
+    const md = ['```html', '<div>hi</div>', '```'].join('\n');
+    const { container } = render(<MessageMarkdown value={md} />);
+    const iframe = container.querySelector('iframe.ss-code-block__iframe');
+    expect(iframe).not.toBeNull();
+    expect(iframe?.getAttribute('sandbox')).toBe('allow-scripts');
+  });
+
+  it('renders non-html fenced blocks via the CodeBlock renderer with a language class', () => {
+    const md = ['```sql', 'SELECT 1', '```'].join('\n');
+    const { container } = render(<MessageMarkdown value={md} />);
+    const wrapper = container.querySelector('.ss-code-block');
+    expect(wrapper).not.toBeNull();
+    // Non-previewable languages don't get the iframe.
+    expect(container.querySelector('iframe.ss-code-block__iframe')).toBeNull();
+    const code = wrapper?.querySelector('code.language-sql');
+    expect(code?.textContent).toContain('SELECT 1');
+  });
+
+  it('sanitizes dangerous content like <script>', () => {
+    const md = '<script>window.__ssXss = true</script>hello';
+    const { container } = render(<MessageMarkdown value={md} />);
+    expect(container.querySelector('script')).toBeNull();
+  });
+});

--- a/src/shared/ui/markdown/extensions/htmlPreview.ts
+++ b/src/shared/ui/markdown/extensions/htmlPreview.ts
@@ -118,9 +118,31 @@ export const htmlPreviewView = $view(codeBlockSchema.node, () => (node) => {
     iframe.setAttribute('sandbox', 'allow-scripts');
     iframe.setAttribute('loading', 'lazy');
     iframe.setAttribute('title', 'HTML preview');
+    const setShowingPreview = (next: boolean) => {
+      showingPreview = next;
+      if (!iframe) return;
+      if (showingPreview) {
+        iframe.style.display = '';
+        pre.style.display = 'none';
+        toggle.textContent = 'Source';
+        setCopyVisible(false);
+      } else {
+        iframe.style.display = 'none';
+        pre.style.display = '';
+        toggle.textContent = 'Preview';
+        setCopyVisible(true);
+      }
+    };
+
     iframe.addEventListener('load', () => {
       if (destroyed || !iframe || !iframe.contentWindow) return;
-      iframeHandlers.set(iframe.contentWindow, scheduleHeight);
+      iframeHandlers.set(iframe.contentWindow, {
+        onHeight: scheduleHeight,
+        onError: () => {
+          if (destroyed) return;
+          if (showingPreview) setShowingPreview(false);
+        },
+      });
     });
     syncIframe(node.textContent);
 
@@ -135,19 +157,7 @@ export const htmlPreviewView = $view(codeBlockSchema.node, () => (node) => {
     toggle.addEventListener('click', (e) => {
       e.preventDefault();
       e.stopPropagation();
-      showingPreview = !showingPreview;
-      if (!iframe) return;
-      if (showingPreview) {
-        iframe.style.display = '';
-        pre.style.display = 'none';
-        toggle.textContent = 'Source';
-        setCopyVisible(false);
-      } else {
-        iframe.style.display = 'none';
-        pre.style.display = '';
-        toggle.textContent = 'Preview';
-        setCopyVisible(true);
-      }
+      setShowingPreview(!showingPreview);
     });
     actions.appendChild(toggle);
   }

--- a/src/shared/ui/markdown/extensions/htmlPreview.ts
+++ b/src/shared/ui/markdown/extensions/htmlPreview.ts
@@ -1,135 +1,18 @@
 import { codeBlockSchema } from '@milkdown/preset-commonmark';
 import { $view } from '@milkdown/utils';
 
+import {
+  copyText,
+  ensureGlobalListener,
+  iframeHandlers,
+  injectHeightReporter,
+  MAX_IFRAME_HEIGHT,
+} from '../htmlPreviewShared';
+
+// Re-exported for existing importers/tests.
+export { injectHeightReporter };
+
 const PREVIEW_LANGUAGES = new Set(['html']);
-
-// Defensive upper bound — a runaway HTML preview (infinite loop resizing,
-// `scrollHeight = 1e9`) shouldn't blow out the page. 5000px is roughly 5
-// viewports on a laptop, so any legitimate chart/table still fits.
-const MAX_IFRAME_HEIGHT = 5000;
-const HEIGHT_MESSAGE = 'ss-html-preview-height';
-
-// Injected into each previewed HTML document. Because the iframe uses
-// `sandbox="allow-scripts"` (no `allow-same-origin`), the parent cannot read
-// `contentDocument` directly, so the iframe has to push its height out via
-// postMessage. ResizeObserver handles late content (charts, images, fonts).
-// The script is idempotent (dedupes repeated heights) so a chatty ResizeObserver
-// doesn't spam the parent.
-const HEIGHT_REPORTER_SCRIPT = `
-<script>(function(){
-  // Reset default UA body margin so the reported height matches actual content
-  // and we don't inherit an extra ~16px of whitespace. Keep body overflow
-  // visible so popovers/anchors inside the preview still work.
-  try {
-    var s = document.createElement('style');
-    s.textContent = 'html,body{margin:0;padding:0;}';
-    (document.head || document.documentElement).appendChild(s);
-  } catch (e) {}
-  var lastSent = -1;
-  function send(){
-    try {
-      var body = document.body;
-      if (!body) return;
-      // getBoundingClientRect returns the laid-out height of the body,
-      // excluding any empty trailing space from html margins/padding.
-      var h = Math.ceil(body.getBoundingClientRect().height);
-      if (h === lastSent) return;
-      lastSent = h;
-      parent.postMessage({ type: ${JSON.stringify(
-        HEIGHT_MESSAGE
-      )}, height: h }, '*');
-    } catch (e) {}
-  }
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', send);
-  } else {
-    send();
-  }
-  window.addEventListener('load', send);
-  try {
-    if (typeof ResizeObserver !== 'undefined') {
-      var ro = new ResizeObserver(send);
-      if (document.body) ro.observe(document.body);
-    }
-  } catch (e) {}
-  setTimeout(send, 100);
-  setTimeout(send, 500);
-  setTimeout(send, 1500);
-})();</script>
-`;
-
-/**
- * Injects the height-reporter script just before the LAST `</body>` (or
- * `</html>`) tag. We use `lastIndexOf` rather than a regex replace because a
- * chat response might include `</body>` inside a string literal or comment,
- * and we want the real closing tag.
- *
- * Exported for unit testing.
- */
-export function injectHeightReporter(html: string): string {
-  const lower = html.toLowerCase();
-  const bodyIdx = lower.lastIndexOf('</body>');
-  if (bodyIdx >= 0) {
-    return (
-      html.slice(0, bodyIdx) + HEIGHT_REPORTER_SCRIPT + html.slice(bodyIdx)
-    );
-  }
-  const htmlIdx = lower.lastIndexOf('</html>');
-  if (htmlIdx >= 0) {
-    return (
-      html.slice(0, htmlIdx) + HEIGHT_REPORTER_SCRIPT + html.slice(htmlIdx)
-    );
-  }
-  return html + HEIGHT_REPORTER_SCRIPT;
-}
-
-// Single global listener — routes height messages back to whichever iframe
-// originated them by matching against `event.source`. A WeakMap means that
-// when an iframe is removed from the DOM and its contentWindow is collected,
-// the handler entry drops automatically — but we still clear eagerly in the
-// node view's `destroy` hook to avoid stale handlers firing mid-teardown.
-const iframeHandlers = new WeakMap<Window, (height: number) => void>();
-
-function ensureGlobalListener() {
-  if (typeof window === 'undefined') return;
-  const w = window as Window & { __ssHtmlPreviewListener?: boolean };
-  if (w.__ssHtmlPreviewListener) return;
-  w.__ssHtmlPreviewListener = true;
-  window.addEventListener('message', (event) => {
-    const data = event.data as { type?: string; height?: number } | null;
-    if (!data || data.type !== HEIGHT_MESSAGE) return;
-    if (typeof data.height !== 'number') return;
-    const source = event.source as Window | null;
-    if (!source) return;
-    const handler = iframeHandlers.get(source);
-    if (handler) handler(data.height);
-  });
-}
-
-async function copyText(text: string): Promise<boolean> {
-  try {
-    if (navigator.clipboard?.writeText) {
-      await navigator.clipboard.writeText(text);
-      return true;
-    }
-  } catch {
-    /* fall through to textarea fallback */
-  }
-  try {
-    const ta = document.createElement('textarea');
-    ta.value = text;
-    ta.setAttribute('readonly', '');
-    ta.style.position = 'fixed';
-    ta.style.opacity = '0';
-    document.body.appendChild(ta);
-    ta.select();
-    const ok = document.execCommand('copy');
-    ta.remove();
-    return ok;
-  } catch {
-    return false;
-  }
-}
 
 // `codeBlockSchema` from @milkdown/preset-commonmark is a `$nodeSchema` result
 // (an array-plus-props). `$view` reads `type.id` lazily, but that `id` field on

--- a/src/shared/ui/markdown/htmlPreviewShared.ts
+++ b/src/shared/ui/markdown/htmlPreviewShared.ts
@@ -3,6 +3,7 @@
 // viewports on a laptop, so any legitimate chart/table still fits.
 export const MAX_IFRAME_HEIGHT = 5000;
 export const HEIGHT_MESSAGE = 'ss-html-preview-height';
+export const ERROR_MESSAGE = 'ss-html-preview-error';
 
 // Injected into each previewed HTML document. Because the iframe uses
 // `sandbox="allow-scripts"` (no `allow-same-origin`), the parent cannot read
@@ -17,6 +18,23 @@ const HEIGHT_REPORTER_SCRIPT = `
     s.textContent = 'html,body{margin:0;padding:0;}';
     (document.head || document.documentElement).appendChild(s);
   } catch (e) {}
+  function reportError(msg){
+    try {
+      parent.postMessage({ type: ${JSON.stringify(
+        ERROR_MESSAGE
+      )}, message: String(msg || 'preview error') }, '*');
+    } catch (e) {}
+  }
+  // Catch synchronous script errors and unhandled promise rejections so the
+  // host can flip the preview back to source view instead of showing a blank
+  // iframe (e.g. when an LLM emits a JS-only snippet referencing a missing
+  // canvas).
+  window.addEventListener('error', function(ev){
+    reportError(ev && ev.message);
+  });
+  window.addEventListener('unhandledrejection', function(ev){
+    reportError(ev && ev.reason && ev.reason.message);
+  });
   var lastSent = -1;
   function send(){
     try {
@@ -70,10 +88,14 @@ export function injectHeightReporter(html: string): string {
   return html + HEIGHT_REPORTER_SCRIPT;
 }
 
-// Single global listener routing height messages back to whichever iframe
-// originated them, via WeakMap keyed on `event.source`. Consumers still clear
-// eagerly on teardown to avoid stale handlers firing mid-destroy.
-export const iframeHandlers = new WeakMap<Window, (height: number) => void>();
+// Single global listener routing height + error messages back to whichever
+// iframe originated them, via WeakMap keyed on `event.source`. Consumers
+// still clear eagerly on teardown to avoid stale handlers firing mid-destroy.
+export type IframeHandler = {
+  onHeight: (height: number) => void;
+  onError?: (message: string) => void;
+};
+export const iframeHandlers = new WeakMap<Window, IframeHandler>();
 
 export function ensureGlobalListener(): void {
   if (typeof window === 'undefined') return;
@@ -81,13 +103,21 @@ export function ensureGlobalListener(): void {
   if (w.__ssHtmlPreviewListener) return;
   w.__ssHtmlPreviewListener = true;
   window.addEventListener('message', (event) => {
-    const data = event.data as { type?: string; height?: number } | null;
-    if (!data || data.type !== HEIGHT_MESSAGE) return;
-    if (typeof data.height !== 'number') return;
+    const data = event.data as {
+      type?: string;
+      height?: number;
+      message?: string;
+    } | null;
+    if (!data || typeof data.type !== 'string') return;
     const source = event.source as Window | null;
     if (!source) return;
     const handler = iframeHandlers.get(source);
-    if (handler) handler(data.height);
+    if (!handler) return;
+    if (data.type === HEIGHT_MESSAGE && typeof data.height === 'number') {
+      handler.onHeight(data.height);
+    } else if (data.type === ERROR_MESSAGE) {
+      handler.onError?.(typeof data.message === 'string' ? data.message : '');
+    }
   });
 }
 

--- a/src/shared/ui/markdown/htmlPreviewShared.ts
+++ b/src/shared/ui/markdown/htmlPreviewShared.ts
@@ -1,0 +1,117 @@
+// Defensive upper bound — a runaway HTML preview (infinite loop resizing,
+// `scrollHeight = 1e9`) shouldn't blow out the page. 5000px is roughly 5
+// viewports on a laptop, so any legitimate chart/table still fits.
+export const MAX_IFRAME_HEIGHT = 5000;
+export const HEIGHT_MESSAGE = 'ss-html-preview-height';
+
+// Injected into each previewed HTML document. Because the iframe uses
+// `sandbox="allow-scripts"` (no `allow-same-origin`), the parent cannot read
+// `contentDocument` directly, so the iframe has to push its height out via
+// postMessage. ResizeObserver handles late content (charts, images, fonts).
+// The script is idempotent (dedupes repeated heights) so a chatty ResizeObserver
+// doesn't spam the parent.
+const HEIGHT_REPORTER_SCRIPT = `
+<script>(function(){
+  try {
+    var s = document.createElement('style');
+    s.textContent = 'html,body{margin:0;padding:0;}';
+    (document.head || document.documentElement).appendChild(s);
+  } catch (e) {}
+  var lastSent = -1;
+  function send(){
+    try {
+      var body = document.body;
+      if (!body) return;
+      var h = Math.ceil(body.getBoundingClientRect().height);
+      if (h === lastSent) return;
+      lastSent = h;
+      parent.postMessage({ type: ${JSON.stringify(
+        HEIGHT_MESSAGE
+      )}, height: h }, '*');
+    } catch (e) {}
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', send);
+  } else {
+    send();
+  }
+  window.addEventListener('load', send);
+  try {
+    if (typeof ResizeObserver !== 'undefined') {
+      var ro = new ResizeObserver(send);
+      if (document.body) ro.observe(document.body);
+    }
+  } catch (e) {}
+  setTimeout(send, 100);
+  setTimeout(send, 500);
+  setTimeout(send, 1500);
+})();</script>
+`;
+
+/**
+ * Injects the height-reporter script just before the LAST `</body>` (or
+ * `</html>`) tag. `lastIndexOf` rather than regex so a `</body>` inside a
+ * string literal or comment doesn't confuse us.
+ */
+export function injectHeightReporter(html: string): string {
+  const lower = html.toLowerCase();
+  const bodyIdx = lower.lastIndexOf('</body>');
+  if (bodyIdx >= 0) {
+    return (
+      html.slice(0, bodyIdx) + HEIGHT_REPORTER_SCRIPT + html.slice(bodyIdx)
+    );
+  }
+  const htmlIdx = lower.lastIndexOf('</html>');
+  if (htmlIdx >= 0) {
+    return (
+      html.slice(0, htmlIdx) + HEIGHT_REPORTER_SCRIPT + html.slice(htmlIdx)
+    );
+  }
+  return html + HEIGHT_REPORTER_SCRIPT;
+}
+
+// Single global listener routing height messages back to whichever iframe
+// originated them, via WeakMap keyed on `event.source`. Consumers still clear
+// eagerly on teardown to avoid stale handlers firing mid-destroy.
+export const iframeHandlers = new WeakMap<Window, (height: number) => void>();
+
+export function ensureGlobalListener(): void {
+  if (typeof window === 'undefined') return;
+  const w = window as Window & { __ssHtmlPreviewListener?: boolean };
+  if (w.__ssHtmlPreviewListener) return;
+  w.__ssHtmlPreviewListener = true;
+  window.addEventListener('message', (event) => {
+    const data = event.data as { type?: string; height?: number } | null;
+    if (!data || data.type !== HEIGHT_MESSAGE) return;
+    if (typeof data.height !== 'number') return;
+    const source = event.source as Window | null;
+    if (!source) return;
+    const handler = iframeHandlers.get(source);
+    if (handler) handler(data.height);
+  });
+}
+
+export async function copyText(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    /* fall through to textarea fallback */
+  }
+  try {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.setAttribute('readonly', '');
+    ta.style.position = 'fixed';
+    ta.style.opacity = '0';
+    document.body.appendChild(ta);
+    ta.select();
+    const ok = document.execCommand('copy');
+    ta.remove();
+    return ok;
+  } catch {
+    return false;
+  }
+}

--- a/src/shared/ui/markdown/plugins/remarkFileTag.ts
+++ b/src/shared/ui/markdown/plugins/remarkFileTag.ts
@@ -1,0 +1,70 @@
+import type { Html, Root, Text } from 'mdast';
+import type { Plugin } from 'unified';
+import type { Node, Parent } from 'unist';
+import { visit } from 'unist-util-visit';
+
+// Matches the same `[[file:<id>|<label>]]` syntax that the Milkdown
+// `fileTag` extension authors. The `id` accepts anything except `|` and `]`
+// to keep the brace-pair as the boundary. The `label` accepts anything
+// except `]`. Both groups must be non-empty.
+const FILE_TAG_RE = /\[\[file:([^|\]]+)\|([^\]]+)\]\]/g;
+
+const escapeHtml = (s: string): string =>
+  s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+const renderFileTag = (id: string, label: string): string =>
+  `<span class="file-tag" data-file-tag data-id="${escapeHtml(
+    id
+  )}">${escapeHtml(label)}</span>`;
+
+/**
+ * Remark plugin that rewrites inline `[[file:<id>|<label>]]` tokens in text
+ * nodes into raw-HTML mdast nodes wrapping the same `<span class="file-tag">`
+ * markup that the Milkdown `fileTag` extension produces. Lets backend-emitted
+ * file references render as styled inline tags in read-only messages while
+ * keeping the DOM contract identical to the editor side.
+ */
+export const remarkFileTag: Plugin<[], Root> = () => (tree) => {
+  visit(tree, 'text', (node: Text, index, parent) => {
+    if (!parent || index == null) return;
+    const value = node.value;
+    if (!value.includes('[[file:')) return;
+
+    FILE_TAG_RE.lastIndex = 0;
+    const replacements: Array<Text | Html> = [];
+    let cursor = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = FILE_TAG_RE.exec(value)) !== null) {
+      if (match.index > cursor) {
+        replacements.push({
+          type: 'text',
+          value: value.slice(cursor, match.index),
+        });
+      }
+      replacements.push({
+        type: 'html',
+        value: renderFileTag(match[1], match[2]),
+      });
+      cursor = match.index + match[0].length;
+    }
+
+    if (replacements.length === 0) return;
+
+    if (cursor < value.length) {
+      replacements.push({ type: 'text', value: value.slice(cursor) });
+    }
+
+    (parent as Parent).children.splice(
+      index,
+      1,
+      ...(replacements as unknown as Node[])
+    );
+    return index + replacements.length;
+  });
+};

--- a/src/shared/ui/markdown/renderers/CodeBlock.tsx
+++ b/src/shared/ui/markdown/renderers/CodeBlock.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { copyText } from '../htmlPreviewShared';
+
+type CodeBlockProps = {
+  language: string;
+  source: string;
+};
+
+export function CodeBlock({ language, source }: CodeBlockProps) {
+  const [copyLabel, setCopyLabel] = useState<'Copy' | 'Copied' | 'Failed'>(
+    'Copy'
+  );
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current) {
+        clearTimeout(resetTimerRef.current);
+        resetTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  const handleCopy = async () => {
+    const ok = await copyText(source);
+    setCopyLabel(ok ? 'Copied' : 'Failed');
+    if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+    resetTimerRef.current = setTimeout(() => {
+      setCopyLabel('Copy');
+      resetTimerRef.current = null;
+    }, 1500);
+  };
+
+  const codeClass = language ? `language-${language}` : undefined;
+
+  return (
+    <div className="ss-code-block">
+      <div className="ss-code-block__header">
+        <span className="ss-code-block__lang">{language || 'text'}</span>
+        <div className="ss-code-block__actions">
+          <button
+            type="button"
+            className="ss-code-block__copy"
+            onMouseDown={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+            onClick={handleCopy}
+          >
+            {copyLabel}
+          </button>
+        </div>
+      </div>
+      <pre {...(language ? { 'data-language': language } : {})}>
+        <code className={codeClass}>{source}</code>
+      </pre>
+    </div>
+  );
+}

--- a/src/shared/ui/markdown/renderers/HtmlPreview.tsx
+++ b/src/shared/ui/markdown/renderers/HtmlPreview.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useRef, useState } from 'react';
+
+import {
+  copyText,
+  ensureGlobalListener,
+  iframeHandlers,
+  injectHeightReporter,
+  MAX_IFRAME_HEIGHT,
+} from '../htmlPreviewShared';
+
+type HtmlPreviewProps = {
+  source: string;
+};
+
+export function HtmlPreview({ source }: HtmlPreviewProps) {
+  const [showingPreview, setShowingPreview] = useState(true);
+  const [copyLabel, setCopyLabel] = useState<'Copy' | 'Copied' | 'Failed'>(
+    'Copy'
+  );
+  const [iframeHeight, setIframeHeight] = useState<number | null>(null);
+
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const rafIdRef = useRef<number | null>(null);
+  const pendingHeightRef = useRef<number | null>(null);
+  const copyResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const srcdoc = injectHeightReporter(source);
+
+  useEffect(() => {
+    ensureGlobalListener();
+  }, []);
+
+  // Register a height handler keyed on the iframe's contentWindow.
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe) return;
+
+    const flushPendingHeight = () => {
+      rafIdRef.current = null;
+      const h = pendingHeightRef.current;
+      if (h == null) return;
+      const next = Math.min(h, MAX_IFRAME_HEIGHT);
+      pendingHeightRef.current = null;
+      if (next <= 0) return;
+      setIframeHeight(next);
+    };
+
+    const scheduleHeight = (height: number) => {
+      pendingHeightRef.current = height;
+      if (rafIdRef.current != null) return;
+      if (typeof requestAnimationFrame === 'function') {
+        rafIdRef.current = requestAnimationFrame(flushPendingHeight);
+      } else {
+        rafIdRef.current = window.setTimeout(
+          flushPendingHeight,
+          16
+        ) as unknown as number;
+      }
+    };
+
+    const onLoad = () => {
+      if (!iframe.contentWindow) return;
+      iframeHandlers.set(iframe.contentWindow, scheduleHeight);
+    };
+
+    iframe.addEventListener('load', onLoad);
+
+    return () => {
+      iframe.removeEventListener('load', onLoad);
+      if (rafIdRef.current != null) {
+        if (typeof cancelAnimationFrame === 'function') {
+          cancelAnimationFrame(rafIdRef.current);
+        } else {
+          clearTimeout(rafIdRef.current);
+        }
+        rafIdRef.current = null;
+      }
+      if (iframe.contentWindow) {
+        iframeHandlers.delete(iframe.contentWindow);
+      }
+    };
+  }, [srcdoc]);
+
+  useEffect(() => {
+    return () => {
+      if (copyResetTimerRef.current) {
+        clearTimeout(copyResetTimerRef.current);
+        copyResetTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  const handleCopy = async () => {
+    const ok = await copyText(source);
+    setCopyLabel(ok ? 'Copied' : 'Failed');
+    if (copyResetTimerRef.current) clearTimeout(copyResetTimerRef.current);
+    copyResetTimerRef.current = setTimeout(() => {
+      setCopyLabel('Copy');
+      copyResetTimerRef.current = null;
+    }, 1500);
+  };
+
+  return (
+    <div className="ss-code-block ss-code-block--previewable">
+      <div className="ss-code-block__header">
+        <span className="ss-code-block__lang">html</span>
+        <div className="ss-code-block__actions">
+          {!showingPreview && (
+            <button
+              type="button"
+              className="ss-code-block__copy"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+              onClick={handleCopy}
+            >
+              {copyLabel}
+            </button>
+          )}
+          <button
+            type="button"
+            className="ss-code-block__toggle"
+            onMouseDown={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+            onClick={() => setShowingPreview((v) => !v)}
+          >
+            {showingPreview ? 'Source' : 'Preview'}
+          </button>
+        </div>
+      </div>
+      <iframe
+        ref={iframeRef}
+        className="ss-code-block__iframe"
+        sandbox="allow-scripts"
+        loading="lazy"
+        title="HTML preview"
+        srcDoc={srcdoc}
+        style={{
+          display: showingPreview ? 'block' : 'none',
+          ...(iframeHeight != null ? { height: `${iframeHeight}px` } : {}),
+        }}
+      />
+      <pre
+        data-language="html"
+        style={{ display: showingPreview ? 'none' : 'block' }}
+      >
+        <code className="language-html">{source}</code>
+      </pre>
+    </div>
+  );
+}

--- a/src/shared/ui/markdown/renderers/HtmlPreview.tsx
+++ b/src/shared/ui/markdown/renderers/HtmlPreview.tsx
@@ -60,7 +60,16 @@ export function HtmlPreview({ source }: HtmlPreviewProps) {
 
     const onLoad = () => {
       if (!iframe.contentWindow) return;
-      iframeHandlers.set(iframe.contentWindow, scheduleHeight);
+      iframeHandlers.set(iframe.contentWindow, {
+        onHeight: scheduleHeight,
+        // Auto-flip to source if the previewed HTML throws (e.g. an LLM
+        // emitted a JS-only snippet referencing a missing canvas, leaving
+        // the iframe blank). Don't fight the user if they've manually
+        // toggled back to preview already.
+        onError: () => {
+          setShowingPreview((current) => (current ? false : current));
+        },
+      });
     };
 
     iframe.addEventListener('load', onLoad);

--- a/src/shared/ui/markdown/renderers/SsImage.tsx
+++ b/src/shared/ui/markdown/renderers/SsImage.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from 'react';
+
+type ImgProps = React.ImgHTMLAttributes<HTMLImageElement>;
+
+type DownloadHook = (id: string) => Promise<string>;
+
+function getDownloadHook(): DownloadHook | null {
+  if (typeof window === 'undefined') return null;
+  const w = window as unknown as { __ssDownloadFile?: DownloadHook };
+  return w.__ssDownloadFile ?? null;
+}
+
+function parseSsFile(src: string): {
+  fileId: string;
+  w?: string;
+  h?: string;
+  fit?: string;
+  align?: string;
+  caption?: string;
+} | null {
+  if (!src.startsWith('ss-file:')) return null;
+  const withoutScheme = src.substring('ss-file:'.length);
+  const [fileId, query = ''] = withoutScheme.split('?');
+  const params = new URLSearchParams(query);
+  return {
+    fileId,
+    w: params.get('w') ?? undefined,
+    h: params.get('h') ?? undefined,
+    fit: params.get('fit') ?? undefined,
+    align: params.get('align') ?? undefined,
+    caption: params.get('caption') ?? undefined,
+  };
+}
+
+/** react-markdown `img` component. Routes `ss-file:` URLs through the
+ *  same `window.__ssDownloadFile` hook the Milkdown node view uses, so both
+ *  paths resolve images via the app API. Non-`ss-file` srcs render as a
+ *  plain `<img>`. */
+export function SsImage(props: ImgProps) {
+  const { src, alt, title, width, height } = props;
+  const parsed = typeof src === 'string' ? parseSsFile(src) : null;
+
+  const [resolvedSrc, setResolvedSrc] = useState<string | null>(null);
+  const [errored, setErrored] = useState(false);
+  const fileId = parsed?.fileId;
+
+  useEffect(() => {
+    if (!fileId) return;
+    let cancelled = false;
+    const hook = getDownloadHook();
+    if (!hook) return;
+    hook(fileId)
+      .then((url) => {
+        if (!cancelled) setResolvedSrc(url);
+      })
+      .catch(() => {
+        if (!cancelled) setErrored(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [fileId]);
+
+  if (!parsed) {
+    return (
+      <img
+        src={src}
+        alt={alt ?? ''}
+        title={title}
+        width={width}
+        height={height}
+      />
+    );
+  }
+
+  const finalWidth = parsed.w ?? width;
+  const finalHeight = parsed.h ?? height;
+
+  return (
+    <span
+      className="ss-attach ss-attach--image"
+      style={{ position: 'relative', display: 'inline-block' }}
+      data-fit={parsed.fit}
+      data-align={parsed.align}
+      data-caption={parsed.caption}
+    >
+      {!resolvedSrc && !errored && <span className="ss-attach__spinner" />}
+      <img
+        className="ss-attach__img"
+        data-ss-image=""
+        data-file-id={parsed.fileId}
+        src={resolvedSrc ?? undefined}
+        alt={alt ?? ''}
+        title={title}
+        width={finalWidth as number | string | undefined}
+        height={finalHeight as number | string | undefined}
+        style={errored ? { background: 'rgba(255,0,0,0.06)' } : undefined}
+      />
+    </span>
+  );
+}

--- a/src/shared/ui/markdown/renderers/SsImage.tsx
+++ b/src/shared/ui/markdown/renderers/SsImage.tsx
@@ -89,12 +89,12 @@ export function SsImage(props: ImgProps) {
         className="ss-attach__img"
         data-ss-image=""
         data-file-id={parsed.fileId}
+        data-error={errored ? '' : undefined}
         src={resolvedSrc ?? undefined}
         alt={alt ?? ''}
         title={title}
         width={finalWidth as number | string | undefined}
         height={finalHeight as number | string | undefined}
-        style={errored ? { background: 'rgba(255,0,0,0.06)' } : undefined}
       />
     </span>
   );

--- a/src/shared/ui/markdown/sanitizeSchema.ts
+++ b/src/shared/ui/markdown/sanitizeSchema.ts
@@ -29,6 +29,14 @@ export const messageSanitizeSchema: Schema = {
       'dataAlign',
       'dataCaption',
     ],
+    // Permits the `<span class="file-tag" data-file-tag data-id>` markup
+    // emitted by `remarkFileTag` for inline `[[file:id|name]]` references.
+    span: [
+      ...((base.attributes?.span as AttrList) ?? []),
+      'className',
+      'dataFileTag',
+      'dataId',
+    ],
   },
   // Re-permit the custom `ss-file:` URI scheme so file attachments embedded
   // as `![](ss-file:id?...)` or `[name](ss-file:id)` survive sanitization.

--- a/src/shared/ui/markdown/sanitizeSchema.ts
+++ b/src/shared/ui/markdown/sanitizeSchema.ts
@@ -1,0 +1,41 @@
+import type { Schema } from 'hast-util-sanitize';
+import { defaultSchema } from 'rehype-sanitize';
+
+const base = defaultSchema;
+
+type AttrList = NonNullable<NonNullable<Schema['attributes']>[string]>;
+
+// Permissive schema for LLM-generated message content. Starts from
+// rehype-sanitize's default (already allows `details`, `summary`, and
+// `code className=language-*`) and re-permits a few attributes our chat
+// backend commonly emits: `<a target rel>`, image metadata, data-* markers
+// used by the ssImage renderer. `<script>`, `<iframe>`, `<object>`, and
+// event handlers remain stripped. Note: the HTML preview iframe is rendered
+// via the `code` component override, which bypasses the sanitize pass.
+export const messageSanitizeSchema: Schema = {
+  ...base,
+  attributes: {
+    ...(base.attributes ?? {}),
+    a: [...((base.attributes?.a as AttrList) ?? []), 'target', 'rel'],
+    img: [
+      ...((base.attributes?.img as AttrList) ?? []),
+      'alt',
+      'title',
+      'width',
+      'height',
+      'dataSsImage',
+      'dataFileId',
+      'dataFit',
+      'dataAlign',
+      'dataCaption',
+    ],
+  },
+  // Re-permit the custom `ss-file:` URI scheme so file attachments embedded
+  // as `![](ss-file:id?...)` or `[name](ss-file:id)` survive sanitization.
+  // Without this the default schema strips them (it only allows http/https).
+  protocols: {
+    ...(base.protocols ?? {}),
+    src: [...(base.protocols?.src ?? []), 'ss-file'],
+    href: [...(base.protocols?.href ?? []), 'ss-file'],
+  },
+};

--- a/src/shared/ui/markdown/styles.css
+++ b/src/shared/ui/markdown/styles.css
@@ -68,6 +68,12 @@
   cursor: pointer;
 }
 
+/* Read-only: error state for ss-file image attachments. The SsImage renderer
+   sets `data-error` when the file resolver hook rejects. */
+.ss-markdown .ss-attach__img[data-error] {
+  background: rgba(220, 38, 38, 0.08);
+}
+
 /* Custom inline file-tag */
 .file-tag {
   display: inline-block;

--- a/src/shared/ui/markdown/styles.css
+++ b/src/shared/ui/markdown/styles.css
@@ -111,8 +111,11 @@
   color: #0369a1;
 }
 
-/* Code block wrapper (via htmlPreview node view) */
-.md-editor .ss-code-block {
+/* Code block wrapper — shared by the Milkdown editor node view
+   (`.md-editor` scope) and the react-markdown read-only renderer
+   (`.ss-markdown` scope). Keep selectors in sync. */
+.md-editor .ss-code-block,
+.ss-markdown .ss-code-block {
   border: 1px solid var(--border, #e5e7eb);
   border-radius: 8px;
   background: #0b1020;
@@ -121,7 +124,8 @@
   overflow: hidden;
 }
 
-.md-editor .ss-code-block__header {
+.md-editor .ss-code-block__header,
+.ss-markdown .ss-code-block__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -132,21 +136,25 @@
   line-height: 1;
 }
 
-.md-editor .ss-code-block__lang {
+.md-editor .ss-code-block__lang,
+.ss-markdown .ss-code-block__lang {
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: #9ba3af;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 }
 
-.md-editor .ss-code-block__actions {
+.md-editor .ss-code-block__actions,
+.ss-markdown .ss-code-block__actions {
   display: flex;
   align-items: center;
   gap: 6px;
 }
 
 .md-editor .ss-code-block__toggle,
-.md-editor .ss-code-block__copy {
+.md-editor .ss-code-block__copy,
+.ss-markdown .ss-code-block__toggle,
+.ss-markdown .ss-code-block__copy {
   appearance: none;
   background: rgba(255, 255, 255, 0.1);
   color: #e6edf3;
@@ -160,11 +168,14 @@
 }
 
 .md-editor .ss-code-block__toggle:hover,
-.md-editor .ss-code-block__copy:hover {
+.md-editor .ss-code-block__copy:hover,
+.ss-markdown .ss-code-block__toggle:hover,
+.ss-markdown .ss-code-block__copy:hover {
   background: rgba(255, 255, 255, 0.18);
 }
 
-.md-editor .ss-code-block pre {
+.md-editor .ss-code-block pre,
+.ss-markdown .ss-code-block pre {
   margin: 0;
   padding: 12px 14px;
   background: transparent;
@@ -176,14 +187,16 @@
   white-space: pre;
 }
 
-.md-editor .ss-code-block pre code {
+.md-editor .ss-code-block pre code,
+.ss-markdown .ss-code-block pre code {
   background: transparent;
   color: inherit;
   padding: 0;
   font: inherit;
 }
 
-.md-editor .ss-code-block__iframe {
+.md-editor .ss-code-block__iframe,
+.ss-markdown .ss-code-block__iframe {
   display: block;
   width: 100%;
   /* Initial height before the height reporter postMessages in the real size
@@ -194,6 +207,34 @@
   /* Kill the baseline gap under replaced elements (iframe is inline by
      default), which otherwise adds ~4px of empty space below the preview. */
   vertical-align: top;
+}
+
+/* Inline code in read-only messages — matches the Milkdown editor's
+   inline code treatment. */
+.ss-markdown :not(pre) > code {
+  background: rgba(135, 131, 120, 0.15);
+  color: #c7254e;
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.9em;
+}
+
+/* Read-only: anchors should feel clickable. */
+.ss-markdown a {
+  color: #2563eb;
+  text-decoration: underline;
+}
+
+/* Read-only: give <details>/<summary> sensible defaults. Most browser UAs
+   already render the triangle, but we tidy spacing. */
+.ss-markdown details {
+  margin: 0.75em 0;
+}
+
+.ss-markdown summary {
+  cursor: pointer;
+  font-weight: 600;
 }
 
 /* Inline code */

--- a/src/ui/messages/MessageBubble.tsx
+++ b/src/ui/messages/MessageBubble.tsx
@@ -12,7 +12,7 @@ import { MessageValueType } from '@/domains/messages/enums';
 
 import { cells, renderers } from '@/ui/chat-variables/renders';
 
-import { MarkdownEditor } from '@/shared/ui/markdown/MarkdownEditor';
+import { MessageMarkdown } from '@/shared/ui/markdown/MessageMarkdown';
 import {
   Avatar,
   AvatarFallback,
@@ -127,7 +127,7 @@ export const MessageBubble: FC<MessageBubbleProps> = (props) => {
                 key={`content-${i}`}
                 className="prose prose-sm max-w-none dark:prose-invert text-sm leading-relaxed mb-3 last:mb-0"
               >
-                <MarkdownEditor value={item.text} editable={false} />
+                <MessageMarkdown value={item.text} />
               </div>
             ) : item.image ? (
               <div key={`image-${i}`} className="mb-3 last:mb-0">

--- a/src/ui/messages/MessageList.tsx
+++ b/src/ui/messages/MessageList.tsx
@@ -2,8 +2,6 @@ import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
 import { useMatch } from '@tanstack/react-router';
 import { AlertTriangle } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
 
 import { isInTeams } from '@/platform/auth/msalConfig';
 import { useRouteIds } from '@/platform/routing/RouteIdsProvider';
@@ -13,6 +11,7 @@ import { useThread } from '@/domains/threads/queries';
 import { useWorkspace } from '@/domains/workspaces/queries';
 
 import { useIsMobile } from '@/shared/hooks/useIsMobile';
+import { MessageMarkdown } from '@/shared/ui/markdown/MessageMarkdown';
 import { useSidebar } from '@/shared/ui/mui-compat/sidebar';
 import { Skeleton } from '@/shared/ui/mui-compat/skeleton';
 
@@ -189,10 +188,8 @@ export function MessageList() {
           {activeWorkspace?.name ?? 'No messages yet'}
         </h3>
         {activeWorkspace?.firstPrompt && (
-          <div className="max-w-3xl mx-auto p-4 whitespace-pre-wrap">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>
-              {activeWorkspace.firstPrompt}
-            </ReactMarkdown>
+          <div className="max-w-3xl mx-auto p-4">
+            <MessageMarkdown value={activeWorkspace.firstPrompt} />
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

- Splits the chat message render pipeline so Milkdown remains the WYSIWYG **authoring** surface and a new react-markdown + rehype-raw + rehype-sanitize pipeline handles **read-only** display. parse5 (via rehype-raw) re-balances mixed HTML/markdown into a proper HAST tree, fixing two long-standing bugs:
  - `<details>` wrapping a fenced ` ```sql ` block was rendering as raw text — the opener and closer were sibling `html` nodes in the ProseMirror doc, so a node view couldn't reparent the code block underneath the `<details>`. react-markdown + rehype-raw rebalances them into a proper parent/child tree.
  - Inline `<a href=… target=_blank>` tags inside list items were rendering as literal text instead of clickable links — same root cause.
- New `MessageMarkdown` component drops into [MessageBubble](src/ui/messages/MessageBubble.tsx) and the empty-thread `firstPrompt` in [MessageList](src/ui/messages/MessageList.tsx). Composer/editor path is untouched — Milkdown still owns authoring.
- Iframe height-reporter machinery from PR #202 is extracted into `htmlPreviewShared.ts`, then reused by both the existing Milkdown node view and a new React `HtmlPreview` component, so ` ```html ` fenced blocks still preview as a sandboxed iframe in read-only mode (1:1 visual parity with PR #202).
- `CodeBlock`, `SsImage` React renderers mirror the Milkdown views' DOM contract (class names, data-attrs) so existing CSS in [styles.css](src/shared/ui/markdown/styles.css) applies unchanged. The `ss-code-block` selectors are now scoped to both `.md-editor` and `.ss-markdown`.
- `messageSanitizeSchema` extends rehype-sanitize's defaults to re-permit `<a target rel>`, image `data-*` attrs, and the `ss-file:` protocol on `src`/`href`. A custom `urlTransform` override on `ReactMarkdown` does the same for its built-in URL safelist (otherwise unknown protocols are stripped before component renderers see them).
- Drive-by fix: `POST /files` was throwing a Zod parse error because the chat API returns `null` for `createdByUserId`/`modifiedByUserId` but the SDK schema marks them required. Coerce nulls to empty strings before validation; mapper doesn't read those fields. Kept as a separate commit for easy revert.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` — 161 passing including 5 new specs covering `<details>`+code, raw `<a>`, `\`\`\`html` iframe preview, plain code blocks, and `<script>` sanitization
- [x] Manual: pasted the failing assistant message (the SQL/charts payload) into a thread — `<details>` is now a real disclosure, the SQL renders as a syntax-classed code block inside, and the `### Tables` list shows clickable anchor links opening in a new tab
- [x] Manual: ` ```html ` chart block still previews as the sandboxed iframe with the bar chart (PR #202 behavior preserved)
- [x] Manual: `![](ss-file:abc?w=&h=)` inline images resolve via `__ssDownloadFile` and render in user messages
- [x] Manual: file upload via composer no longer Zod-throws; "Attachments" section in the bot reply renders the uploaded files
- [x] Manual: composer/editor (Milkdown) WYSIWYG behavior unchanged