### PR TITLE
refactor(models): move getModelIcon into models domain

### DIFF
--- a/src/domains/models/__tests__/mapper.spec.ts
+++ b/src/domains/models/__tests__/mapper.spec.ts
@@ -21,8 +21,40 @@ describe('models mapper', () => {
     } as any;
     const m = mapModelDtoToModel(dto);
     expect(m.id).toBe('m1');
+    expect(m.modelPublisher).toBeNull();
     expect(m.createdAt).toBeInstanceOf(Date);
     expect(m.createdAt.toISOString()).toBe('2024-06-01T12:00:00.000Z');
+  });
+
+  it('maps modelPublisher string values through', () => {
+    const dto = {
+      id: 'm1',
+      name: 'A',
+      displayName: 'A',
+      deploymentStatus: 'x',
+      modelDeploymentProviderType: 'AzureOpenAi',
+      modelPublisher: 'Meta',
+      createdByUserId: 'u',
+      createdAt: '2024-06-01T12:00:00Z',
+      properties: [],
+      virtualMachineUrl: null,
+    } as any;
+    expect(mapModelDtoToModel(dto).modelPublisher).toBe('Meta');
+  });
+
+  it('coerces missing modelPublisher field to null', () => {
+    const dto = {
+      id: 'm1',
+      name: 'A',
+      displayName: 'A',
+      deploymentStatus: 'x',
+      modelDeploymentProviderType: 'y',
+      createdByUserId: 'u',
+      createdAt: '2024-06-01T12:00:00Z',
+      properties: [],
+      virtualMachineUrl: null,
+    } as any;
+    expect(mapModelDtoToModel(dto).modelPublisher).toBeNull();
   });
 
   it('maps envelope', () => {

--- a/src/domains/models/__tests__/model-icon.spec.ts
+++ b/src/domains/models/__tests__/model-icon.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Model } from '@/domains/models/model';
+import { getModelIcon } from '@/domains/models/model-icon';
+
+const makeModel = (overrides: Partial<Model> = {}): Model => ({
+  id: 'id',
+  name: 'n',
+  displayName: 'n',
+  deploymentStatus: 's',
+  modelDeploymentProviderType: '',
+  modelPublisher: null,
+  createdByUserId: 'u',
+  createdAt: new Date(0),
+  properties: [],
+  virtualMachineUrl: null,
+  ...overrides,
+});
+
+describe('getModelIcon', () => {
+  it('returns null when model is null or undefined', () => {
+    expect(getModelIcon(null)).toBeNull();
+    expect(getModelIcon(undefined)).toBeNull();
+  });
+
+  it('returns an icon url when the publisher matches', () => {
+    const icon = getModelIcon(makeModel({ modelPublisher: 'OpenAI' }));
+    expect(icon).toBeTruthy();
+    expect(typeof icon).toBe('string');
+  });
+
+  it('is case-insensitive on publisher', () => {
+    const upper = getModelIcon(makeModel({ modelPublisher: 'META' }));
+    const lower = getModelIcon(makeModel({ modelPublisher: 'meta' }));
+    expect(upper).toBe(lower);
+    expect(upper).toBeTruthy();
+  });
+
+  it('falls back to the foundry icon when publisher is unknown', () => {
+    const fallback = getModelIcon(
+      makeModel({
+        modelPublisher: 'SomeNewPublisher',
+        modelDeploymentProviderType: 'AzureOpenAi',
+      })
+    );
+    const direct = getModelIcon(
+      makeModel({ modelDeploymentProviderType: 'AzureOpenAi' })
+    );
+    expect(fallback).toBe(direct);
+    expect(fallback).toBeTruthy();
+  });
+
+  it('falls back to the foundry icon when publisher is null', () => {
+    const icon = getModelIcon(
+      makeModel({
+        modelPublisher: null,
+        modelDeploymentProviderType: 'VertexAi',
+      })
+    );
+    expect(icon).toBeTruthy();
+  });
+
+  it('returns null when neither publisher nor foundry match', () => {
+    const icon = getModelIcon(
+      makeModel({
+        modelPublisher: 'unknown',
+        modelDeploymentProviderType: 'nothing',
+      })
+    );
+    expect(icon).toBeNull();
+  });
+
+  it('treats empty-string publisher as missing and falls back', () => {
+    const icon = getModelIcon(
+      makeModel({
+        modelPublisher: '',
+        modelDeploymentProviderType: 'OpenAi',
+      })
+    );
+    expect(icon).toBeTruthy();
+  });
+});

--- a/src/domains/models/index.ts
+++ b/src/domains/models/index.ts
@@ -1,5 +1,10 @@
+export { getModelIcon } from './model-icon';
 export type { Model } from './model';
-export { modelDetailOptions, modelsListOptions, useModel, useModels } from './queries';
+export {
+  modelDetailOptions,
+  modelsListOptions,
+  useModel,
+  useModels,
+} from './queries';
 export { modelsKeys } from './queryKeys';
 export * from './service';
-

--- a/src/domains/models/model-icon.ts
+++ b/src/domains/models/model-icon.ts
@@ -11,9 +11,10 @@ import mistralIcon from '@lobehub/icons-static-svg/icons/mistral-color.svg';
 import openaiIcon from '@lobehub/icons-static-svg/icons/openai.svg';
 import perplexityIcon from '@lobehub/icons-static-svg/icons/perplexity-color.svg';
 import qwenIcon from '@lobehub/icons-static-svg/icons/qwen-color.svg';
+import vertexaiIcon from '@lobehub/icons-static-svg/icons/vertexai-color.svg';
 import xaiIcon from '@lobehub/icons-static-svg/icons/xai.svg';
 
-import type { Model } from '@/domains/models/model';
+import type { Model } from './model';
 
 const PUBLISHER_ICONS: Record<string, string> = {
   openai: openaiIcon,
@@ -36,10 +37,13 @@ const FOUNDRY_ICONS: Record<string, string> = {
   anthropic: claudeIcon,
   azureopenai: azureAiIcon,
   azure: azureAiIcon,
+  azurefoundry: azureAiIcon,
   google: geminiIcon,
   gemini: geminiIcon,
   googlegemini: geminiIcon,
+  vertexai: vertexaiIcon,
   huggingface: huggingfaceIcon,
+  cohere: cohereIcon,
 };
 
 export function getModelIcon(model: Model | null | undefined): string | null {

--- a/src/domains/models/schemas.ts
+++ b/src/domains/models/schemas.ts
@@ -33,7 +33,6 @@ export const ModelPropertiesSchema = z
   })
   .catchall(z.any());
 
-export type Model = z.infer<typeof ModelSchema>;
 export const ModelListSchema = z.array(ModelSchema);
 export type ModelList = z.infer<typeof ModelListSchema>;
 /** Envelope the API returns for list endpoints */

--- a/src/ui/chat-variables/renders/model-id-renderer.tsx
+++ b/src/ui/chat-variables/renders/model-id-renderer.tsx
@@ -18,10 +18,7 @@ import React, {
   useState,
 } from 'react';
 
-import { getModelIcon } from './modelIcon';
-import { useModels } from '../../../domains/models/queries';
-import type { Model } from '../../../domains/models/schemas';
-
+import { getModelIcon, type Model, useModels } from '@/domains/models';
 
 type AccessUiSchema = { access?: 'Read' | 'Write' };
 
@@ -171,9 +168,7 @@ const ModelIdRenderer: React.FC<ControlProps> = ({
           className="inline-flex items-center gap-2 rounded-full px-3 py-1.5 bg-accent text-foreground/90 hover:bg-accent/80 transition-colors"
           style={{ width: 'fit-content', maxWidth: '100%' }}
         >
-          {iconSrc && (
-            <img src={iconSrc} alt="Provider" className="h-4 w-4" />
-          )}
+          {iconSrc && <img src={iconSrc} alt="Provider" className="h-4 w-4" />}
           <span className="text-sm truncate">
             {selectedModel
               ? selectedModel.displayName || selectedModel.name
@@ -401,38 +396,24 @@ const ModelIdRenderer: React.FC<ControlProps> = ({
             className="!px-4 !py-3 hover:!bg-gray-50 cursor-pointer transition-colors duration-150 border-b border-gray-50 last:border-b-0"
           >
             <div className="flex items-center space-x-3">
-              <div
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  width: '24px',
-                  height: '24px',
-                  flexShrink: 0,
-                }}
-              >
+              <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center">
                 {iconSrc ? (
                   <img
                     src={iconSrc}
                     alt="Provider logo"
-                    style={{
-                      width: 20,
-                      height: 20,
-                      objectFit: 'contain',
-                    }}
+                    className="h-5 w-5 object-contain"
                   />
                 ) : (
                   <span
                     role="img"
                     aria-label="Provider"
-                    style={{ color: '#6B7280', fontSize: '12px' }}
+                    className="text-muted-foreground text-xs"
                   >
                     ⚡
                   </span>
                 )}
               </div>
 
-              {/* Model Info */}
               <div className="flex flex-col space-y-1 flex-1">
                 <div className="flex items-center justify-between">
                   <span className="font-medium text-gray-900 text-sm leading-tight">


### PR DESCRIPTION
## Summary
- Move `getModelIcon` from `src/ui/chat-variables/renders/modelIcon.ts` into `src/domains/models/model-icon.ts` so icon mapping lives in the domain it describes
- Export `getModelIcon` from the `@/domains/models` barrel; update `ModelIdRenderer` to import via the barrel
- Replace inline `style={{}}` props in `ModelIdRenderer` with Tailwind classes; swap hardcoded `#6B7280` for `text-muted-foreground`
- Drop duplicate `Model` type export from `schemas.ts` (single source in `model.ts`)
- Add unit tests for `getModelIcon` and extend `mapper.spec.ts`

Follow-up cleanup to #198 — recovered from an uncommitted worktree.

## Test plan
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm test -- model-icon`
- [ ] Visual check: model picker icons still render for OpenAI / Anthropic / Azure deployments