### PR TITLE
feat(realtime): split SignalR receivers into chat + config hubs

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@mui/system": "^6.5.0",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-slot": "^1.2.4",
-    "@smartspace/api-client": "0.1.0-dev.08df941",
+    "@smartspace/api-client": "0.1.0-dev.ae2656d",
     "@tanstack/react-query": "^5.96.2",
     "@tanstack/react-router": "^1.168.10",
     "ace-builds": "^1.43.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: ^1.2.4
         version: 1.2.4(@types/react@18.3.1)(react@18.3.1)
       '@smartspace/api-client':
-        specifier: 0.1.0-dev.08df941
-        version: 0.1.0-dev.08df941(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
+        specifier: 0.1.0-dev.ae2656d
+        version: 0.1.0-dev.ae2656d(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
       '@tanstack/react-query':
         specifier: ^5.96.2
         version: 5.99.2(react@18.3.1)
@@ -2706,8 +2706,8 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
-  '@smartspace/api-client@0.1.0-dev.08df941':
-    resolution: {integrity: sha512-J+RrgM5eMGt5v+MXzEQgAWAFSpuf8eDGg8Bwf4zDte80chbaaKhuZ2YSOc8vKBVy3M1AVUPGjrwfQao9TDMtmg==}
+  '@smartspace/api-client@0.1.0-dev.ae2656d':
+    resolution: {integrity: sha512-atF8p7sDdKhe/NI5k2C0Qdq5Z41Ezd/8iSD32t3IJVIG2g0qg0+pm9i1+3ppjMAQ4MNhBZm+ZqU3w0DrrAeAog==}
     peerDependencies:
       '@microsoft/signalr': '>=8.0.0'
       axios: '>=1.0.0'
@@ -10528,7 +10528,7 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
-  '@smartspace/api-client@0.1.0-dev.08df941(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)':
+  '@smartspace/api-client@0.1.0-dev.ae2656d(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)':
     dependencies:
       '@microsoft/signalr': 8.0.17(encoding@0.1.13)
       axios: 1.15.1

--- a/src/platform/realtime/RealtimeProvider.tsx
+++ b/src/platform/realtime/RealtimeProvider.tsx
@@ -19,8 +19,8 @@ import {
 
 import { parseScopes } from '@/platform/auth/scopes';
 
-const createClientHub = (connection: HubConnection) =>
-  SignalR.getHubProxyFactory('IClientHubInvoker').createHubProxy(connection);
+const createChatHub = (connection: HubConnection) =>
+  SignalR.getHubProxyFactory('IChatHubInvoker').createHubProxy(connection);
 
 type RealtimeCtx = {
   connection?: HubConnection;
@@ -108,7 +108,7 @@ export function RealtimeProvider({
         return; // lifecycle will re-join
       }
       try {
-        const hub = createClientHub(connection);
+        const hub = createChatHub(connection);
         await hub[method](groupName);
       } catch (err) {
         if (attempt < 3) {
@@ -172,7 +172,7 @@ export function RealtimeProvider({
     // rejoin desired groups after reconnect
     const rejoin = async () => {
       if (conn.state !== HubConnectionState.Connected) return;
-      const hub = createClientHub(conn);
+      const hub = createChatHub(conn);
       for (const g of desiredGroups.current) {
         try {
           await hub.joinGroup(g);

--- a/src/platform/realtime/useWorkspaceRealtime.ts
+++ b/src/platform/realtime/useWorkspaceRealtime.ts
@@ -31,25 +31,23 @@ export function useWorkspaceRealtime(
     // join workspace group
     subscribeToGroup(workspaceId);
 
-    const subscription = SignalR.getReceiverRegister(
-      'INotificationReceiver'
-    ).register(connection, {
-      receiveMessage: async () => {
-        /* no-op: toast/notification handling lives elsewhere */
-      },
-      receiveThreadUpdate: async (thread) => {
-        handlers.onThreadUpdate?.(thread);
-      },
-      receiveThreadDeleted: async (thread) => {
-        handlers.onThreadDeleted?.(thread);
-      },
-      receiveCommentsUpdate: async (comment) => {
-        handlers.onCommentsUpdate?.(comment);
-      },
-      blocksUpdate: async () => {
-        /* no-op: blocks invalidation handled by domain listeners */
-      },
-    });
+    const subscription = SignalR.getReceiverRegister('IChatReceiver').register(
+      connection,
+      {
+        receiveMessage: async () => {
+          /* no-op: toast/notification handling lives elsewhere */
+        },
+        receiveThreadUpdate: async (thread) => {
+          handlers.onThreadUpdate?.(thread);
+        },
+        receiveThreadDeleted: async (thread) => {
+          handlers.onThreadDeleted?.(thread);
+        },
+        receiveCommentsUpdate: async (comment) => {
+          handlers.onCommentsUpdate?.(comment);
+        },
+      }
+    );
 
     return () => {
       unsubscribeFromGroup(workspaceId);


### PR DESCRIPTION
## Summary

- Bump `@smartspace/api-client` to `0.1.0-dev.ae2656d`, which replaces the unified `IClientHubInvoker` / `INotificationReceiver` with hub-specific `IChatHubInvoker` / `IChatReceiver` and `IConfigHubInvoker` / `IConfigReceiver` — mirroring the ChatApi / ConfigApi split on the backend.
- `RealtimeProvider` now wires `IChatHubInvoker` for `joinGroup` / `leaveGroup`.
- `useWorkspaceRealtime` now registers `IChatReceiver`. The `blocksUpdate` no-op — which lived on the old unified receiver — is dropped. It belongs to the config hub and was never consumed here.

No URL change needed: both hubs are served at `/notifications` on their respective API hosts, and this template only talks to the chat host.

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [ ] Manual: open a workspace thread, observe that thread updates, thread deletion (navigation back to workspace root), and comment updates still invalidate the right queries via SignalR