### PR TITLE
fix(composer): prevent message text loss when typing fast then hitting Enter

### DIFF
--- a/src/shared/ui/markdown/MarkdownEditor.tsx
+++ b/src/shared/ui/markdown/MarkdownEditor.tsx
@@ -4,6 +4,7 @@ import {
   editorViewCtx,
   editorViewOptionsCtx,
   rootCtx,
+  serializerCtx,
 } from '@milkdown/core';
 import { history } from '@milkdown/kit/plugin/history';
 import { clipboard } from '@milkdown/plugin-clipboard';
@@ -56,6 +57,13 @@ export type MarkdownEditorHandle = {
   focus: () => void;
   /** Clears the editor content (useful when host clears `value`, since Milkdown isn't fully controlled here). */
   clear: () => void;
+  /**
+   * Serializes the current editor doc to markdown synchronously.
+   * Needed because the `markdownUpdated` listener is debounced by 200ms inside
+   * `@milkdown/plugin-listener`, so React state can lag behind what's in the editor.
+   * Callers that need the freshest text (e.g. sending on Enter) should read from here.
+   */
+  getMarkdown: () => string;
   /**
    * Returns mention users currently present in the editor document.
    * Useful for building API payloads (e.g. comments.mentionedUsers).
@@ -171,6 +179,7 @@ function EditorInner({
   const previewUrlsRef = useRef<string[]>([]);
   const [_isDragging, setIsDragging] = useState(false);
   const viewRef = useRef<EditorView | null>(null);
+  const serializerRef = useRef<((doc: PMNode) => string) | null>(null);
 
   function guessImageExt(mime: string) {
     const t = (mime || '').toLowerCase();
@@ -326,6 +335,13 @@ function EditorInner({
               const anyCtx = c as { get: (t: unknown) => unknown };
               const view = anyCtx.get(editorViewCtx) as EditorView;
               viewRef.current = view;
+              try {
+                serializerRef.current = anyCtx.get(serializerCtx) as (
+                  doc: PMNode
+                ) => string;
+              } catch {
+                /* serializer not ready yet */
+              }
               const handle = () => {
                 try {
                   if (enableMentions) updateMentionFromView();
@@ -602,6 +618,16 @@ function EditorInner({
           chars[i] = /\w/.test(next) ? ' ' : '';
         }
         return chars.join('').trimEnd();
+      },
+      getMarkdown: () => {
+        const view = viewRef.current;
+        const serializer = serializerRef.current;
+        if (!view || !serializer) return (value ?? '') as string;
+        try {
+          return serializer(view.state.doc);
+        } catch {
+          return (value ?? '') as string;
+        }
       },
       clear: () => {
         const view = viewRef.current;

--- a/src/ui/messages/MessageComposer.tsx
+++ b/src/ui/messages/MessageComposer.tsx
@@ -294,21 +294,24 @@ export default function MessageComposer() {
   }, [editorKey]);
 
   const handleSendMessageAndClear = () => {
-    if (sendDisabled) return;
-    handleSendMessage(uploadedAttachments);
+    // Read the freshest markdown straight from the editor. The `markdownUpdated`
+    // listener is debounced by 200ms in `@milkdown/plugin-listener`, so when a
+    // user types fast and hits Enter the React `newMessage` state can be stale —
+    // previously that caused the send to use/require old text and the subsequent
+    // editor remount to wipe characters the user had just typed.
+    const latestText = editorRef.current?.getMarkdown() ?? newMessage;
+    const sent = handleSendMessage(latestText, uploadedAttachments);
+    if (!sent) return;
     handleClearAttachments();
     setEditorKey((k) => k + 1);
   };
 
   const handleComposerKeyDown = (e: React.KeyboardEvent) => {
-    // Send on Enter (no Shift) and then clear both attachments + editor UI state.
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      if (sendDisabled) return;
       handleSendMessageAndClear();
       return;
     }
-    // Preserve any other key handling from the VM (currently a no-op outside Enter).
     handleKeyDown(e, uploadedAttachments);
   };
 

--- a/src/ui/messages/MessageComposer.vm.ts
+++ b/src/ui/messages/MessageComposer.vm.ts
@@ -55,10 +55,14 @@ export function useMessageComposerVm(props: MessageComposerVmProps = {}) {
     props.hasAttachments,
   ]);
 
-  const internalSend = (files?: { id: string; name: string }[]) => {
+  const internalSend = (
+    text: string,
+    files?: { id: string; name: string }[]
+  ) => {
     if (!workspaceId || !threadId) return;
-    const contentList = newMessage.trim()
-      ? [{ text: newMessage.trim(), image: undefined }]
+    const trimmed = text.trim();
+    const contentList = trimmed
+      ? [{ text: trimmed, image: undefined }]
       : undefined;
     const vars =
       variables && Object.keys(variables).length > 0 ? variables : undefined;
@@ -71,23 +75,41 @@ export function useMessageComposerVm(props: MessageComposerVmProps = {}) {
     });
     setNewMessage('');
   };
-  /** Unified "Send" */
-  const sendNow = (files?: { id: string; name: string }[]) => {
-    if (sendDisabled) return;
-    internalSend(files);
+
+  /**
+   * Can we send given the provided text/files right now?
+   * Kept separate from `sendDisabled` (which drives the UI button) so callers
+   * can bypass the React-state-based check when they have a fresher text value —
+   * e.g. when reading directly from the editor at Enter time, since the Milkdown
+   * `markdownUpdated` listener is debounced by 200ms and React state can lag.
+   */
+  const canSend = (text: string, files?: { id: string; name: string }[]) => {
+    const hasFiles = (files?.length ?? 0) > 0 || !!props.hasAttachments;
+    const nothingToSend = !text.trim() && !hasFiles;
+    const flowBlocked = !!thread?.isFlowRunning || sendMessage.isPending;
+    return !(isUploadingFiles || flowBlocked || nothingToSend);
   };
 
-  const handleSendMessage = (files?: { id: string; name: string }[]) =>
-    sendNow(files);
+  /**
+   * Returns true when the message was dispatched, false when blocked.
+   * Callers use the return value to decide whether to clear local UI state.
+   */
+  const handleSendMessage = (
+    text: string,
+    files?: { id: string; name: string }[]
+  ): boolean => {
+    if (!canSend(text, files)) return false;
+    internalSend(text, files);
+    return true;
+  };
 
   const handleKeyDown = (
-    e: React.KeyboardEvent,
-    files?: { id: string; name: string }[]
+    _e: React.KeyboardEvent,
+    _files?: { id: string; name: string }[]
   ) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      if (!sendDisabled) sendNow(files);
-    }
+    // Enter handling lives in the composer so it can read the editor's current
+    // markdown directly — Milkdown's `markdownUpdated` listener is debounced
+    // 200ms, so relying on React state here dropped characters on fast typing.
   };
 
   return {


### PR DESCRIPTION
## Summary

- Milkdown's `markdownUpdated` listener is debounced by 200ms in `@milkdown/plugin-listener` (see `node_modules/@milkdown/plugin-listener/lib/index.js:76-91`). During a fast typing burst, each keystroke resets the debounce, so `setNewMessage(md)` never fires before Enter. Sending read stale React state (old or empty text), and the editor remount (`setEditorKey((k) => k + 1)`) then wiped the freshly-typed characters from the UI.
- Fixed by reading markdown directly from the ProseMirror doc at send time: a new synchronous `getMarkdown()` on `MarkdownEditorHandle` serializes `view.state.doc` via `serializerCtx`. The VM's `handleSendMessage` now takes `text` as a parameter and returns a success flag so the composer only clears on a real send.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (47 files / 171 tests)
- [ ] Manual: type a burst of characters within ~200ms and hit Enter — full message sends and editor clears (no trailing chars missing)
- [ ] Manual: single-char message + Enter still sends correctly
- [ ] Manual: Enter with empty editor is still a no-op (no phantom empty send)
- [ ] Manual: Shift+Enter still inserts newline
- [ ] Manual: Send button click (mobile + desktop) still works
- [ ] Manual: attachment-only send (no text) still works