### PR TITLE
ci(deploy): write 404.html as a copy of index.html for SPA deep-link refreshes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,6 +52,9 @@ jobs:
             --source=.
             export --path=./dist/smartspace
 
+      - name: Copy index.html to 404.html for SPA deep-link refreshes
+        run: cp ./dist/smartspace/index.html ./dist/smartspace/404.html
+
       - name: Deploy to Azure Storage
         uses: azure/CLI@v2
         with:


### PR DESCRIPTION
## Summary
Copy the freshly-built `index.html` to `404.html` before uploading to Azure Storage, so deep-link refreshes on SPA routes (e.g. `/workspace/:id/thread/:id`) serve the current build instead of a stale error document left over from a previous deploy.

## Problem
Azure Storage Static Websites serve the configured error document (almost always `404.html`) for any unresolved path. For an SPA that covers every client-side route. In practice, a user was seeing:

- Sign in → lands at `/` → new `index.html` served → correct branding ✓
- Navigate in-app to `/workspace/<id>/thread/<id>` → SPA routing, no HTML refetch → still correct
- Refresh the workspace URL → browser fetches `/workspace/<id>/thread/<id>` from origin → Azure falls back to `404.html` → **served an old build's HTML (wrong branding, wrong bundle filename)**

`404.html` persisted unchanged across deploys because `az storage blob upload-batch` only writes the files in `./dist/smartspace`, and Vite does not emit a `404.html`.

## Fix
Before the upload step, `cp index.html 404.html`. Both are then uploaded with the same `no-cache` directive from the existing cache-control work, so deep-link refreshes always boot the current build.

## Test plan
- [ ] Deploy to dev.
- [ ] Hit a deep-link URL like `/workspace/<id>/thread/<id>` directly (or refresh from such a URL) — network tab should show the response referencing the same `main-*.js` / `main-*.css` hashes as the root.
- [ ] `curl https://<your-site>/404.html` should return the current build's HTML.
- [ ] `curl https://<your-site>/some/nonexistent/path` should also return the current build's HTML (via error-document fallback).