### PR TITLE
fix(routing): use pathless _layout so workspace layout wraps children

### DIFF
--- a/src/platform/routing/RouteIdsProvider.tsx
+++ b/src/platform/routing/RouteIdsProvider.tsx
@@ -16,15 +16,15 @@ export function RouteIdsProvider({ children }: { children: React.ReactNode }) {
   // NOTE: the file-router generator creates multiple route ids around $workspaceId.
   // Use `useMatch` on the routes that are actually active to avoid `never` params.
   const threadMatch = useMatch({
-    from: '/_protected/workspace/$workspaceId/thread/$threadId',
+    from: '/_protected/workspace/$workspaceId/_layout/thread/$threadId',
     shouldThrow: false,
   });
   const workspaceIndexMatch = useMatch({
-    from: '/_protected/workspace/$workspaceId/',
+    from: '/_protected/workspace/$workspaceId/_layout/',
     shouldThrow: false,
   });
   const workspaceLayoutMatch = useMatch({
-    from: '/_protected/workspace/$workspaceId/__layout',
+    from: '/_protected/workspace/$workspaceId/_layout',
     shouldThrow: false,
   });
 
@@ -51,15 +51,15 @@ export function useRouteIds(): RouteIds {
   const ctx = useContext(RouteIdsContext);
   // Fallback: derive ids from router if provider isn't mounted
   const threadMatch = useMatch({
-    from: '/_protected/workspace/$workspaceId/thread/$threadId',
+    from: '/_protected/workspace/$workspaceId/_layout/thread/$threadId',
     shouldThrow: false,
   });
   const workspaceIndexMatch = useMatch({
-    from: '/_protected/workspace/$workspaceId/',
+    from: '/_protected/workspace/$workspaceId/_layout/',
     shouldThrow: false,
   });
   const workspaceLayoutMatch = useMatch({
-    from: '/_protected/workspace/$workspaceId/__layout',
+    from: '/_protected/workspace/$workspaceId/_layout',
     shouldThrow: false,
   });
 

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -8,8 +8,6 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { createFileRoute } from '@tanstack/react-router'
-
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as _rootNotFoundRouteImport } from './routes/__root.notFound'
 import { Route as LoginRouteImport } from './routes/login'
@@ -17,13 +15,9 @@ import { Route as ProtectedRouteImport } from './routes/_protected'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ProtectedWorkspaceIndexRouteImport } from './routes/_protected/workspace/index'
 import { Route as ProtectedWorkspaceNoWorkspacesRouteImport } from './routes/_protected/workspace/no-workspaces'
-import { Route as ProtectedWorkspaceWorkspaceIdIndexRouteImport } from './routes/_protected/workspace/$workspaceId/index'
-import { Route as ProtectedWorkspaceWorkspaceId_layoutRouteImport } from './routes/_protected/workspace/$workspaceId/__layout'
-import { Route as ProtectedWorkspaceWorkspaceIdThreadThreadIdRouteImport } from './routes/_protected/workspace/$workspaceId/thread/$threadId'
-
-const ProtectedWorkspaceWorkspaceIdRouteImport = createFileRoute(
-  '/_protected/workspace/$workspaceId',
-)()
+import { Route as ProtectedWorkspaceWorkspaceIdLayoutRouteImport } from './routes/_protected/workspace/$workspaceId/_layout'
+import { Route as ProtectedWorkspaceWorkspaceIdLayoutIndexRouteImport } from './routes/_protected/workspace/$workspaceId/_layout/index'
+import { Route as ProtectedWorkspaceWorkspaceIdLayoutThreadThreadIdRouteImport } from './routes/_protected/workspace/$workspaceId/_layout/thread/$threadId'
 
 const _rootNotFoundRoute = _rootNotFoundRouteImport.update({
   id: '/__root/notFound',
@@ -44,12 +38,6 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ProtectedWorkspaceWorkspaceIdRoute =
-  ProtectedWorkspaceWorkspaceIdRouteImport.update({
-    id: '/workspace/$workspaceId',
-    path: '/workspace/$workspaceId',
-    getParentRoute: () => ProtectedRoute,
-  } as any)
 const ProtectedWorkspaceIndexRoute = ProtectedWorkspaceIndexRouteImport.update({
   id: '/workspace/',
   path: '/workspace/',
@@ -61,22 +49,23 @@ const ProtectedWorkspaceNoWorkspacesRoute =
     path: '/workspace/no-workspaces',
     getParentRoute: () => ProtectedRoute,
   } as any)
-const ProtectedWorkspaceWorkspaceIdIndexRoute =
-  ProtectedWorkspaceWorkspaceIdIndexRouteImport.update({
+const ProtectedWorkspaceWorkspaceIdLayoutRoute =
+  ProtectedWorkspaceWorkspaceIdLayoutRouteImport.update({
+    id: '/workspace/$workspaceId/_layout',
+    path: '/workspace/$workspaceId',
+    getParentRoute: () => ProtectedRoute,
+  } as any)
+const ProtectedWorkspaceWorkspaceIdLayoutIndexRoute =
+  ProtectedWorkspaceWorkspaceIdLayoutIndexRouteImport.update({
     id: '/',
     path: '/',
-    getParentRoute: () => ProtectedWorkspaceWorkspaceIdRoute,
+    getParentRoute: () => ProtectedWorkspaceWorkspaceIdLayoutRoute,
   } as any)
-const ProtectedWorkspaceWorkspaceId_layoutRoute =
-  ProtectedWorkspaceWorkspaceId_layoutRouteImport.update({
-    id: '/__layout',
-    getParentRoute: () => ProtectedWorkspaceWorkspaceIdRoute,
-  } as any)
-const ProtectedWorkspaceWorkspaceIdThreadThreadIdRoute =
-  ProtectedWorkspaceWorkspaceIdThreadThreadIdRouteImport.update({
+const ProtectedWorkspaceWorkspaceIdLayoutThreadThreadIdRoute =
+  ProtectedWorkspaceWorkspaceIdLayoutThreadThreadIdRouteImport.update({
     id: '/thread/$threadId',
     path: '/thread/$threadId',
-    getParentRoute: () => ProtectedWorkspaceWorkspaceIdRoute,
+    getParentRoute: () => ProtectedWorkspaceWorkspaceIdLayoutRoute,
   } as any)
 
 export interface FileRoutesByFullPath {
@@ -84,10 +73,10 @@ export interface FileRoutesByFullPath {
   '/login': typeof LoginRoute
   '/notFound': typeof _rootNotFoundRoute
   '/workspace/no-workspaces': typeof ProtectedWorkspaceNoWorkspacesRoute
-  '/workspace': typeof ProtectedWorkspaceIndexRoute
-  '/workspace/$workspaceId': typeof ProtectedWorkspaceWorkspaceId_layoutRoute
-  '/workspace/$workspaceId/': typeof ProtectedWorkspaceWorkspaceIdIndexRoute
-  '/workspace/$workspaceId/thread/$threadId': typeof ProtectedWorkspaceWorkspaceIdThreadThreadIdRoute
+  '/workspace/': typeof ProtectedWorkspaceIndexRoute
+  '/workspace/$workspaceId': typeof ProtectedWorkspaceWorkspaceIdLayoutRouteWithChildren
+  '/workspace/$workspaceId/': typeof ProtectedWorkspaceWorkspaceIdLayoutIndexRoute
+  '/workspace/$workspaceId/thread/$threadId': typeof ProtectedWorkspaceWorkspaceIdLayoutThreadThreadIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -95,8 +84,8 @@ export interface FileRoutesByTo {
   '/notFound': typeof _rootNotFoundRoute
   '/workspace/no-workspaces': typeof ProtectedWorkspaceNoWorkspacesRoute
   '/workspace': typeof ProtectedWorkspaceIndexRoute
-  '/workspace/$workspaceId': typeof ProtectedWorkspaceWorkspaceIdIndexRoute
-  '/workspace/$workspaceId/thread/$threadId': typeof ProtectedWorkspaceWorkspaceIdThreadThreadIdRoute
+  '/workspace/$workspaceId': typeof ProtectedWorkspaceWorkspaceIdLayoutIndexRoute
+  '/workspace/$workspaceId/thread/$threadId': typeof ProtectedWorkspaceWorkspaceIdLayoutThreadThreadIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -106,10 +95,9 @@ export interface FileRoutesById {
   '/__root/notFound': typeof _rootNotFoundRoute
   '/_protected/workspace/no-workspaces': typeof ProtectedWorkspaceNoWorkspacesRoute
   '/_protected/workspace/': typeof ProtectedWorkspaceIndexRoute
-  '/_protected/workspace/$workspaceId': typeof ProtectedWorkspaceWorkspaceIdRouteWithChildren
-  '/_protected/workspace/$workspaceId/__layout': typeof ProtectedWorkspaceWorkspaceId_layoutRoute
-  '/_protected/workspace/$workspaceId/': typeof ProtectedWorkspaceWorkspaceIdIndexRoute
-  '/_protected/workspace/$workspaceId/thread/$threadId': typeof ProtectedWorkspaceWorkspaceIdThreadThreadIdRoute
+  '/_protected/workspace/$workspaceId/_layout': typeof ProtectedWorkspaceWorkspaceIdLayoutRouteWithChildren
+  '/_protected/workspace/$workspaceId/_layout/': typeof ProtectedWorkspaceWorkspaceIdLayoutIndexRoute
+  '/_protected/workspace/$workspaceId/_layout/thread/$threadId': typeof ProtectedWorkspaceWorkspaceIdLayoutThreadThreadIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -118,7 +106,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/notFound'
     | '/workspace/no-workspaces'
-    | '/workspace'
+    | '/workspace/'
     | '/workspace/$workspaceId'
     | '/workspace/$workspaceId/'
     | '/workspace/$workspaceId/thread/$threadId'
@@ -139,10 +127,9 @@ export interface FileRouteTypes {
     | '/__root/notFound'
     | '/_protected/workspace/no-workspaces'
     | '/_protected/workspace/'
-    | '/_protected/workspace/$workspaceId'
-    | '/_protected/workspace/$workspaceId/__layout'
-    | '/_protected/workspace/$workspaceId/'
-    | '/_protected/workspace/$workspaceId/thread/$threadId'
+    | '/_protected/workspace/$workspaceId/_layout'
+    | '/_protected/workspace/$workspaceId/_layout/'
+    | '/_protected/workspace/$workspaceId/_layout/thread/$threadId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -171,7 +158,7 @@ declare module '@tanstack/react-router' {
     '/_protected': {
       id: '/_protected'
       path: ''
-      fullPath: ''
+      fullPath: '/'
       preLoaderRoute: typeof ProtectedRouteImport
       parentRoute: typeof rootRouteImport
     }
@@ -182,17 +169,10 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/_protected/workspace/$workspaceId': {
-      id: '/_protected/workspace/$workspaceId'
-      path: '/workspace/$workspaceId'
-      fullPath: '/workspace/$workspaceId'
-      preLoaderRoute: typeof ProtectedWorkspaceWorkspaceIdRouteImport
-      parentRoute: typeof ProtectedRoute
-    }
     '/_protected/workspace/': {
       id: '/_protected/workspace/'
       path: '/workspace'
-      fullPath: '/workspace'
+      fullPath: '/workspace/'
       preLoaderRoute: typeof ProtectedWorkspaceIndexRouteImport
       parentRoute: typeof ProtectedRoute
     }
@@ -203,62 +183,59 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProtectedWorkspaceNoWorkspacesRouteImport
       parentRoute: typeof ProtectedRoute
     }
-    '/_protected/workspace/$workspaceId/': {
-      id: '/_protected/workspace/$workspaceId/'
-      path: '/'
-      fullPath: '/workspace/$workspaceId/'
-      preLoaderRoute: typeof ProtectedWorkspaceWorkspaceIdIndexRouteImport
-      parentRoute: typeof ProtectedWorkspaceWorkspaceIdRoute
-    }
-    '/_protected/workspace/$workspaceId/__layout': {
-      id: '/_protected/workspace/$workspaceId/__layout'
+    '/_protected/workspace/$workspaceId/_layout': {
+      id: '/_protected/workspace/$workspaceId/_layout'
       path: '/workspace/$workspaceId'
       fullPath: '/workspace/$workspaceId'
-      preLoaderRoute: typeof ProtectedWorkspaceWorkspaceId_layoutRouteImport
-      parentRoute: typeof ProtectedWorkspaceWorkspaceIdRoute
+      preLoaderRoute: typeof ProtectedWorkspaceWorkspaceIdLayoutRouteImport
+      parentRoute: typeof ProtectedRoute
     }
-    '/_protected/workspace/$workspaceId/thread/$threadId': {
-      id: '/_protected/workspace/$workspaceId/thread/$threadId'
+    '/_protected/workspace/$workspaceId/_layout/': {
+      id: '/_protected/workspace/$workspaceId/_layout/'
+      path: '/'
+      fullPath: '/workspace/$workspaceId/'
+      preLoaderRoute: typeof ProtectedWorkspaceWorkspaceIdLayoutIndexRouteImport
+      parentRoute: typeof ProtectedWorkspaceWorkspaceIdLayoutRoute
+    }
+    '/_protected/workspace/$workspaceId/_layout/thread/$threadId': {
+      id: '/_protected/workspace/$workspaceId/_layout/thread/$threadId'
       path: '/thread/$threadId'
       fullPath: '/workspace/$workspaceId/thread/$threadId'
-      preLoaderRoute: typeof ProtectedWorkspaceWorkspaceIdThreadThreadIdRouteImport
-      parentRoute: typeof ProtectedWorkspaceWorkspaceIdRoute
+      preLoaderRoute: typeof ProtectedWorkspaceWorkspaceIdLayoutThreadThreadIdRouteImport
+      parentRoute: typeof ProtectedWorkspaceWorkspaceIdLayoutRoute
     }
   }
 }
 
-interface ProtectedWorkspaceWorkspaceIdRouteChildren {
-  ProtectedWorkspaceWorkspaceId_layoutRoute: typeof ProtectedWorkspaceWorkspaceId_layoutRoute
-  ProtectedWorkspaceWorkspaceIdIndexRoute: typeof ProtectedWorkspaceWorkspaceIdIndexRoute
-  ProtectedWorkspaceWorkspaceIdThreadThreadIdRoute: typeof ProtectedWorkspaceWorkspaceIdThreadThreadIdRoute
+interface ProtectedWorkspaceWorkspaceIdLayoutRouteChildren {
+  ProtectedWorkspaceWorkspaceIdLayoutIndexRoute: typeof ProtectedWorkspaceWorkspaceIdLayoutIndexRoute
+  ProtectedWorkspaceWorkspaceIdLayoutThreadThreadIdRoute: typeof ProtectedWorkspaceWorkspaceIdLayoutThreadThreadIdRoute
 }
 
-const ProtectedWorkspaceWorkspaceIdRouteChildren: ProtectedWorkspaceWorkspaceIdRouteChildren =
+const ProtectedWorkspaceWorkspaceIdLayoutRouteChildren: ProtectedWorkspaceWorkspaceIdLayoutRouteChildren =
   {
-    ProtectedWorkspaceWorkspaceId_layoutRoute:
-      ProtectedWorkspaceWorkspaceId_layoutRoute,
-    ProtectedWorkspaceWorkspaceIdIndexRoute:
-      ProtectedWorkspaceWorkspaceIdIndexRoute,
-    ProtectedWorkspaceWorkspaceIdThreadThreadIdRoute:
-      ProtectedWorkspaceWorkspaceIdThreadThreadIdRoute,
+    ProtectedWorkspaceWorkspaceIdLayoutIndexRoute:
+      ProtectedWorkspaceWorkspaceIdLayoutIndexRoute,
+    ProtectedWorkspaceWorkspaceIdLayoutThreadThreadIdRoute:
+      ProtectedWorkspaceWorkspaceIdLayoutThreadThreadIdRoute,
   }
 
-const ProtectedWorkspaceWorkspaceIdRouteWithChildren =
-  ProtectedWorkspaceWorkspaceIdRoute._addFileChildren(
-    ProtectedWorkspaceWorkspaceIdRouteChildren,
+const ProtectedWorkspaceWorkspaceIdLayoutRouteWithChildren =
+  ProtectedWorkspaceWorkspaceIdLayoutRoute._addFileChildren(
+    ProtectedWorkspaceWorkspaceIdLayoutRouteChildren,
   )
 
 interface ProtectedRouteChildren {
   ProtectedWorkspaceNoWorkspacesRoute: typeof ProtectedWorkspaceNoWorkspacesRoute
   ProtectedWorkspaceIndexRoute: typeof ProtectedWorkspaceIndexRoute
-  ProtectedWorkspaceWorkspaceIdRoute: typeof ProtectedWorkspaceWorkspaceIdRouteWithChildren
+  ProtectedWorkspaceWorkspaceIdLayoutRoute: typeof ProtectedWorkspaceWorkspaceIdLayoutRouteWithChildren
 }
 
 const ProtectedRouteChildren: ProtectedRouteChildren = {
   ProtectedWorkspaceNoWorkspacesRoute: ProtectedWorkspaceNoWorkspacesRoute,
   ProtectedWorkspaceIndexRoute: ProtectedWorkspaceIndexRoute,
-  ProtectedWorkspaceWorkspaceIdRoute:
-    ProtectedWorkspaceWorkspaceIdRouteWithChildren,
+  ProtectedWorkspaceWorkspaceIdLayoutRoute:
+    ProtectedWorkspaceWorkspaceIdLayoutRouteWithChildren,
 }
 
 const ProtectedRouteWithChildren = ProtectedRoute._addFileChildren(

--- a/src/routes/_protected/workspace/$workspaceId/_layout.tsx
+++ b/src/routes/_protected/workspace/$workspaceId/_layout.tsx
@@ -1,4 +1,4 @@
-// routes/_protected/workspace/$workspaceId/__layout.tsx
+// routes/_protected/workspace/$workspaceId/_layout.tsx
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { Suspense, useEffect, useMemo } from 'react';
 
@@ -50,7 +50,7 @@ function WorkspaceBodyBackground() {
 }
 
 export const Route = createFileRoute(
-  '/_protected/workspace/$workspaceId/__layout'
+  '/_protected/workspace/$workspaceId/_layout'
 )({
   loader: ({ params, context }) =>
     context.queryClient.ensureQueryData(

--- a/src/routes/_protected/workspace/$workspaceId/_layout/index.tsx
+++ b/src/routes/_protected/workspace/$workspaceId/_layout/index.tsx
@@ -6,7 +6,9 @@ import { threadsListOptions } from '@/domains/threads/queries';
 import ChatBotPage from '@/pages/WorkspaceThreadPage/chat';
 
 // routes/_protected/workspace/$workspaceId/index.tsx
-export const Route = createFileRoute('/_protected/workspace/$workspaceId/')({
+export const Route = createFileRoute(
+  '/_protected/workspace/$workspaceId/_layout/'
+)({
   pendingMs: 0,
   pendingComponent: WorkspaceIndexRouteComponent,
   loader: async ({ params, context }) => {

--- a/src/routes/_protected/workspace/$workspaceId/_layout/thread/$threadId.tsx
+++ b/src/routes/_protected/workspace/$workspaceId/_layout/thread/$threadId.tsx
@@ -27,7 +27,7 @@ export type ThreadRouteSearch = z.infer<typeof threadRouteSearchSchema>;
 
 // routes/_protected/workspace/$workspaceId/thread/$threadId.tsx
 export const Route = createFileRoute(
-  '/_protected/workspace/$workspaceId/thread/$threadId'
+  '/_protected/workspace/$workspaceId/_layout/thread/$threadId'
 )({
   validateSearch: (search): ThreadRouteSearch =>
     threadRouteSearchSchema.parse(search),

--- a/src/ui/header/notifications-panel.tsx
+++ b/src/ui/header/notifications-panel.tsx
@@ -30,11 +30,11 @@ export function NotificationPanel() {
   const navigate = useNavigate();
 
   const workspaceThreadMatch = useMatch({
-    from: '/_protected/workspace/$workspaceId/thread/$threadId',
+    from: '/_protected/workspace/$workspaceId/_layout/thread/$threadId',
     shouldThrow: false,
   });
   const workspaceIndexMatch = useMatch({
-    from: '/_protected/workspace/$workspaceId/',
+    from: '/_protected/workspace/$workspaceId/_layout/',
     shouldThrow: false,
   });
   const workspaceId =

--- a/src/ui/messages/MessageList.tsx
+++ b/src/ui/messages/MessageList.tsx
@@ -31,7 +31,7 @@ export function MessageList() {
 
   const { data: activeWorkspace } = useWorkspace(workspaceId);
   const workspaceIndexMatch = useMatch({
-    from: '/_protected/workspace/$workspaceId/',
+    from: '/_protected/workspace/$workspaceId/_layout/',
     shouldThrow: false,
   });
 

--- a/src/ui/workspaces/useWorkspaceSubscriptions.ts
+++ b/src/ui/workspaces/useWorkspaceSubscriptions.ts
@@ -9,7 +9,7 @@ import { threadsKeys } from '@/domains/threads/queryKeys';
 
 export function useWorkspaceSubscriptions() {
   const match = useMatch({
-    from: '/_protected/workspace/$workspaceId/thread/$threadId',
+    from: '/_protected/workspace/$workspaceId/_layout/thread/$threadId',
     shouldThrow: false,
   });
   const workspaceId = match?.params?.workspaceId;


### PR DESCRIPTION
## Summary

The workspace layout at `src/routes/_protected/workspace/$workspaceId/` was named `__layout.tsx` (double-underscore). TanStack Router's file-based routing treats that as a **regular route** at the same URL as the index — not a pathless parent layout — so `thread/$threadId.tsx` and `index.tsx` rendered as **siblings** of the layout, not children. Anything the layout provides never reached those routes.

This didn't bite on `develop` because the current layout only renders a background gradient. But it blocks PR #201's `ChatProvider` from wrapping the message UI — `useThread()` throws `Chat hook used outside <ChatProvider>` as soon as you open a thread.

The correct TanStack Router convention for a pathless layout is a single-underscore `_layout`, with child routes nested inside a matching `_layout/` directory.

## Changes

File moves:
- `__layout.tsx` → `_layout.tsx`
- `index.tsx` → `_layout/index.tsx`
- `thread/$threadId.tsx` → `_layout/thread/$threadId.tsx`

`useMatch({ from })` route-id updates:
- `src/platform/routing/RouteIdsProvider.tsx`
- `src/ui/header/notifications-panel.tsx`
- `src/ui/messages/MessageList.tsx`
- `src/ui/workspaces/useWorkspaceSubscriptions.ts`

`routeTree.gen.ts` regenerates on next dev/build run.

## Verification

Before: browsing to `/workspace/:id/thread/:id` threw \`Chat hook used outside <ChatProvider>\` in dev because the child route had no ancestor providing the context.

After (verified on top of PR #201): \`useThread()\` resolves the \`ChatProvider\` value, the thread loads, and the route-tree generator produces the expected parent/child wiring (\`ProtectedWorkspaceWorkspaceIdLayoutRoute\` as parent of both index and thread routes).

## Test plan

- [ ] CI green (lint / typecheck / test / build)
- [ ] On a branch that has PR #201 merged/rebased, open \`/workspace/\$id/thread/\$id\` — no provider error, thread renders.
- [ ] Notifications panel (\`useMatch\` callsite) still resolves \`workspaceId\` on the index page and the thread page.
- [ ] URLs stay the same (pathless \`_layout\` doesn't change user-facing URLs).