### PR TITLE
feat(realtime): migrate to typed SignalR SDK client

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@mui/system": "^6.5.0",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-slot": "^1.2.4",
-    "@smartspace/api-client": "0.1.0-dev.793b98c",
+    "@smartspace/api-client": "0.1.0-dev.08df941",
     "@tanstack/react-query": "^5.96.2",
     "@tanstack/react-router": "^1.168.10",
     "ace-builds": "^1.43.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: ^1.2.4
         version: 1.2.4(@types/react@18.3.1)(react@18.3.1)
       '@smartspace/api-client':
-        specifier: 0.1.0-dev.793b98c
-        version: 0.1.0-dev.793b98c(axios@1.15.1)(zod@4.3.6)
+        specifier: 0.1.0-dev.08df941
+        version: 0.1.0-dev.08df941(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
       '@tanstack/react-query':
         specifier: ^5.96.2
         version: 5.99.2(react@18.3.1)
@@ -2706,9 +2706,10 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
-  '@smartspace/api-client@0.1.0-dev.793b98c':
-    resolution: {integrity: sha512-S2EgutrA8oxodp82qBYEYd02E5ETufWqoKha8bDDEACOCnE9x6mZxvwJENUEM2nxle2p0KgZOT56VMZUMdRVig==}
+  '@smartspace/api-client@0.1.0-dev.08df941':
+    resolution: {integrity: sha512-J+RrgM5eMGt5v+MXzEQgAWAFSpuf8eDGg8Bwf4zDte80chbaaKhuZ2YSOc8vKBVy3M1AVUPGjrwfQao9TDMtmg==}
     peerDependencies:
+      '@microsoft/signalr': '>=8.0.0'
       axios: '>=1.0.0'
       zod: ^4.0.0
 
@@ -10527,8 +10528,9 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
-  '@smartspace/api-client@0.1.0-dev.793b98c(axios@1.15.1)(zod@4.3.6)':
+  '@smartspace/api-client@0.1.0-dev.08df941(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)':
     dependencies:
+      '@microsoft/signalr': 8.0.17(encoding@0.1.13)
       axios: 1.15.1
       zod: 4.3.6
 

--- a/src/platform/realtime/RealtimeProvider.tsx
+++ b/src/platform/realtime/RealtimeProvider.tsx
@@ -5,6 +5,7 @@ import {
   HubConnectionBuilder,
   HubConnectionState,
 } from '@microsoft/signalr';
+import { SignalR } from '@smartspace/api-client';
 import {
   createContext,
   useCallback,
@@ -17,6 +18,9 @@ import {
 } from 'react';
 
 import { parseScopes } from '@/platform/auth/scopes';
+
+const createClientHub = (connection: HubConnection) =>
+  SignalR.getHubProxyFactory('IClientHubInvoker').createHubProxy(connection);
 
 type RealtimeCtx = {
   connection?: HubConnection;
@@ -104,7 +108,8 @@ export function RealtimeProvider({
         return; // lifecycle will re-join
       }
       try {
-        await connection.invoke(method, groupName);
+        const hub = createClientHub(connection);
+        await hub[method](groupName);
       } catch (err) {
         if (attempt < 3) {
           const delay = 300 * Math.pow(2, attempt) + Math.random() * 100;
@@ -167,9 +172,10 @@ export function RealtimeProvider({
     // rejoin desired groups after reconnect
     const rejoin = async () => {
       if (conn.state !== HubConnectionState.Connected) return;
+      const hub = createClientHub(conn);
       for (const g of desiredGroups.current) {
         try {
-          await conn.invoke('joinGroup', g);
+          await hub.joinGroup(g);
         } catch {
           console.error('Error joining group', g);
         }

--- a/src/platform/realtime/useWorkspaceRealtime.ts
+++ b/src/platform/realtime/useWorkspaceRealtime.ts
@@ -1,12 +1,13 @@
 // src/platform/realtime/useWorkspaceRealtime.ts
+import { SignalR } from '@smartspace/api-client';
 import { useEffect } from 'react';
 
 import { useOptionalRealtime } from './RealtimeProvider';
 
 type Handlers = {
-  onThreadUpdate?: (threadId: string) => void;
-  onThreadDeleted?: (threadId: string) => void;
-  onCommentsUpdate?: (threadId: string) => void;
+  onThreadUpdate?: (thread: SignalR.MessageThreadSummary) => void;
+  onThreadDeleted?: (thread: SignalR.MessageThreadSummary) => void;
+  onCommentsUpdate?: (comment: SignalR.CommentSummary) => void;
 };
 
 export function useWorkspaceRealtime(
@@ -30,27 +31,29 @@ export function useWorkspaceRealtime(
     // join workspace group
     subscribeToGroup(workspaceId);
 
-    const onThreadUpdate = (t: { id: string } & Record<string, unknown>) => {
-      handlers.onThreadUpdate?.(t.id);
-    };
-    const onThreadDeleted = (t: { id: string } & Record<string, unknown>) => {
-      handlers.onThreadDeleted?.(t.id);
-    };
-    const onCommentsUpdate = (
-      c: { messageThreadId: string } & Record<string, unknown>
-    ) => {
-      handlers.onCommentsUpdate?.(c.messageThreadId);
-    };
-
-    connection.on('ReceiveThreadUpdate', onThreadUpdate);
-    connection.on('ReceiveThreadDeleted', onThreadDeleted);
-    connection.on('ReceiveCommentsUpdate', onCommentsUpdate);
+    const subscription = SignalR.getReceiverRegister(
+      'INotificationReceiver'
+    ).register(connection, {
+      receiveMessage: async () => {
+        /* no-op: toast/notification handling lives elsewhere */
+      },
+      receiveThreadUpdate: async (thread) => {
+        handlers.onThreadUpdate?.(thread);
+      },
+      receiveThreadDeleted: async (thread) => {
+        handlers.onThreadDeleted?.(thread);
+      },
+      receiveCommentsUpdate: async (comment) => {
+        handlers.onCommentsUpdate?.(comment);
+      },
+      blocksUpdate: async () => {
+        /* no-op: blocks invalidation handled by domain listeners */
+      },
+    });
 
     return () => {
       unsubscribeFromGroup(workspaceId);
-      connection.off('ReceiveThreadUpdate', onThreadUpdate);
-      connection.off('ReceiveThreadDeleted', onThreadDeleted);
-      connection.off('ReceiveCommentsUpdate', onCommentsUpdate);
+      subscription.dispose();
     };
   }, [
     workspaceId,

--- a/src/ui/workspaces/useWorkspaceSubscriptions.ts
+++ b/src/ui/workspaces/useWorkspaceSubscriptions.ts
@@ -18,23 +18,27 @@ export function useWorkspaceSubscriptions() {
   const navigate = useNavigate();
 
   useWorkspaceRealtime(workspaceId, {
-    onThreadUpdate: (id) => {
+    onThreadUpdate: (thread) => {
       if (!workspaceId) return;
       // eslint-disable-next-line no-console
-      console.log('[SignalR] ReceiveThreadUpdate for thread:', id);
+      console.log('[SignalR] ReceiveThreadUpdate for thread:', thread.id);
       qc.invalidateQueries({ queryKey: threadsKeys.list(workspaceId) });
-      qc.invalidateQueries({ queryKey: threadsKeys.detail(workspaceId, id) });
-      qc.invalidateQueries({ queryKey: messagesKeys.list(id) });
+      qc.invalidateQueries({
+        queryKey: threadsKeys.detail(workspaceId, thread.id),
+      });
+      qc.invalidateQueries({ queryKey: messagesKeys.list(thread.id) });
     },
-    onThreadDeleted: (id) => {
+    onThreadDeleted: (thread) => {
       if (!workspaceId) return;
       qc.invalidateQueries({ queryKey: threadsKeys.list(workspaceId) });
-      if (id === threadId) {
+      if (thread.id === threadId) {
         navigate({ to: '/workspace/$workspaceId', params: { workspaceId } });
       }
     },
-    onCommentsUpdate: (tid) => {
-      qc.invalidateQueries({ queryKey: ['comments', tid] });
+    onCommentsUpdate: (comment) => {
+      qc.invalidateQueries({
+        queryKey: ['comments', comment.messageThreadId],
+      });
     },
   });
 }


### PR DESCRIPTION
## Summary

- Swap raw `connection.on`/`connection.invoke` calls in the realtime layer for the typed `getHubProxyFactory('IClientHubInvoker')` and `getReceiverRegister('INotificationReceiver')` helpers shipped in `@smartspace/api-client@0.1.0-dev.08df941`.
- Workspace subscription handlers now receive `MessageThreadSummary` / `CommentSummary` DTOs instead of bare id strings, so `tsc` will catch shape drift when the hub contract changes.
- `@microsoft/signalr` peer was already at `^8.0.17` in `package.json`; no new deps added.

## What changed

| File | Change |
|---|---|
| `src/platform/realtime/RealtimeProvider.tsx` | `joinGroup` / `leaveGroup` invoked via typed hub proxy. Rejoin-on-reconnect uses the same proxy. |
| `src/platform/realtime/useWorkspaceRealtime.ts` | Subscription uses `getReceiverRegister(...).register(conn, { ... })` and cleans up via `subscription.dispose()`. |
| `src/ui/workspaces/useWorkspaceSubscriptions.ts` | Handler payloads updated from `string` (id) to `MessageThreadSummary` / `CommentSummary`. |

## Notes

- `receiveMessage` and `blocksUpdate` are wired as no-op handlers — not used on the frontend today. Raise them to real handlers when toasts / block invalidation land.
- No test mock changes needed: the SDK delegates to `connection.on/off/invoke`, which the existing `@microsoft/signalr` mock in `src/test/setup.ts` already stubs.

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm test` (171/171 passing)
- [ ] Smoke in dev: open a workspace, confirm thread/comment updates still invalidate queries via SignalR
- [ ] Smoke: disconnect network, reconnect, confirm workspace rejoin happens