### PR TITLE
fix(messages): keep optimistic send visible during SignalR thread updates

### DIFF
--- a/src/domains/messages/__tests__/mutations.spec.tsx
+++ b/src/domains/messages/__tests__/mutations.spec.tsx
@@ -14,18 +14,18 @@ import {
 } from '@/domains/messages/mutations';
 import { messagesKeys } from '@/domains/messages/queryKeys';
 import * as service from '@/domains/messages/service';
+import { threadsKeys } from '@/domains/threads/queryKeys';
 
 describe('messages mutations', () => {
-  it('useSendMessage writes optimistic and subscribes to subject', async () => {
+  it('useSendMessage writes optimistic and keeps it after postMessage resolves', async () => {
     const client = new QueryClient();
     const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
       <QueryClientProvider client={client}>{children}</QueryClientProvider>
     );
 
-    const subject = {
-      subscribe: vi.fn(() => ({ unsubscribe: vi.fn() })),
-    } as any;
-    const spy = vi.spyOn(service, 'postMessage').mockReturnValueOnce(subject);
+    const spy = vi
+      .spyOn(service, 'postMessage')
+      .mockResolvedValueOnce(undefined);
 
     const { result } = renderHook(() => useSendMessage(), { wrapper });
     await result.current.mutateAsync({
@@ -35,9 +35,43 @@ describe('messages mutations', () => {
       files: [],
       variables: {},
     });
+
     const data = client.getQueryData<any[]>(messagesKeys.list('t')) || [];
     expect(data.some((m) => m.optimistic)).toBe(true);
-    expect(subject.subscribe).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledOnce();
+    spy.mockRestore();
+  });
+
+  it('useSendMessage rolls back optimistic on postMessage error', async () => {
+    const client = new QueryClient();
+    const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+
+    client.setQueryData(threadsKeys.detail('w', 't'), {
+      id: 't',
+      isFlowRunning: false,
+    } as any);
+
+    const spy = vi
+      .spyOn(service, 'postMessage')
+      .mockRejectedValueOnce(new Error('boom'));
+
+    const { result } = renderHook(() => useSendMessage(), { wrapper });
+    await expect(
+      result.current.mutateAsync({
+        workspaceId: 'w',
+        threadId: 't',
+        contentList: [],
+        files: [],
+        variables: {},
+      })
+    ).rejects.toThrow('boom');
+
+    const data = client.getQueryData<any[]>(messagesKeys.list('t')) || [];
+    expect(data.some((m) => m.optimistic)).toBe(false);
+    const detail = client.getQueryData<any>(threadsKeys.detail('w', 't'));
+    expect(detail?.isFlowRunning).toBe(false);
     spy.mockRestore();
   });
 

--- a/src/domains/messages/__tests__/service.spec.ts
+++ b/src/domains/messages/__tests__/service.spec.ts
@@ -65,59 +65,35 @@ describe('messages service', () => {
     expect(res[0].id).toBe('m1');
   });
 
-  it('postMessage sets up SSE handling (smoke)', async () => {
-    // capture onDownloadProgress to trigger after subscription
-    let capturedCb: ((e: ProgressEventLike) => void) | undefined;
-    const postSpy = vi.spyOn(api, 'post').mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      async (_url: string, _payload: any, cfg?: any) => {
-        capturedCb = cfg?.onDownloadProgress as
-          | ((e: ProgressEventLike) => void)
-          | undefined;
-        return undefined as unknown as never;
-      }
-    );
+  it('postMessage posts to /messages and resolves when the request completes', async () => {
+    const postSpy = vi
+      .spyOn(api, 'post')
+      .mockResolvedValueOnce(undefined as never);
 
-    const obs = postMessage({ workSpaceId: 'w', threadId: 't1' });
+    await expect(
+      postMessage({
+        workSpaceId: 'w',
+        threadId: 't1',
+        contentList: [{ type: 'text', text: 'hi' } as never],
+      })
+    ).resolves.toBeUndefined();
 
-    // now simulate streaming frames after subscription
-    const chunk = JSON.stringify({
-      id: 'm2',
-      createdAt: '2024-01-01',
-      createdBy: 'u1',
-      hasComments: false,
-      createdByUserId: 'u1',
-      messageThreadId: 't1',
-      values: [],
-    });
-    capturedCb?.({
-      event: { currentTarget: { response: `data:${chunk}\n\n` } },
-    });
-    capturedCb?.({
-      event: {
-        currentTarget: { response: `data:${chunk}\n\ndata:${chunk}\n\n` },
-      },
-    });
-
-    expect(typeof obs.subscribe).toBe('function');
+    expect(postSpy).toHaveBeenCalledOnce();
+    const [url, payload] = postSpy.mock.calls[0];
+    expect(url).toBe('/messages');
+    expect((payload as { messageThreadId: string }).messageThreadId).toBe('t1');
     postSpy.mockRestore();
   });
 
-  it('postMessage observable emits error when stream fails', () => {
+  it('postMessage rejects when the underlying request fails', async () => {
     const networkError = new Error('Network failure');
     const postSpy = vi.spyOn(api, 'post').mockRejectedValueOnce(networkError);
 
-    const obs = postMessage({ workSpaceId: 'w', threadId: 't1' });
+    await expect(
+      postMessage({ workSpaceId: 'w', threadId: 't1' })
+    ).rejects.toBe(networkError);
 
-    return new Promise<void>((resolve) => {
-      obs.subscribe({
-        error: (err) => {
-          expect(err).toBe(networkError);
-          postSpy.mockRestore();
-          resolve();
-        },
-      });
-    });
+    postSpy.mockRestore();
   });
 
   it('addInputToMessage throws when no valid message received', async () => {

--- a/src/domains/messages/mutations.ts
+++ b/src/domains/messages/mutations.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Subject } from 'rxjs';
 import { toast } from 'sonner';
 
 import { useUserDisplayName, useUserId } from '@/platform/auth/session';
@@ -11,12 +10,6 @@ import { MessageValueType } from './enums';
 import { Message, MessageContentItem } from './model';
 import { messagesKeys } from './queryKeys';
 import { addInputToMessage, postMessage } from './service';
-
-function isPromptMessage(m: Message): boolean {
-  return !!m.values?.some(
-    (v) => v.type === MessageValueType.INPUT && v.name === 'prompt'
-  );
-}
 
 type SendArgs = {
   workspaceId: string;
@@ -31,7 +24,7 @@ export function useSendMessage() {
   const userId = useUserId();
   const userName = useUserDisplayName();
 
-  return useMutation<Subject<Message>, Error, SendArgs>({
+  return useMutation<void, Error, SendArgs>({
     mutationFn: async ({
       workspaceId,
       threadId,
@@ -104,74 +97,49 @@ export function useSendMessage() {
           old && typeof old === 'object' ? { ...old, isFlowRunning: true } : old
       );
 
-      // cancel in-flight refetches for this list
+      // cancel in-flight refetches for this list so they don't race the optimistic insert
       await qc.cancelQueries({ queryKey: messagesKeys.list(threadId) });
 
-      // start server call (returns Subject synchronously so we subscribe before data arrives)
-      const subject = postMessage({
-        workSpaceId: workspaceId,
-        threadId,
-        contentList,
-        files,
-        variables,
-      });
+      try {
+        await postMessage({
+          workSpaceId: workspaceId,
+          threadId,
+          contentList,
+          files,
+          variables,
+        });
+      } catch (err) {
+        // rollback: remove optimistics and clear optimistic isFlowRunning
+        qc.setQueryData<Message[]>(messagesKeys.list(threadId), (old = []) =>
+          old.filter((x) => !x.optimistic)
+        );
+        qc.setQueryData(
+          threadsKeys.detail(workspaceId, threadId),
+          (old: unknown) =>
+            old && typeof old === 'object'
+              ? { ...old, isFlowRunning: false }
+              : old
+        );
+        toast.error('There was an error posting your message');
+        throw err;
+      }
 
-      // subscribe to server stream: replace optimistic with real items / updates
-      const sub = subject.subscribe({
-        next: (m: Message) => {
-          qc.setQueryData<Message[]>(
-            messagesKeys.list(threadId),
-            (old = []) => {
-              // Only drop optimistic messages if the server actually sent back a prompt message.
-              // Many backends stream assistant output first; dropping optimistics there would hide the user's message.
-              const stable = isPromptMessage(m)
-                ? old.filter((x) => !x.optimistic)
-                : old;
-              // upsert by id
-              const idx = stable.findIndex((x) => x.id === m.id);
-              if (idx === -1) return [...stable, m];
-              const copy = stable.slice();
-              copy[idx] = m;
-              return copy;
-            }
+      // Reconcile thread list ordering / last-message preview and thread detail
+      // (isFlowRunning). The messages list itself is driven by SignalR
+      // ReceiveThreadUpdate -> mergeFetchedWithOptimistics, so don't invalidate it here.
+      qc.invalidateQueries({
+        predicate: (query) => {
+          const k = query.queryKey as unknown[];
+          return (
+            k[0] === 'threads' &&
+            k[1] === 'list' &&
+            (k[2] as { workspaceId?: string })?.workspaceId === workspaceId
           );
-        },
-        error: (_err: Error) => {
-          // rollback: remove any optimistics
-          qc.setQueryData<Message[]>(messagesKeys.list(threadId), (old = []) =>
-            old.filter((x) => !x.optimistic)
-          );
-          // rollback optimistic isFlowRunning
-          qc.setQueryData(
-            threadsKeys.detail(workspaceId, threadId),
-            (old: unknown) =>
-              old && typeof old === 'object'
-                ? { ...old, isFlowRunning: false }
-                : old
-          );
-          toast.error('There was an error posting your message');
-          sub.unsubscribe();
-        },
-        complete: () => {
-          sub.unsubscribe();
-          qc.invalidateQueries({
-            predicate: (query) => {
-              const k = query.queryKey as unknown[];
-              return (
-                k[0] === 'threads' &&
-                k[1] === 'list' &&
-                (k[2] as { workspaceId?: string })?.workspaceId === workspaceId
-              );
-            },
-          });
-          // Refetch thread detail so isFlowRunning reflects server state
-          qc.invalidateQueries({
-            queryKey: threadsKeys.detail(workspaceId, threadId),
-          });
         },
       });
-
-      return subject;
+      qc.invalidateQueries({
+        queryKey: threadsKeys.detail(workspaceId, threadId),
+      });
     },
     retry: false,
   });

--- a/src/domains/messages/service.ts
+++ b/src/domains/messages/service.ts
@@ -1,8 +1,6 @@
 import { ChatApi, ChatZod } from '@smartspace/api-client';
-import { Subject } from 'rxjs';
 
 import { api } from '@/platform/api';
-import { ssDebug, ssWarn, ssError } from '@/platform/log';
 import { parseOrThrow } from '@/platform/validation';
 
 import { FileInfo } from '@/domains/files';
@@ -93,8 +91,9 @@ export async function addInputToMessage({
 }
 
 // Post a new user message to a thread (supports content + files + variables).
-// Returns a Subject synchronously so the caller can subscribe *before* data arrives.
-export function postMessage({
+// Resolves when the server has finished processing the request. Cache updates
+// are driven by SignalR ReceiveThreadUpdate, not by the SSE stream payload.
+export async function postMessage({
   workSpaceId,
   threadId,
   contentList,
@@ -106,7 +105,7 @@ export function postMessage({
   contentList?: MessageContentItem[];
   files?: FileInfo[];
   variables?: Record<string, unknown>;
-}): Subject<Message> {
+}): Promise<void> {
   const inputs: Array<{ name: string; value: unknown }> = [];
 
   if (contentList?.length) {
@@ -134,49 +133,8 @@ export function postMessage({
     variables,
   };
 
-  const observable = new Subject<Message>();
-
-  api
-    .post(`/messages`, payload, {
-      adapter: 'xhr',
-      headers: { Accept: 'text/event-stream' },
-      onDownloadProgress: (e) => {
-        const xhr = e.event?.currentTarget as XMLHttpRequest | undefined;
-        const raw = String(xhr?.response ?? '');
-        ssDebug('sse', 'onDownloadProgress fired', {
-          rawLength: raw.length,
-          xhrExists: !!xhr,
-        });
-        const chunks = raw
-          .split('\n\n')
-          .map((c) => c.trim())
-          .filter(Boolean);
-        if (!chunks.length) return;
-        const last = chunks[chunks.length - 1];
-        const dataLine = last.startsWith('data:') ? last.slice(5).trim() : last;
-        if (!dataLine) return;
-        try {
-          const parsed = JSON.parse(dataLine);
-          coerceMessageDto(parsed);
-          const dto = messagesResponseSchema.shape.data.element.parse(parsed);
-          const parsedMessage = mapMessageDtoToModel(dto);
-          ssDebug('sse', `emitting message: ${parsedMessage.id}`, {
-            values: parsedMessage.values?.map((v) => v.name),
-          });
-          observable.next(parsedMessage);
-        } catch (err) {
-          ssWarn('sse', 'parse failed', err);
-        }
-      },
-    })
-    .then(() => {
-      ssDebug('sse', 'stream complete');
-      observable.complete();
-    })
-    .catch((error) => {
-      ssError('sse', 'stream error', error);
-      observable.error(error);
-    });
-
-  return observable;
+  await api.post(`/messages`, payload, {
+    adapter: 'xhr',
+    headers: { Accept: 'text/event-stream' },
+  });
 }


### PR DESCRIPTION
## Summary
- When a thread already had messages and the user sent a new one, the optimistic message would vanish mid-flight and only reappear on a later refetch. Root cause: `useSendMessage` subscribed to the `postMessage` SSE stream and upserted frames into the messages cache, which stripped the `optimistic` flag — a racing SignalR `ReceiveThreadUpdate` then invalidated the list before the server had persisted the send, and `mergeFetchedWithOptimistics` had nothing flagged to preserve.
- `postMessage` now returns `Promise<void>`; `useSendMessage` awaits it without touching the messages cache mid-flight. The optimistic insert stays flagged until a SignalR-driven refetch returns its server counterpart, at which point `mergeFetchedWithOptimistics` drops it by prompt signature. Error path still rolls back optimistics and clears `isFlowRunning`.
- Tests: `mutations.spec.tsx` swapped the subject-subscription assertion for a Promise-resolution test and added an error-rollback test; `service.spec.ts` replaced the SSE smoke tests with Promise-based assertions against `/messages`.

## Test plan
- [ ] `npm run lint:all` · `npm run typecheck` · `npm test` all pass (already green locally: 171/171).
- [ ] In a thread with existing messages, send a new message and confirm it appears immediately and **stays visible** continuously while the assistant reply streams in (watch the `[SignalR] ReceiveThreadUpdate` console log fire — the user message must not blink out).
- [ ] Confirm the assistant reply renders and the running indicator clears when the stream completes.
- [ ] Send a second message in the same thread — no duplicates, no stale state.
- [ ] Send into a brand-new (previously empty) thread — optimistic survives until the first SignalR refetch returns it.
- [ ] Force an error on `POST /messages` (block in DevTools) — optimistic rolls back and the error toast shows.
- [ ] Cross-tab: open the same thread in two tabs, send from tab A; tab B receives the message via SignalR.