### PR TITLE
feat(realtime): thread-keyed SSE for live messages + direct cache writes from SignalR

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@mui/system": "^6.5.0",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-slot": "^1.2.4",
-    "@smartspace/api-client": "0.1.0-dev.ae2656d",
+    "@smartspace/api-client": "0.1.0-pr.745.138eb31",
     "@tanstack/react-query": "^5.96.2",
     "@tanstack/react-router": "^1.168.10",
     "ace-builds": "^1.43.6",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@mui/system": "^6.5.0",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-slot": "^1.2.4",
-    "@smartspace/api-client": "0.1.0-pr.745.138eb31",
+    "@smartspace/api-client": "0.1.0-dev.bc5fd87",
     "@tanstack/react-query": "^5.96.2",
     "@tanstack/react-router": "^1.168.10",
     "ace-builds": "^1.43.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: ^1.2.4
         version: 1.2.4(@types/react@18.3.1)(react@18.3.1)
       '@smartspace/api-client':
-        specifier: 0.1.0-dev.ae2656d
-        version: 0.1.0-dev.ae2656d(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
+        specifier: 0.1.0-pr.745.138eb31
+        version: 0.1.0-pr.745.138eb31(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
       '@tanstack/react-query':
         specifier: ^5.96.2
         version: 5.99.2(react@18.3.1)
@@ -2706,8 +2706,8 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
-  '@smartspace/api-client@0.1.0-dev.ae2656d':
-    resolution: {integrity: sha512-atF8p7sDdKhe/NI5k2C0Qdq5Z41Ezd/8iSD32t3IJVIG2g0qg0+pm9i1+3ppjMAQ4MNhBZm+ZqU3w0DrrAeAog==}
+  '@smartspace/api-client@0.1.0-pr.745.138eb31':
+    resolution: {integrity: sha512-jTGxIT0kVhHq9tUsUxkZNxY/2PA1IMZsnkmozP9qUm2+sqLO9uQIE2DI6dNQeCDErrv0Jnr8fVqhjlWi1wmYjQ==}
     peerDependencies:
       '@microsoft/signalr': '>=8.0.0'
       axios: '>=1.0.0'
@@ -10528,7 +10528,7 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
-  '@smartspace/api-client@0.1.0-dev.ae2656d(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)':
+  '@smartspace/api-client@0.1.0-pr.745.138eb31(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)':
     dependencies:
       '@microsoft/signalr': 8.0.17(encoding@0.1.13)
       axios: 1.15.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: ^1.2.4
         version: 1.2.4(@types/react@18.3.1)(react@18.3.1)
       '@smartspace/api-client':
-        specifier: 0.1.0-pr.745.138eb31
-        version: 0.1.0-pr.745.138eb31(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
+        specifier: 0.1.0-dev.bc5fd87
+        version: 0.1.0-dev.bc5fd87(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
       '@tanstack/react-query':
         specifier: ^5.96.2
         version: 5.99.2(react@18.3.1)
@@ -2706,8 +2706,8 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
-  '@smartspace/api-client@0.1.0-pr.745.138eb31':
-    resolution: {integrity: sha512-jTGxIT0kVhHq9tUsUxkZNxY/2PA1IMZsnkmozP9qUm2+sqLO9uQIE2DI6dNQeCDErrv0Jnr8fVqhjlWi1wmYjQ==}
+  '@smartspace/api-client@0.1.0-dev.bc5fd87':
+    resolution: {integrity: sha512-cFZ31ndAlIHtgU/yxbV48tV9jw8WAz34P9wwqB1bst4Bn9AHruUabc0Uax0KHfhmx6pEAt1b4YvQkPtZ80jUEQ==}
     peerDependencies:
       '@microsoft/signalr': '>=8.0.0'
       axios: '>=1.0.0'
@@ -10528,7 +10528,7 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
-  '@smartspace/api-client@0.1.0-pr.745.138eb31(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)':
+  '@smartspace/api-client@0.1.0-dev.bc5fd87(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)':
     dependencies:
       '@microsoft/signalr': 8.0.17(encoding@0.1.13)
       axios: 1.15.1

--- a/src/domains/comments/__tests__/cache.spec.ts
+++ b/src/domains/comments/__tests__/cache.spec.ts
@@ -1,0 +1,90 @@
+import { QueryClient } from '@tanstack/react-query';
+import { describe, expect, it } from 'vitest';
+
+import { applyCommentToCache } from '@/domains/comments/cache';
+import type { Comment } from '@/domains/comments/model';
+import { commentsKeys } from '@/domains/comments/queryKeys';
+
+const summary = (
+  over: Partial<{ id: string; createdAt: string; content: string }> = {}
+) => ({
+  id: over.id ?? 'c1',
+  messageThreadId: 't1',
+  createdAt: over.createdAt ?? '2024-01-01T00:00:00Z',
+  createdByUserId: 'u1',
+  createdBy: 'User',
+  content: over.content ?? 'hello',
+  mentionedUsers: [],
+});
+
+describe('applyCommentToCache', () => {
+  it('writes to commentsKeys.list(threadId) — not the legacy ["comments", threadId] key', () => {
+    const qc = new QueryClient();
+    qc.setQueryData<Comment[]>(commentsKeys.list('t1'), []);
+
+    const applied = applyCommentToCache(qc, summary());
+
+    expect(applied).toBe(true);
+    const listed = qc.getQueryData<Comment[]>(commentsKeys.list('t1'));
+    expect(listed?.length).toBe(1);
+    expect(listed?.[0].id).toBe('c1');
+
+    // The previously-broken handler targeted this key, which was never the
+    // real cache key. Asserting it stays empty guards against a regression
+    // back to that shape.
+    expect(qc.getQueryData(['comments', 't1'])).toBeUndefined();
+  });
+
+  it('returns false when no list cache exists yet (caller falls back to invalidate)', () => {
+    const qc = new QueryClient();
+    expect(applyCommentToCache(qc, summary())).toBe(false);
+  });
+
+  it('replaces by id when the comment already exists', () => {
+    const qc = new QueryClient();
+    qc.setQueryData<Comment[]>(commentsKeys.list('t1'), [
+      {
+        id: 'c1',
+        createdAt: new Date('2024-01-01T00:00:00Z'),
+        createdBy: 'User',
+        createdByUserId: 'u1',
+        content: 'old',
+        mentionedUsers: [],
+        messageThreadId: 't1',
+      },
+    ]);
+
+    applyCommentToCache(qc, summary({ content: 'edited' }));
+
+    const listed = qc.getQueryData<Comment[]>(commentsKeys.list('t1')) ?? [];
+    expect(listed.length).toBe(1);
+    expect(listed[0].content).toBe('edited');
+  });
+
+  it('appends and sorts ascending by createdAt for new comments', () => {
+    const qc = new QueryClient();
+    qc.setQueryData<Comment[]>(commentsKeys.list('t1'), [
+      {
+        id: 'c1',
+        createdAt: new Date('2024-01-01T00:00:01Z'),
+        createdBy: 'User',
+        createdByUserId: 'u1',
+        content: 'first',
+        mentionedUsers: [],
+        messageThreadId: 't1',
+      },
+    ]);
+
+    applyCommentToCache(
+      qc,
+      summary({
+        id: 'c0',
+        createdAt: '2024-01-01T00:00:00Z',
+        content: 'earlier',
+      })
+    );
+
+    const listed = qc.getQueryData<Comment[]>(commentsKeys.list('t1')) ?? [];
+    expect(listed.map((c) => c.id)).toEqual(['c0', 'c1']);
+  });
+});

--- a/src/domains/comments/cache.ts
+++ b/src/domains/comments/cache.ts
@@ -1,0 +1,37 @@
+import type { SignalR } from '@smartspace/api-client';
+import type { QueryClient } from '@tanstack/react-query';
+
+import { mapSignalRCommentSummaryToModel } from './mapper';
+import type { Comment } from './model';
+import { commentsKeys } from './queryKeys';
+
+/**
+ * Splice a freshly-observed comment (from SignalR `receiveCommentsUpdate`)
+ * straight into the comments list cache for its thread. Replaces an existing
+ * entry by id, otherwise appends and re-sorts by `createdAt`. Returns `true`
+ * when the cache had a list to patch — callers can fall back to invalidating
+ * if it returns `false` (e.g. the user has never opened the comments panel
+ * for this thread).
+ */
+export function applyCommentToCache(
+  qc: QueryClient,
+  summary: SignalR.CommentSummary
+): boolean {
+  const mapped = mapSignalRCommentSummaryToModel(summary);
+  const listKey = commentsKeys.list(summary.messageThreadId);
+  let applied = false;
+  qc.setQueryData<Comment[]>(listKey, (old) => {
+    if (!old) return old;
+    applied = true;
+    const idx = old.findIndex((c) => c.id === summary.id);
+    if (idx === -1) {
+      return [...old, mapped].sort(
+        (a, b) => a.createdAt.getTime() - b.createdAt.getTime()
+      );
+    }
+    const copy = old.slice();
+    copy[idx] = mapped;
+    return copy;
+  });
+  return applied;
+}

--- a/src/domains/comments/index.ts
+++ b/src/domains/comments/index.ts
@@ -1,6 +1,6 @@
+export { mapSignalRCommentSummaryToModel } from './mapper';
 export type { Comment, MentionUser } from './model';
 export * from './mutations';
 export { commentsListOptions, useComments } from './queries';
 export { commentsKeys } from './queryKeys';
 export * from './service';
-

--- a/src/domains/comments/index.ts
+++ b/src/domains/comments/index.ts
@@ -1,3 +1,4 @@
+export { applyCommentToCache } from './cache';
 export { mapSignalRCommentSummaryToModel } from './mapper';
 export type { Comment, MentionUser } from './model';
 export * from './mutations';

--- a/src/domains/comments/mapper.ts
+++ b/src/domains/comments/mapper.ts
@@ -1,4 +1,4 @@
-import { ChatZod } from '@smartspace/api-client';
+import { ChatZod, SignalR } from '@smartspace/api-client';
 import type { z } from 'zod';
 
 import { utcDate } from '@/shared/utils/dateFromApi';
@@ -45,3 +45,26 @@ export function mapCommentDtoToModel(
 
 export const mapCommentsDtoToModels = (arr: CommentDto[]) =>
   arr.map(mapCommentDtoToModel);
+
+/**
+ * Map the SignalR `receiveCommentsUpdate` payload to our comment model so we
+ * can splice it directly into the comments list cache without an invalidate +
+ * refetch roundtrip.
+ */
+export function mapSignalRCommentSummaryToModel(
+  summary: SignalR.CommentSummary
+): Comment {
+  return {
+    id: summary.id,
+    createdAt: utcDate(summary.createdAt),
+    createdByUserId: summary.createdByUserId,
+    createdBy: summary.createdBy ?? '',
+    content: summary.content,
+    mentionedUsers: (summary.mentionedUsers ?? []).map((u) => ({
+      id: u.id,
+      displayName: u.name ?? '',
+      initials: null,
+    })),
+    messageThreadId: summary.messageThreadId,
+  };
+}

--- a/src/domains/messages/__tests__/mapper.spec.ts
+++ b/src/domains/messages/__tests__/mapper.spec.ts
@@ -1,19 +1,135 @@
 import { describe, expect, it } from 'vitest';
 
-import { mapMessageDtoToModel, mapMessagesDtoToModels } from '@/domains/messages/mapper';
+import { MessageValueType } from '@/domains/messages/enums';
+import {
+  applyDeltaToMessage,
+  mapMessageDtoToModel,
+  mapMessagesDtoToModels,
+} from '@/domains/messages/mapper';
+import type { Message, MessageValue } from '@/domains/messages/model';
 
 describe('messages mapper', () => {
   it('maps single dto to model with defaults', () => {
-    const dto = { id: null, createdAt: new Date('2024-01-01T00:00:00Z'), createdBy: null, hasComments: undefined, createdByUserId: null, messageThreadId: null, values: null } as any;
+    const dto = {
+      id: null,
+      createdAt: new Date('2024-01-01T00:00:00Z'),
+      createdBy: null,
+      hasComments: undefined,
+      createdByUserId: null,
+      messageThreadId: null,
+      values: null,
+    } as any;
     const m = mapMessageDtoToModel(dto);
     expect(m.id).toBeUndefined();
     expect(m.hasComments).toBe(false);
   });
 
   it('maps list dto to models', () => {
-    const list = [{ id: '1', createdAt: '2024-01-01T00:00:00Z', createdBy: 'u', hasComments: true, createdByUserId: 'u', messageThreadId: 't', values: [] }];
+    const list = [
+      {
+        id: '1',
+        createdAt: '2024-01-01T00:00:00Z',
+        createdBy: 'u',
+        hasComments: true,
+        createdByUserId: 'u',
+        messageThreadId: 't',
+        values: [],
+      },
+    ];
     const res = mapMessagesDtoToModels(list);
     expect(res.length).toBe(1);
     expect(res[0].id).toBe('1');
+  });
+});
+
+describe('applyDeltaToMessage', () => {
+  const msg = (values: MessageValue[]): Message => ({
+    id: 'm1',
+    createdAt: new Date('2024-01-01T00:00:00Z'),
+    createdBy: 'bot',
+    values,
+    errors: [],
+  });
+
+  const out = (
+    name: string,
+    value: string,
+    id = `${name}-1`
+  ): MessageValue => ({
+    id,
+    name,
+    type: MessageValueType.OUTPUT,
+    value,
+    channels: {},
+    createdAt: new Date('2024-01-01T00:00:00Z'),
+    createdBy: 'bot',
+    createdByUserId: 'bot',
+  });
+
+  it('replaces by (name, type) so cumulative chunks do not duplicate', () => {
+    const start = msg([
+      {
+        id: 'p1',
+        name: 'prompt',
+        type: MessageValueType.INPUT,
+        value: 'hi',
+        channels: {},
+        createdAt: new Date('2024-01-01T00:00:00Z'),
+        createdBy: 'user',
+        createdByUserId: 'u',
+      },
+    ]);
+
+    const afterFirst = applyDeltaToMessage(start, {
+      outputs: [out('response', 'He')],
+      errors: [],
+    });
+    expect(afterFirst.values?.length).toBe(2);
+    expect(afterFirst.values?.find((v) => v.name === 'response')?.value).toBe(
+      'He'
+    );
+
+    const afterSecond = applyDeltaToMessage(afterFirst, {
+      outputs: [out('response', 'Hel')],
+      errors: [],
+    });
+    expect(afterSecond.values?.length).toBe(2);
+    expect(afterSecond.values?.find((v) => v.name === 'response')?.value).toBe(
+      'Hel'
+    );
+
+    const afterThird = applyDeltaToMessage(afterSecond, {
+      outputs: [out('response', 'Hello'), out('sources', '[]', 'sources-1')],
+      errors: [],
+    });
+    expect(afterThird.values?.length).toBe(3);
+    expect(afterThird.values?.find((v) => v.name === 'response')?.value).toBe(
+      'Hello'
+    );
+    expect(afterThird.values?.find((v) => v.name === 'sources')).toBeDefined();
+  });
+
+  it('appends errors (not cumulative)', () => {
+    const start = msg([]);
+    const after = applyDeltaToMessage(start, {
+      outputs: [],
+      errors: [
+        { code: 1, message: 'first', data: null, blockId: 'b' },
+        { code: 2, message: 'second', data: null, blockId: 'b' },
+      ],
+    });
+    expect(after.errors?.length).toBe(2);
+
+    const more = applyDeltaToMessage(after, {
+      outputs: [],
+      errors: [{ code: 3, message: 'third', data: null, blockId: 'b' }],
+    });
+    expect(more.errors?.length).toBe(3);
+  });
+
+  it('returns the same reference when no outputs or errors', () => {
+    const start = msg([]);
+    const after = applyDeltaToMessage(start, { outputs: [], errors: [] });
+    expect(after).toBe(start);
   });
 });

--- a/src/domains/messages/__tests__/mutations.spec.tsx
+++ b/src/domains/messages/__tests__/mutations.spec.tsx
@@ -23,6 +23,13 @@ describe('messages mutations', () => {
       <QueryClientProvider client={client}>{children}</QueryClientProvider>
     );
 
+    // Seed an existing thread detail so the post-POST isFlowRunning flip
+    // has a record to merge into.
+    client.setQueryData(threadsKeys.detail('w', 't'), {
+      id: 't',
+      isFlowRunning: false,
+    } as any);
+
     const realMessage = {
       id: 'real-42',
       createdAt: new Date(),
@@ -46,6 +53,43 @@ describe('messages mutations', () => {
     expect(data.some((m) => m.optimistic)).toBe(false);
     expect(data.some((m) => m.id === 'real-42')).toBe(true);
     expect(spy).toHaveBeenCalledOnce();
+
+    // Post-POST flip closes the composer indicator gap and opens the SSE
+    // gate without waiting for SignalR.
+    const detail = client.getQueryData<any>(threadsKeys.detail('w', 't'));
+    expect(detail?.isFlowRunning).toBe(true);
+
+    spy.mockRestore();
+  });
+
+  it('useSendMessage does not flip detail.isFlowRunning on POST error', async () => {
+    const client = new QueryClient();
+    const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+
+    client.setQueryData(threadsKeys.detail('w', 't'), {
+      id: 't',
+      isFlowRunning: false,
+    } as any);
+
+    const spy = vi
+      .spyOn(service, 'postMessage')
+      .mockRejectedValueOnce(new Error('boom'));
+
+    const { result } = renderHook(() => useSendMessage(), { wrapper });
+    await expect(
+      result.current.mutateAsync({
+        workspaceId: 'w',
+        threadId: 't',
+        contentList: [],
+        files: [],
+        variables: {},
+      })
+    ).rejects.toThrow('boom');
+
+    const detail = client.getQueryData<any>(threadsKeys.detail('w', 't'));
+    expect(detail?.isFlowRunning).toBe(false);
     spy.mockRestore();
   });
 

--- a/src/domains/messages/__tests__/mutations.spec.tsx
+++ b/src/domains/messages/__tests__/mutations.spec.tsx
@@ -17,15 +17,21 @@ import * as service from '@/domains/messages/service';
 import { threadsKeys } from '@/domains/threads/queryKeys';
 
 describe('messages mutations', () => {
-  it('useSendMessage writes optimistic and keeps it after postMessage resolves', async () => {
+  it('useSendMessage swaps the optimistic entry for the real Message returned by postMessage', async () => {
     const client = new QueryClient();
     const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
       <QueryClientProvider client={client}>{children}</QueryClientProvider>
     );
 
+    const realMessage = {
+      id: 'real-42',
+      createdAt: new Date(),
+      createdBy: 'Server',
+      values: [],
+    } as any;
     const spy = vi
       .spyOn(service, 'postMessage')
-      .mockResolvedValueOnce(undefined);
+      .mockResolvedValueOnce(realMessage);
 
     const { result } = renderHook(() => useSendMessage(), { wrapper });
     await result.current.mutateAsync({
@@ -37,8 +43,42 @@ describe('messages mutations', () => {
     });
 
     const data = client.getQueryData<any[]>(messagesKeys.list('t')) || [];
-    expect(data.some((m) => m.optimistic)).toBe(true);
+    expect(data.some((m) => m.optimistic)).toBe(false);
+    expect(data.some((m) => m.id === 'real-42')).toBe(true);
     expect(spy).toHaveBeenCalledOnce();
+    spy.mockRestore();
+  });
+
+  it('useSendMessage keeps the thread SSE copy when it already added the real id', async () => {
+    const client = new QueryClient();
+    const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+
+    // Thread SSE snapshot wrote this entry before postMessage resolved.
+    client.setQueryData(messagesKeys.list('t'), [
+      { id: 'real-42', createdAt: new Date(), values: [], createdBy: 'Server' },
+    ] as any);
+
+    const spy = vi.spyOn(service, 'postMessage').mockResolvedValueOnce({
+      id: 'real-42',
+      createdAt: new Date(),
+      createdBy: 'Server',
+      values: [],
+    } as any);
+
+    const { result } = renderHook(() => useSendMessage(), { wrapper });
+    await result.current.mutateAsync({
+      workspaceId: 'w',
+      threadId: 't',
+      contentList: [],
+      files: [],
+      variables: {},
+    });
+
+    const data = client.getQueryData<any[]>(messagesKeys.list('t')) || [];
+    expect(data.filter((m) => m.id === 'real-42').length).toBe(1);
+    expect(data.some((m) => m.optimistic)).toBe(false);
     spy.mockRestore();
   });
 

--- a/src/domains/messages/__tests__/service.spec.ts
+++ b/src/domains/messages/__tests__/service.spec.ts
@@ -1,7 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { api } from '@/platform/api';
-
 const {
   mockGetMessages,
   mockPostMessage,
@@ -62,8 +60,6 @@ import {
   fetchMessages,
   postMessage,
 } from '@/domains/messages';
-
-type ProgressEventLike = { event: { currentTarget: { response: string } } };
 
 function bodyFromChunks(chunks: string[]): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
@@ -137,7 +133,9 @@ describe('messages service', () => {
   });
 
   it('addInputToMessage throws when no valid message received', async () => {
-    vi.spyOn(api, 'post').mockResolvedValueOnce(undefined as never);
+    globalThis.fetch = vi.fn(
+      async () => new Response(bodyFromChunks([]), { status: 200 })
+    ) as typeof fetch;
 
     await expect(
       addInputToMessage({
@@ -149,8 +147,8 @@ describe('messages service', () => {
     ).rejects.toThrow('No valid message received from stream');
   });
 
-  it('addInputToMessage returns parsed message from SSE stream', async () => {
-    const chunk = JSON.stringify({
+  it('addInputToMessage returns the last successfully parsed Message', async () => {
+    const chunkA = JSON.stringify({
       id: 'm3',
       createdAt: '2024-01-01',
       createdBy: 'u1',
@@ -159,19 +157,35 @@ describe('messages service', () => {
       messageThreadId: 't1',
       values: [],
     });
+    const chunkB = JSON.stringify({
+      id: 'm3',
+      createdAt: '2024-01-01',
+      createdBy: 'u1',
+      hasComments: false,
+      createdByUserId: 'u1',
+      messageThreadId: 't1',
+      values: [
+        {
+          id: 'v1',
+          name: 'x',
+          type: 'INPUT',
+          value: 'y',
+          channels: {},
+          createdAt: '2024-01-01',
+          createdBy: 'me',
+          createdByUserId: 'me',
+        },
+      ],
+    });
 
-    vi.spyOn(api, 'post').mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      async (_url: string, _payload: any, cfg?: any) => {
-        const cb = cfg?.onDownloadProgress as
-          | ((e: ProgressEventLike) => void)
-          | undefined;
-        cb?.({
-          event: { currentTarget: { response: `data:${chunk}\n\n` } },
-        });
-        return undefined as unknown as never;
-      }
-    );
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          bodyFromChunks([`data: ${chunkA}\n\n`, `data: ${chunkB}\n\n`]),
+          { status: 200 }
+        )
+    ) as unknown as typeof fetch;
+    globalThis.fetch = fetchMock;
 
     const result = await addInputToMessage({
       messageId: 'm1',
@@ -179,6 +193,32 @@ describe('messages service', () => {
       value: 'v',
       channels: null,
     });
+
+    // Last frame wins (final message after streaming completes).
     expect(result.id).toBe('m3');
+    expect(result.values?.length).toBe(1);
+
+    const [rawUrl, init] = (fetchMock as unknown as ReturnType<typeof vi.fn>)
+      .mock.calls[0] as [string, RequestInit];
+    expect(rawUrl).toBe('https://api.test/messages/m1/values');
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>).Accept).toBe(
+      'text/event-stream'
+    );
+  });
+
+  it('addInputToMessage rejects when the server returns a non-2xx status', async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response('err', { status: 500 })
+    ) as typeof fetch;
+
+    await expect(
+      addInputToMessage({
+        messageId: 'm1',
+        name: 'test',
+        value: 'v',
+        channels: null,
+      })
+    ).rejects.toThrow(/status 500/);
   });
 });

--- a/src/domains/messages/__tests__/service.spec.ts
+++ b/src/domains/messages/__tests__/service.spec.ts
@@ -1,16 +1,24 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { api } from '@/platform/api';
 
-const { mockGetMessages, mockMessageElementParse } = vi.hoisted(() => ({
+const {
+  mockGetMessages,
+  mockPostMessage,
+  mockMessageElementParse,
+  mockGetAccessToken,
+} = vi.hoisted(() => ({
   mockGetMessages: vi.fn(),
+  mockPostMessage: vi.fn(),
   mockMessageElementParse: vi.fn((data: unknown) => data),
+  mockGetAccessToken: vi.fn(async () => 'test-token'),
 }));
 
 vi.mock('@smartspace/api-client', () => ({
   ChatApi: {
     getSmartSpaceChatAPI: () => ({
       messageThreadsThreadMessagesIdMessages: mockGetMessages,
+      messagesThreadMessages: mockPostMessage,
     }),
   },
   ChatZod: {
@@ -19,12 +27,16 @@ vi.mock('@smartspace/api-client', () => ({
         data: {
           element: {
             parse: mockMessageElementParse,
+            shape: {
+              values: { element: { parse: vi.fn((d: unknown) => d) } },
+              errors: { element: { parse: vi.fn((d: unknown) => d) } },
+            },
           },
         },
       },
     },
   },
-  AXIOS_INSTANCE: {},
+  AXIOS_INSTANCE: { defaults: { baseURL: 'https://api.test' } },
 }));
 vi.mock('@/platform/validation', () => ({
   parseOrThrow: vi.fn((_schema: unknown, data: unknown) => data),
@@ -32,8 +44,17 @@ vi.mock('@/platform/validation', () => ({
 
 vi.mock('@/platform/log', () => ({
   ssDebug: vi.fn(),
+  ssInfo: vi.fn(),
   ssWarn: vi.fn(),
   ssError: vi.fn(),
+}));
+
+vi.mock('@/platform/auth', () => ({
+  getAuthAdapter: () => ({ getAccessToken: mockGetAccessToken }),
+}));
+
+vi.mock('@/platform/auth/scopes', () => ({
+  getApiScopes: () => ['scope.read'],
 }));
 
 import {
@@ -44,7 +65,22 @@ import {
 
 type ProgressEventLike = { event: { currentTarget: { response: string } } };
 
+function bodyFromChunks(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
 describe('messages service', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
   it('fetchMessages returns mapped list', async () => {
     const envelope = {
       data: [
@@ -65,35 +101,39 @@ describe('messages service', () => {
     expect(res[0].id).toBe('m1');
   });
 
-  it('postMessage posts to /messages and resolves when the request completes', async () => {
-    const postSpy = vi
-      .spyOn(api, 'post')
-      .mockResolvedValueOnce(undefined as never);
+  it('postMessage POSTs JSON and returns the parsed Message body', async () => {
+    const real = {
+      id: 'real-7',
+      createdAt: '2024-01-01T00:00:00Z',
+      createdBy: 'Server',
+      createdByUserId: 'u1',
+      hasComments: false,
+      messageThreadId: 't1',
+      errors: [],
+      values: [],
+    };
+    mockPostMessage.mockResolvedValueOnce({ data: real });
 
-    await expect(
-      postMessage({
-        workSpaceId: 'w',
-        threadId: 't1',
-        contentList: [{ type: 'text', text: 'hi' } as never],
-      })
-    ).resolves.toBeUndefined();
+    const result = await postMessage({
+      workSpaceId: 'w',
+      threadId: 't1',
+      contentList: [{ type: 'text', text: 'hi' } as never],
+    });
 
-    expect(postSpy).toHaveBeenCalledOnce();
-    const [url, payload] = postSpy.mock.calls[0];
-    expect(url).toBe('/messages');
-    expect((payload as { messageThreadId: string }).messageThreadId).toBe('t1');
-    postSpy.mockRestore();
+    expect(result.id).toBe('real-7');
+
+    expect(mockPostMessage).toHaveBeenCalledOnce();
+    const [body] = mockPostMessage.mock.calls[0];
+    expect(body.messageThreadId).toBe('t1');
+    expect(body.workSpaceId).toBe('w');
+    expect(body.inputs[0].name).toBe('prompt');
   });
 
-  it('postMessage rejects when the underlying request fails', async () => {
-    const networkError = new Error('Network failure');
-    const postSpy = vi.spyOn(api, 'post').mockRejectedValueOnce(networkError);
-
+  it('postMessage propagates errors from the request', async () => {
+    mockPostMessage.mockRejectedValueOnce(new Error('boom'));
     await expect(
       postMessage({ workSpaceId: 'w', threadId: 't1' })
-    ).rejects.toBe(networkError);
-
-    postSpy.mockRestore();
+    ).rejects.toThrow('boom');
   });
 
   it('addInputToMessage throws when no valid message received', async () => {

--- a/src/domains/messages/__tests__/streamThreadMessages.spec.ts
+++ b/src/domains/messages/__tests__/streamThreadMessages.spec.ts
@@ -1,0 +1,390 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockMessageElementParse,
+  mockValueElementParse,
+  mockErrorElementParse,
+  mockGetAccessToken,
+} = vi.hoisted(() => ({
+  mockMessageElementParse: vi.fn((data: unknown) => data),
+  mockValueElementParse: vi.fn((data: unknown) => data),
+  mockErrorElementParse: vi.fn((data: unknown) => data),
+  mockGetAccessToken: vi.fn(async () => 'test-token'),
+}));
+
+vi.mock('@smartspace/api-client', () => ({
+  ChatApi: {
+    getSmartSpaceChatAPI: () => ({
+      messageThreadsThreadMessagesIdMessages: vi.fn(),
+    }),
+  },
+  ChatZod: {
+    messageThreadsThreadMessagesIdMessagesResponse: {
+      shape: {
+        data: {
+          element: {
+            parse: mockMessageElementParse,
+            shape: {
+              values: { element: { parse: mockValueElementParse } },
+              errors: { element: { parse: mockErrorElementParse } },
+            },
+          },
+        },
+      },
+    },
+  },
+  AXIOS_INSTANCE: { defaults: { baseURL: 'https://api.test' } },
+}));
+
+vi.mock('@/platform/validation', () => ({
+  parseOrThrow: vi.fn((_schema: unknown, data: unknown) => data),
+}));
+
+vi.mock('@/platform/log', () => ({
+  ssDebug: vi.fn(),
+  ssInfo: vi.fn(),
+  ssWarn: vi.fn(),
+  ssError: vi.fn(),
+}));
+
+vi.mock('@/platform/auth', () => ({
+  getAuthAdapter: () => ({ getAccessToken: mockGetAccessToken }),
+}));
+
+vi.mock('@/platform/auth/scopes', () => ({
+  getApiScopes: () => ['scope.read'],
+}));
+
+import { streamThreadMessages } from '@/domains/messages';
+
+function bodyFromChunks(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+function dto(id: string, text: string) {
+  return {
+    id,
+    createdAt: '2024-01-01T00:00:00Z',
+    createdBy: 'bot',
+    createdByUserId: 'bot',
+    hasComments: false,
+    messageThreadId: 't1',
+    errors: [],
+    values: [
+      {
+        id: `${id}-v1`,
+        name: 'response',
+        type: 'Output',
+        value: text,
+        channels: {},
+        createdAt: '2024-01-01T00:00:00Z',
+        createdBy: 'bot',
+        createdByUserId: 'bot',
+      },
+    ],
+  };
+}
+
+describe('streamThreadMessages', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    mockMessageElementParse.mockClear();
+    mockMessageElementParse.mockImplementation((data: unknown) => data);
+    mockValueElementParse.mockClear();
+    mockValueElementParse.mockImplementation((data: unknown) => data);
+    mockErrorElementParse.mockClear();
+    mockErrorElementParse.mockImplementation((data: unknown) => data);
+    mockGetAccessToken.mockClear();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns not-found when server responds 404', async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response(null, { status: 404 }) as unknown as Response
+    ) as typeof fetch;
+
+    const result = await streamThreadMessages({
+      threadId: 't1',
+      signal: new AbortController().signal,
+      onSnapshot: () => {
+        throw new Error('should not be called');
+      },
+      onMessage: () => {
+        throw new Error('should not be called');
+      },
+    });
+
+    expect(result).toEqual({ status: 'not-found' });
+  });
+
+  it('delivers snapshot, per-message upserts, and thread summaries on snapshot + terminal frames', async () => {
+    const threadRunning = {
+      id: 't1',
+      workSpaceId: 'w1',
+      name: 'My Thread',
+      totalMessages: 2,
+      favorited: false,
+      isFlowRunning: true,
+      createdAt: '2024-01-01T00:00:00Z',
+      createdByUserId: 'u1',
+      lastUpdatedAt: '2024-01-01T00:00:00Z',
+      lastUpdatedByUserId: 'u1',
+    };
+    const threadDone = { ...threadRunning, isFlowRunning: false };
+
+    const snapshotFrame = `data: ${JSON.stringify({
+      snapshot: [dto('m1', 'hi'), dto('m2', 'world')],
+      thread: threadRunning,
+      terminal: false,
+    })}\n\n`;
+    const upsertFrame = `data: ${JSON.stringify({
+      messageId: 'm2',
+      message: dto('m2', 'world!'),
+      terminal: false,
+    })}\n\n`;
+    // Real backend terminal frame: message is null and the thread summary
+    // carries the authoritative isFlowRunning: false.
+    const terminalFrame = `data: ${JSON.stringify({
+      messageId: 'm2',
+      message: null,
+      terminal: true,
+      thread: threadDone,
+    })}\n\n`;
+
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(
+          bodyFromChunks([snapshotFrame, upsertFrame, terminalFrame]),
+          { status: 200 }
+        )
+    ) as typeof fetch;
+
+    const snapshots: Array<{ count: number }> = [];
+    const upserts: Array<{ messageId: string; terminal: boolean }> = [];
+    const threadCalls: Array<{ isFlowRunning: boolean }> = [];
+
+    const result = await streamThreadMessages({
+      threadId: 't1',
+      signal: new AbortController().signal,
+      onSnapshot: (messages) => snapshots.push({ count: messages.length }),
+      onMessage: (messageId, _m, terminal) =>
+        upserts.push({ messageId, terminal }),
+      onThread: (thread) =>
+        threadCalls.push({ isFlowRunning: thread.isFlowRunning }),
+    });
+
+    expect(snapshots).toEqual([{ count: 2 }]);
+    expect(upserts).toEqual([{ messageId: 'm2', terminal: false }]);
+    expect(threadCalls).toEqual([
+      { isFlowRunning: true },
+      { isFlowRunning: false },
+    ]);
+    expect(result).toEqual({ status: 'completed' });
+  });
+
+  it('attaches bearer token to the GET and targets the thread endpoint', async () => {
+    const fetchMock = vi.fn(
+      async () => new Response(bodyFromChunks([]), { status: 200 })
+    ) as unknown as typeof fetch;
+    globalThis.fetch = fetchMock;
+
+    await streamThreadMessages({
+      threadId: 't1',
+      signal: new AbortController().signal,
+      onSnapshot: () => undefined,
+      onMessage: () => undefined,
+    });
+
+    const [rawUrl, init] = (fetchMock as unknown as ReturnType<typeof vi.fn>)
+      .mock.calls[0] as [string, RequestInit];
+    expect(rawUrl).toBe('https://api.test/MessageThreads/t1/messages/stream');
+    expect(rawUrl).not.toContain('since=');
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer test-token');
+    expect(headers.Accept).toBe('text/event-stream');
+  });
+
+  it('throws on non-2xx non-404 responses', async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response('nope', { status: 500 })
+    ) as typeof fetch;
+
+    await expect(
+      streamThreadMessages({
+        threadId: 't1',
+        signal: new AbortController().signal,
+        onSnapshot: () => undefined,
+        onMessage: () => undefined,
+      })
+    ).rejects.toThrow(/status 500/);
+  });
+
+  it('emits onMessage for chunk #0 and onDelta for appended outputs', async () => {
+    const threadRunning = {
+      id: 't1',
+      workSpaceId: 'w1',
+      name: 'Thread',
+      totalMessages: 1,
+      favorited: false,
+      isFlowRunning: true,
+      createdAt: '2024-01-01T00:00:00Z',
+      createdByUserId: 'u1',
+      lastUpdatedAt: '2024-01-01T00:00:00Z',
+      lastUpdatedByUserId: 'u1',
+    };
+    const threadDone = { ...threadRunning, isFlowRunning: false };
+
+    // Chunk #0: full Message (inputs present, outputs empty).
+    const messageFrame = `data: ${JSON.stringify({
+      messageId: 'm1',
+      message: {
+        ...dto('m1', ''),
+        values: [
+          {
+            id: 'm1-prompt',
+            name: 'prompt',
+            type: 'Input',
+            value: 'hello',
+            channels: {},
+            createdAt: '2024-01-01T00:00:00Z',
+            createdBy: 'user',
+            createdByUserId: 'u1',
+          },
+        ],
+      },
+      terminal: false,
+      thread: threadRunning,
+    })}\n\n`;
+
+    // Chunk #1: cumulative delta carrying the response output so far.
+    const deltaFrame1 = `data: ${JSON.stringify({
+      delta: {
+        messageId: 'm1',
+        outputs: [
+          {
+            id: 'm1-o1',
+            name: 'response',
+            type: 'Output',
+            value: 'Hel',
+            channels: {},
+            createdAt: '2024-01-01T00:00:00Z',
+            createdBy: 'bot',
+            createdByUserId: 'bot',
+          },
+        ],
+        errors: [],
+      },
+      terminal: false,
+    })}\n\n`;
+
+    // Chunk #2: cumulative delta with the same (name, type) extended.
+    const deltaFrame2 = `data: ${JSON.stringify({
+      delta: {
+        messageId: 'm1',
+        outputs: [
+          {
+            id: 'm1-o1',
+            name: 'response',
+            type: 'Output',
+            value: 'Hello',
+            channels: {},
+            createdAt: '2024-01-01T00:00:00Z',
+            createdBy: 'bot',
+            createdByUserId: 'bot',
+          },
+        ],
+        errors: [],
+      },
+      terminal: false,
+    })}\n\n`;
+
+    // Terminal: null message, thread summary with isFlowRunning: false.
+    const terminalFrame = `data: ${JSON.stringify({
+      messageId: 'm1',
+      message: null,
+      terminal: true,
+      thread: threadDone,
+    })}\n\n`;
+
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(
+          bodyFromChunks([
+            messageFrame,
+            deltaFrame1,
+            deltaFrame2,
+            terminalFrame,
+          ]),
+          { status: 200 }
+        )
+    ) as typeof fetch;
+
+    const messageCalls: Array<{ id: string; outputCount: number }> = [];
+    const deltaCalls: Array<{
+      id: string;
+      outputCount: number;
+      firstValue: unknown;
+    }> = [];
+    const threadCalls: Array<{ running: boolean }> = [];
+
+    await streamThreadMessages({
+      threadId: 't1',
+      signal: new AbortController().signal,
+      onSnapshot: () => undefined,
+      onMessage: (id, msg) =>
+        messageCalls.push({
+          id,
+          outputCount:
+            msg.values?.filter((v) => v.type === ('Output' as unknown))
+              .length ?? 0,
+        }),
+      onDelta: (id, delta) =>
+        deltaCalls.push({
+          id,
+          outputCount: delta.outputs.length,
+          firstValue: delta.outputs[0]?.value,
+        }),
+      onThread: (thread) => threadCalls.push({ running: thread.isFlowRunning }),
+    });
+
+    expect(messageCalls).toEqual([{ id: 'm1', outputCount: 0 }]);
+    expect(deltaCalls).toEqual([
+      { id: 'm1', outputCount: 1, firstValue: 'Hel' },
+      { id: 'm1', outputCount: 1, firstValue: 'Hello' },
+    ]);
+    expect(threadCalls).toEqual([{ running: true }, { running: false }]);
+  });
+
+  it('skips malformed JSON frames without aborting the stream', async () => {
+    const bad = `data: {not valid json}\n\n`;
+    const good = `data: ${JSON.stringify({
+      messageId: 'm1',
+      message: dto('m1', 'ok'),
+      terminal: true,
+    })}\n\n`;
+
+    globalThis.fetch = vi.fn(
+      async () => new Response(bodyFromChunks([bad, good]), { status: 200 })
+    ) as typeof fetch;
+
+    const received: Array<string> = [];
+    await streamThreadMessages({
+      threadId: 't1',
+      signal: new AbortController().signal,
+      onSnapshot: () => undefined,
+      onMessage: (messageId) => received.push(messageId),
+    });
+
+    expect(received).toEqual(['m1']);
+  });
+});

--- a/src/domains/messages/index.ts
+++ b/src/domains/messages/index.ts
@@ -4,4 +4,4 @@ export * from './mutations';
 export { messagesListOptions, useMessages } from './queries';
 export { messagesKeys, messagesMutationsKeys } from './queryKeys';
 export * from './service';
-
+export { useThreadMessageStream } from './threadStream';

--- a/src/domains/messages/mapper.ts
+++ b/src/domains/messages/mapper.ts
@@ -4,7 +4,7 @@ import type { z } from 'zod';
 import { utcDate } from '@/shared/utils/dateFromApi';
 
 import { MessageValueType } from './enums';
-import { Message } from './model';
+import { Message, MessageValue } from './model';
 
 const {
   messageThreadsThreadMessagesIdMessagesResponse: messagesResponseSchema,
@@ -12,6 +12,10 @@ const {
 
 type MessagesResponseDto = z.infer<typeof messagesResponseSchema>;
 type MessageDto = MessagesResponseDto['data'][number];
+type MessageValueDto = NonNullable<MessageDto['values']>[number];
+type MessageErrorDto = NonNullable<MessageDto['errors']>[number];
+
+export type MessageError = NonNullable<Message['errors']>[number];
 
 const toChannelNumber = (value: unknown): number => {
   if (typeof value === 'number') return value;
@@ -29,6 +33,26 @@ const normalizeChannels = (
     Object.entries(channels).map(([key, val]) => [key, toChannelNumber(val)])
   );
 
+export function mapMessageValueDtoToModel(dto: MessageValueDto): MessageValue {
+  return {
+    id: dto.id,
+    name: dto.name,
+    type: dto.type as unknown as MessageValueType,
+    value: dto.value,
+    channels: normalizeChannels(dto.channels ?? {}),
+    createdAt: utcDate(dto.createdAt),
+    createdBy: dto.createdBy ?? '',
+    createdByUserId: dto.createdByUserId ?? undefined,
+  };
+}
+
+export function mapMessageErrorDtoToModel(dto: MessageErrorDto): MessageError {
+  return {
+    ...dto,
+    data: dto.data as string | null | undefined,
+  };
+}
+
 export function mapMessageDtoToModel(dto: MessageDto): Message {
   return {
     id: dto.id ?? undefined,
@@ -37,26 +61,40 @@ export function mapMessageDtoToModel(dto: MessageDto): Message {
     hasComments: dto.hasComments ?? false,
     createdByUserId: dto.createdByUserId ?? undefined,
     messageThreadId: dto.messageThreadId ?? undefined,
-    errors:
-      dto.errors?.map((e) => ({
-        ...e,
-        data: e.data as string | null | undefined,
-      })) ?? undefined,
-    values: dto.values
-      ? dto.values.map((v) => ({
-          id: v.id,
-          name: v.name,
-          type: v.type as unknown as MessageValueType,
-          value: v.value,
-          channels: normalizeChannels(v.channels ?? {}),
-          createdAt: utcDate(v.createdAt),
-          createdBy: v.createdBy ?? '',
-          createdByUserId: v.createdByUserId ?? undefined,
-        }))
-      : undefined,
+    errors: dto.errors?.map(mapMessageErrorDtoToModel) ?? undefined,
+    values: dto.values?.map(mapMessageValueDtoToModel),
   };
 }
 
 export function mapMessagesDtoToModels(dto: MessageDto[]): Message[] {
   return dto.map(mapMessageDtoToModel);
+}
+
+/**
+ * Merge a streaming delta into a message. `outputs` is a cumulative snapshot
+ * keyed by `(name, type)` per the SSE protocol — when an output streams from
+ * "He" → "Hel" → "Hello" we receive three deltas each carrying the full
+ * text-so-far, so we replace by key rather than appending. Errors aren't
+ * documented as cumulative, so we append them.
+ */
+export function applyDeltaToMessage(
+  target: Message,
+  delta: { outputs: MessageValue[]; errors: MessageError[] }
+): Message {
+  if (!delta.outputs.length && !delta.errors.length) return target;
+  const nextValues = (target.values ?? []).slice();
+  for (const incoming of delta.outputs) {
+    const idx = nextValues.findIndex(
+      (v) => v.name === incoming.name && v.type === incoming.type
+    );
+    if (idx === -1) nextValues.push(incoming);
+    else nextValues[idx] = incoming;
+  }
+  return {
+    ...target,
+    values: nextValues,
+    errors: delta.errors.length
+      ? [...(target.errors ?? []), ...delta.errors]
+      : target.errors,
+  };
 }

--- a/src/domains/messages/mutations.ts
+++ b/src/domains/messages/mutations.ts
@@ -4,7 +4,11 @@ import { toast } from 'sonner';
 import { useUserDisplayName, useUserId } from '@/platform/auth/session';
 
 import { FileInfo } from '@/domains/files';
-import { setThreadRunningInLists, threadsKeys } from '@/domains/threads';
+import {
+  type MessageThread,
+  setThreadRunningInLists,
+  threadsKeys,
+} from '@/domains/threads';
 
 import { MessageValueType } from './enums';
 import { Message, MessageContentItem } from './model';
@@ -132,6 +136,20 @@ export function useSendMessage() {
           ? withoutOptimistic
           : [...withoutOptimistic, realMessage];
       });
+
+      // POST returned successfully — the server has accepted the message
+      // and the flow is now running. Mirror that in the detail cache so:
+      //   1. The composer doesn't briefly drop its "running" indicator
+      //      between mutation resolution and the SignalR receiveThreadUpdate
+      //      broadcast (which can lag by a few hundred ms).
+      //   2. The thread SSE gate (which reads this value) opens immediately
+      //      instead of waiting for SignalR to flip it.
+      // SignalR / SSE thread frames will overwrite this with the authoritative
+      // value as they arrive.
+      qc.setQueryData<MessageThread>(
+        threadsKeys.detail(workspaceId, threadId),
+        (old) => (old ? { ...old, isFlowRunning: true } : old)
+      );
 
       // Reconcile thread list ordering / last-message preview and thread detail
       // (isFlowRunning). Message content continues to arrive via the thread SSE.

--- a/src/domains/messages/mutations.ts
+++ b/src/domains/messages/mutations.ts
@@ -4,6 +4,7 @@ import { toast } from 'sonner';
 import { useUserDisplayName, useUserId } from '@/platform/auth/session';
 
 import { FileInfo } from '@/domains/files';
+import { setThreadRunningInLists } from '@/domains/threads';
 import { threadsKeys } from '@/domains/threads/queryKeys';
 
 import { MessageValueType } from './enums';
@@ -90,18 +91,19 @@ export function useSendMessage() {
         optimistic,
       ]);
 
-      // Optimistically mark thread as running so the loading indicator shows immediately
-      qc.setQueryData(
-        threadsKeys.detail(workspaceId, threadId),
-        (old: unknown) =>
-          old && typeof old === 'object' ? { ...old, isFlowRunning: true } : old
-      );
+      // Light up the sidebar's running indicator instantly. We patch the
+      // thread-list caches only — NOT the detail cache, which gates the
+      // thread SSE (that value must stay server-confirmed so we don't open
+      // the SSE before the backend has actually started the flow). The
+      // composer's spinner is already covered by `mutation.isPending`.
+      setThreadRunningInLists(qc, workspaceId, threadId, true);
 
       // cancel in-flight refetches for this list so they don't race the optimistic insert
       await qc.cancelQueries({ queryKey: messagesKeys.list(threadId) });
 
+      let realMessage: Message;
       try {
-        await postMessage({
+        realMessage = await postMessage({
           workSpaceId: workspaceId,
           threadId,
           contentList,
@@ -109,24 +111,31 @@ export function useSendMessage() {
           variables,
         });
       } catch (err) {
-        // rollback: remove optimistics and clear optimistic isFlowRunning
+        // rollback: remove optimistics, undo the running flag in lists
         qc.setQueryData<Message[]>(messagesKeys.list(threadId), (old = []) =>
           old.filter((x) => !x.optimistic)
         );
-        qc.setQueryData(
-          threadsKeys.detail(workspaceId, threadId),
-          (old: unknown) =>
-            old && typeof old === 'object'
-              ? { ...old, isFlowRunning: false }
-              : old
-        );
+        setThreadRunningInLists(qc, workspaceId, threadId, false);
         toast.error('There was an error posting your message');
         throw err;
       }
 
+      // Replace the optimistic temp-id entry with the server-authoritative
+      // Message we just got back. If the thread SSE already added the same
+      // id (from its snapshot frame), keep its copy — it's at least as fresh
+      // as ours — and just drop the optimistic.
+      qc.setQueryData<Message[]>(messagesKeys.list(threadId), (old = []) => {
+        const withoutOptimistic = old.filter((m) => !m.optimistic);
+        const alreadyPresent = withoutOptimistic.some(
+          (m) => m.id === realMessage.id
+        );
+        return alreadyPresent
+          ? withoutOptimistic
+          : [...withoutOptimistic, realMessage];
+      });
+
       // Reconcile thread list ordering / last-message preview and thread detail
-      // (isFlowRunning). The messages list itself is driven by SignalR
-      // ReceiveThreadUpdate -> mergeFetchedWithOptimistics, so don't invalidate it here.
+      // (isFlowRunning). Message content continues to arrive via the thread SSE.
       qc.invalidateQueries({
         predicate: (query) => {
           const k = query.queryKey as unknown[];

--- a/src/domains/messages/mutations.ts
+++ b/src/domains/messages/mutations.ts
@@ -4,8 +4,7 @@ import { toast } from 'sonner';
 import { useUserDisplayName, useUserId } from '@/platform/auth/session';
 
 import { FileInfo } from '@/domains/files';
-import { setThreadRunningInLists } from '@/domains/threads';
-import { threadsKeys } from '@/domains/threads/queryKeys';
+import { setThreadRunningInLists, threadsKeys } from '@/domains/threads';
 
 import { MessageValueType } from './enums';
 import { Message, MessageContentItem } from './model';

--- a/src/domains/messages/service.ts
+++ b/src/domains/messages/service.ts
@@ -5,7 +5,6 @@ import {
   SignalR,
 } from '@smartspace/api-client';
 
-import { api } from '@/platform/api';
 import { getAuthAdapter } from '@/platform/auth';
 import { getApiScopes } from '@/platform/auth/scopes';
 import { parseOrThrow } from '@/platform/validation';
@@ -55,7 +54,11 @@ export async function fetchMessages(
   return mapMessagesDtoToModels(parsed.data);
 }
 
-// Send structured input (e.g. form values) to a specific message
+// Send structured input (e.g. form values) to a specific message. The server
+// streams an `IAsyncEnumerable<Message>` of intermediate states and a final
+// state — we read the stream to completion and return the last successfully
+// parsed Message. Used by sandbox / iterative-input flows; the standard chat
+// send path uses `postMessage` + the thread SSE instead.
 export async function addInputToMessage({
   messageId,
   name,
@@ -67,42 +70,48 @@ export async function addInputToMessage({
   value: unknown;
   channels: Record<string, number> | null;
 }): Promise<Message> {
-  let result: Message | null = null;
+  const baseUrl = (AXIOS_INSTANCE.defaults.baseURL ?? '').replace(/\/$/, '');
+  const token = await getAuthAdapter().getAccessToken({
+    silentOnly: true,
+    scopes: getApiScopes(),
+  });
 
-  await api.post(
-    `/messages/${messageId}/values`,
-    { name, value, channels },
-    {
-      adapter: 'xhr',
-      headers: { Accept: 'text/event-stream' },
-      onDownloadProgress: (event) => {
-        const xhr = event.event?.currentTarget as XMLHttpRequest | undefined;
-        const raw = String(xhr?.response ?? '');
-        // Split by server-sent event message delimiter and normalize "data:" prefix
-        const chunks = raw
-          .split('\n\n')
-          .map((c) => c.trim())
-          .filter(Boolean);
-        const last = chunks[chunks.length - 1] || '';
-        const dataLine = last.startsWith('data:') ? last.slice(5).trim() : last;
-        if (!dataLine) return;
-        try {
-          const parsed = JSON.parse(dataLine);
-          coerceMessageDto(parsed);
-          const dto = messagesResponseSchema.shape.data.element.parse(parsed);
-          result = mapMessageDtoToModel(dto);
-        } catch (error) {
-          // Ignore incomplete JSON frames; wait for more data
-        }
-      },
-    }
-  );
+  const response = await fetch(`${baseUrl}/messages/${messageId}/values`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'text/event-stream',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ name, value, channels }),
+  });
 
-  if (!result) {
-    throw new Error('No valid message received from stream');
+  if (!response.ok) {
+    throw new Error(
+      `POST /messages/${messageId}/values failed with status ${response.status}`
+    );
+  }
+  if (!response.body) {
+    throw new Error('POST /messages/:id/values returned no body');
   }
 
-  return result;
+  const messageDtoSchema = messagesResponseSchema.shape.data.element;
+  let last: Message | null = null;
+  for await (const frame of parseSseStream(response.body)) {
+    if (!frame.data) continue;
+    try {
+      const parsed = JSON.parse(frame.data) as Record<string, unknown>;
+      coerceMessageDto(parsed);
+      last = mapMessageDtoToModel(messageDtoSchema.parse(parsed));
+    } catch {
+      // Ignore malformed/partial frames; the next frame will bring fresh state.
+    }
+  }
+
+  if (!last) {
+    throw new Error('No valid message received from stream');
+  }
+  return last;
 }
 
 // Post a new user message to a thread (supports content + files + variables).

--- a/src/domains/messages/service.ts
+++ b/src/domains/messages/service.ts
@@ -1,12 +1,27 @@
-import { ChatApi, ChatZod } from '@smartspace/api-client';
+import {
+  AXIOS_INSTANCE,
+  ChatApi,
+  ChatZod,
+  SignalR,
+} from '@smartspace/api-client';
 
 import { api } from '@/platform/api';
+import { getAuthAdapter } from '@/platform/auth';
+import { getApiScopes } from '@/platform/auth/scopes';
 import { parseOrThrow } from '@/platform/validation';
 
 import { FileInfo } from '@/domains/files';
 
-import { mapMessageDtoToModel, mapMessagesDtoToModels } from './mapper';
-import type { Message, MessageContentItem } from './model';
+import { parseSseStream } from '@/shared/utils/sseStream';
+
+import {
+  mapMessageDtoToModel,
+  mapMessageErrorDtoToModel,
+  mapMessageValueDtoToModel,
+  mapMessagesDtoToModels,
+  type MessageError,
+} from './mapper';
+import type { Message, MessageContentItem, MessageValue } from './model';
 
 const {
   messageThreadsThreadMessagesIdMessagesResponse: messagesResponseSchema,
@@ -91,8 +106,10 @@ export async function addInputToMessage({
 }
 
 // Post a new user message to a thread (supports content + files + variables).
-// Resolves when the server has finished processing the request. Cache updates
-// are driven by SignalR ReceiveThreadUpdate, not by the SSE stream payload.
+// Returns a single JSON Message synchronously — the row created server-side
+// with inputs populated and id assigned. The flow continues running in the
+// background; output deltas arrive on the thread SSE keyed by the returned id.
+// Callers should reconcile their optimistic temp-id entry with this Message.
 export async function postMessage({
   workSpaceId,
   threadId,
@@ -105,7 +122,7 @@ export async function postMessage({
   contentList?: MessageContentItem[];
   files?: FileInfo[];
   variables?: Record<string, unknown>;
-}): Promise<void> {
+}): Promise<Message> {
   const inputs: Array<{ name: string; value: unknown }> = [];
 
   if (contentList?.length) {
@@ -126,15 +143,171 @@ export async function postMessage({
     });
   }
 
-  const payload = {
+  const response = await chatApi.messagesThreadMessages({
     inputs,
     messageThreadId: threadId,
-    workspaceId: workSpaceId,
+    workSpaceId,
     variables,
-  };
-
-  await api.post(`/messages`, payload, {
-    adapter: 'xhr',
-    headers: { Accept: 'text/event-stream' },
   });
+
+  const raw = response.data as unknown as Record<string, unknown>;
+  if (!raw) throw new Error('POST /messages returned no body');
+  coerceMessageDto(raw);
+  return mapMessageDtoToModel(
+    messagesResponseSchema.shape.data.element.parse(raw)
+  );
+}
+
+/**
+ * A streaming delta for an existing message. `outputs` is a cumulative
+ * snapshot keyed by `(name, type)` — when an output streams from "He" → "Hel"
+ * → "Hello" we receive three deltas each carrying the full text-so-far, so
+ * the caller replaces by key rather than appending. Errors aren't documented
+ * as cumulative.
+ */
+export type MessageDelta = {
+  outputs: MessageValue[];
+  errors: MessageError[];
+};
+
+export type ThreadStreamHandlers = {
+  /** First frame: authoritative snapshot of the thread's messages. */
+  onSnapshot: (messages: Message[]) => void;
+  /**
+   * Full-message frame. Fires when a brand-new message is added to the thread
+   * (inputs populated, outputs empty). Subsequent updates to that same
+   * message arrive via `onDelta`.
+   */
+  onMessage: (messageId: string, message: Message, terminal: boolean) => void;
+  /**
+   * Cumulative update for an existing message. `outputs` is keyed by
+   * (name, type) — replace, do not append.
+   */
+  onDelta?: (messageId: string, delta: MessageDelta, terminal: boolean) => void;
+  /**
+   * Authoritative thread summary attached to the initial snapshot frame (so
+   * late joiners see the current `isFlowRunning`) and to terminal frames
+   * (so the client learns flow-complete even if SignalR flakes). Not present
+   * on intermediate chunk frames.
+   */
+  onThread?: (thread: SignalR.MessageThreadSummary) => void;
+};
+
+export type StreamThreadMessagesResult =
+  | { status: 'completed' }
+  | { status: 'not-found' };
+
+/**
+ * Tails the GET `/MessageThreads/{threadId}/messages/stream` SSE endpoint.
+ * Every viewer of a thread (initiator + other tabs + late joiners) subscribes
+ * here. The first frame is a full snapshot; subsequent frames carry full-
+ * message frames (chunk #0 for a brand-new message) or cumulative deltas
+ * (chunks #1+, keyed by name+type). On reconnect we just reopen — the next
+ * snapshot frame brings authoritative state, no cursor handshake needed.
+ * Returns `not-found` when the server responds 404 (thread does not exist).
+ */
+export async function streamThreadMessages({
+  threadId,
+  signal,
+  onSnapshot,
+  onMessage,
+  onDelta,
+  onThread,
+}: {
+  threadId: string;
+  signal: AbortSignal;
+} & ThreadStreamHandlers): Promise<StreamThreadMessagesResult> {
+  const baseUrl = (AXIOS_INSTANCE.defaults.baseURL ?? '').replace(/\/$/, '');
+  const token = await getAuthAdapter().getAccessToken({
+    silentOnly: true,
+    scopes: getApiScopes(),
+  });
+
+  const response = await fetch(
+    `${baseUrl}/MessageThreads/${threadId}/messages/stream`,
+    {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'text/event-stream',
+      },
+      signal,
+    }
+  );
+
+  if (response.status === 404) return { status: 'not-found' };
+  if (!response.ok) {
+    throw new Error(`Stream open failed with status ${response.status}`);
+  }
+  if (!response.body) {
+    throw new Error('Stream response missing body');
+  }
+
+  const messageDtoSchema = messagesResponseSchema.shape.data.element;
+  const valueDtoSchema = messageDtoSchema.shape.values.element;
+  const errorDtoSchema = messageDtoSchema.shape.errors.element;
+
+  for await (const frame of parseSseStream(response.body, signal)) {
+    if (!frame.data) continue;
+    try {
+      const envelope = JSON.parse(frame.data) as {
+        snapshot?: unknown[];
+        messageId?: string;
+        message?: unknown;
+        delta?: {
+          messageId?: string;
+          outputs?: unknown[];
+          errors?: unknown[];
+        } | null;
+        terminal?: boolean;
+        thread?: SignalR.MessageThreadSummary | null;
+      };
+      const terminal = Boolean(envelope.terminal);
+
+      // `thread` is attached to initial snapshot + terminal frames. Surface
+      // it first so the cache flips `isFlowRunning` before we apply the
+      // message payload that came with the same frame.
+      if (envelope.thread && onThread) {
+        onThread(envelope.thread);
+      }
+
+      if (Array.isArray(envelope.snapshot)) {
+        const messages = envelope.snapshot.map((raw) => {
+          const obj = raw as Record<string, unknown>;
+          coerceMessageDto(obj);
+          return mapMessageDtoToModel(messageDtoSchema.parse(obj));
+        });
+        onSnapshot(messages);
+        continue;
+      }
+
+      // Chunk #0 for a new message — full Message payload.
+      if (envelope.messageId && envelope.message) {
+        const raw = envelope.message as Record<string, unknown>;
+        coerceMessageDto(raw);
+        const message = mapMessageDtoToModel(messageDtoSchema.parse(raw));
+        onMessage(envelope.messageId, message, terminal);
+        continue;
+      }
+
+      // Chunks #1+ for an existing message — cumulative deltas.
+      if (envelope.delta) {
+        const targetId = envelope.delta.messageId ?? envelope.messageId;
+        if (!targetId || !onDelta) continue;
+        const outputs = (envelope.delta.outputs ?? []).map((raw) => {
+          const obj = raw as Record<string, unknown>;
+          if (obj.createdByUserId == null) obj.createdByUserId = '';
+          return mapMessageValueDtoToModel(valueDtoSchema.parse(obj));
+        });
+        const errors = (envelope.delta.errors ?? []).map((raw) =>
+          mapMessageErrorDtoToModel(errorDtoSchema.parse(raw))
+        );
+        onDelta(targetId, { outputs, errors }, terminal);
+      }
+    } catch {
+      // Ignore malformed/partial frames — server will send another envelope.
+    }
+  }
+
+  return { status: 'completed' };
 }

--- a/src/domains/messages/threadStream.ts
+++ b/src/domains/messages/threadStream.ts
@@ -1,3 +1,4 @@
+import { SignalR } from '@smartspace/api-client';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 
@@ -13,7 +14,8 @@ import { Message } from './model';
 import { messagesKeys } from './queryKeys';
 import { type MessageDelta, streamThreadMessages } from './service';
 
-const RECONNECT_BACKOFF_MS = 500;
+const RECONNECT_BASE_DELAY_MS = 500;
+const RECONNECT_MAX_DELAY_MS = 10_000;
 
 /**
  * Holds the thread-scoped SSE open while `enabled` is true (typically bound
@@ -40,7 +42,7 @@ export function useThreadMessageStream(
     const byCreatedAt = (a: Message, b: Message) =>
       a.createdAt.getTime() - b.createdAt.getTime();
 
-    const applySnapshot = (messages: Message[]) => {
+    const onSnapshot = (messages: Message[]) => {
       const sorted = [...messages].sort(byCreatedAt);
       qc.setQueryData<Message[]>(messagesKeys.list(threadId), (old = []) => {
         const optimistics = old.filter((m) => m.optimistic);
@@ -48,7 +50,7 @@ export function useThreadMessageStream(
       });
     };
 
-    const applyUpsert = (messageId: string, message: Message) => {
+    const onUpsert = (messageId: string, message: Message) => {
       qc.setQueryData<Message[]>(messagesKeys.list(threadId), (old = []) => {
         const stable = old.filter((m) => !m.optimistic);
         const optimistics = old.filter((m) => m.optimistic);
@@ -61,7 +63,7 @@ export function useThreadMessageStream(
       });
     };
 
-    const applyDelta = (messageId: string, delta: MessageDelta) => {
+    const onDelta = (messageId: string, delta: MessageDelta) => {
       if (!delta.outputs.length && !delta.errors.length) return;
       qc.setQueryData<Message[]>(messagesKeys.list(threadId), (old = []) => {
         const idx = old.findIndex((m) => m.id === messageId);
@@ -75,48 +77,52 @@ export function useThreadMessageStream(
       });
     };
 
-    const handleSnapshot = (messages: Message[]) => applySnapshot(messages);
-    const handleUpsert = (messageId: string, message: Message) =>
-      applyUpsert(messageId, message);
-    const handleDelta = (messageId: string, delta: MessageDelta) =>
-      applyDelta(messageId, delta);
-
     // Thread summary comes on the initial snapshot (late joiner catch-up) and
     // terminal frames (authoritative flow-complete). Treat these as the source
     // of truth for isFlowRunning — SignalR receiveThreadUpdate is a hint and
     // may silently drop if Azure SignalR flakes.
-    const handleThread = (
-      summary: Parameters<
-        NonNullable<Parameters<typeof streamThreadMessages>[0]['onThread']>
-      >[0]
-    ) => {
+    const onThread = (summary: SignalR.MessageThreadSummary) => {
       applyThreadToCache(qc, mapSignalRThreadSummaryToModel(summary));
     };
 
+    const backoffFor = (attempt: number) =>
+      Math.min(RECONNECT_MAX_DELAY_MS, RECONNECT_BASE_DELAY_MS * 2 ** attempt);
+
     const run = async () => {
+      let attempt = 0;
       while (!state.stopped && !controller.signal.aborted) {
         try {
           const result = await streamThreadMessages({
             threadId,
             signal: controller.signal,
-            onSnapshot: handleSnapshot,
-            onMessage: handleUpsert,
-            onDelta: handleDelta,
-            onThread: handleThread,
+            onSnapshot,
+            onMessage: onUpsert,
+            onDelta,
+            onThread,
           });
           if (result.status === 'not-found') {
             ssInfo('sse', 'thread stream 404', { threadId });
             return;
           }
-          if (state.stopped || controller.signal.aborted) return;
+          // Server closed the connection cleanly. The terminal frame's
+          // `onThread` (if any) has already flipped `isFlowRunning: false`
+          // in the cache, which will trip the gate and trigger cleanup. Exit
+          // immediately so we don't open a redundant connection while the
+          // useEffect cleanup is still propagating.
+          return;
         } catch (err) {
           if (controller.signal.aborted) return;
           ssWarn('sse', 'thread stream error — reconnecting', {
             threadId,
+            attempt,
             error: err instanceof Error ? err.message : String(err),
           });
+          const delay = backoffFor(attempt);
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, delay);
+          });
+          attempt += 1;
         }
-        await new Promise((r) => setTimeout(r, RECONNECT_BACKOFF_MS));
       }
     };
 

--- a/src/domains/messages/threadStream.ts
+++ b/src/domains/messages/threadStream.ts
@@ -1,0 +1,130 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
+
+import { ssInfo, ssWarn } from '@/platform/log';
+
+import {
+  applyThreadToCache,
+  mapSignalRThreadSummaryToModel,
+} from '@/domains/threads';
+
+import { applyDeltaToMessage } from './mapper';
+import { Message } from './model';
+import { messagesKeys } from './queryKeys';
+import { type MessageDelta, streamThreadMessages } from './service';
+
+const RECONNECT_BACKOFF_MS = 500;
+
+/**
+ * Holds the thread-scoped SSE open while `enabled` is true (typically bound
+ * to the thread's server-confirmed `isFlowRunning`). The first frame is an
+ * authoritative snapshot; subsequent frames carry full-message frames or
+ * cumulative deltas. On transient errors we reopen and let the next snapshot
+ * resync state — no cursor/since handshake. All work is aborted when the
+ * threadId changes, `enabled` flips false, or the hook unmounts.
+ */
+export function useThreadMessageStream(
+  threadId: string | undefined,
+  enabled: boolean
+): void {
+  const qc = useQueryClient();
+
+  useEffect(() => {
+    if (!threadId || !enabled) return;
+
+    const controller = new AbortController();
+    const state = { stopped: false };
+
+    // Sort ascending by createdAt so the UI renders oldest → newest regardless
+    // of the order the server emits.
+    const byCreatedAt = (a: Message, b: Message) =>
+      a.createdAt.getTime() - b.createdAt.getTime();
+
+    const applySnapshot = (messages: Message[]) => {
+      const sorted = [...messages].sort(byCreatedAt);
+      qc.setQueryData<Message[]>(messagesKeys.list(threadId), (old = []) => {
+        const optimistics = old.filter((m) => m.optimistic);
+        return [...sorted, ...optimistics];
+      });
+    };
+
+    const applyUpsert = (messageId: string, message: Message) => {
+      qc.setQueryData<Message[]>(messagesKeys.list(threadId), (old = []) => {
+        const stable = old.filter((m) => !m.optimistic);
+        const optimistics = old.filter((m) => m.optimistic);
+        const idx = stable.findIndex((m) => m.id === messageId);
+        const nextStable =
+          idx === -1
+            ? [...stable, message].sort(byCreatedAt)
+            : stable.map((m, i) => (i === idx ? message : m));
+        return [...nextStable, ...optimistics];
+      });
+    };
+
+    const applyDelta = (messageId: string, delta: MessageDelta) => {
+      if (!delta.outputs.length && !delta.errors.length) return;
+      qc.setQueryData<Message[]>(messagesKeys.list(threadId), (old = []) => {
+        const idx = old.findIndex((m) => m.id === messageId);
+        // No base message yet — ignore. The full `message` frame either
+        // hasn't arrived or we missed it; the next reconnect snapshot will
+        // bring authoritative state.
+        if (idx === -1) return old;
+        const copy = old.slice();
+        copy[idx] = applyDeltaToMessage(old[idx], delta);
+        return copy;
+      });
+    };
+
+    const handleSnapshot = (messages: Message[]) => applySnapshot(messages);
+    const handleUpsert = (messageId: string, message: Message) =>
+      applyUpsert(messageId, message);
+    const handleDelta = (messageId: string, delta: MessageDelta) =>
+      applyDelta(messageId, delta);
+
+    // Thread summary comes on the initial snapshot (late joiner catch-up) and
+    // terminal frames (authoritative flow-complete). Treat these as the source
+    // of truth for isFlowRunning — SignalR receiveThreadUpdate is a hint and
+    // may silently drop if Azure SignalR flakes.
+    const handleThread = (
+      summary: Parameters<
+        NonNullable<Parameters<typeof streamThreadMessages>[0]['onThread']>
+      >[0]
+    ) => {
+      applyThreadToCache(qc, mapSignalRThreadSummaryToModel(summary));
+    };
+
+    const run = async () => {
+      while (!state.stopped && !controller.signal.aborted) {
+        try {
+          const result = await streamThreadMessages({
+            threadId,
+            signal: controller.signal,
+            onSnapshot: handleSnapshot,
+            onMessage: handleUpsert,
+            onDelta: handleDelta,
+            onThread: handleThread,
+          });
+          if (result.status === 'not-found') {
+            ssInfo('sse', 'thread stream 404', { threadId });
+            return;
+          }
+          if (state.stopped || controller.signal.aborted) return;
+        } catch (err) {
+          if (controller.signal.aborted) return;
+          ssWarn('sse', 'thread stream error — reconnecting', {
+            threadId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+        await new Promise((r) => setTimeout(r, RECONNECT_BACKOFF_MS));
+      }
+    };
+
+    void run();
+
+    return () => {
+      state.stopped = true;
+      controller.abort();
+    };
+  }, [threadId, enabled, qc]);
+}

--- a/src/domains/threads/__tests__/cache.spec.ts
+++ b/src/domains/threads/__tests__/cache.spec.ts
@@ -1,0 +1,146 @@
+import { QueryClient } from '@tanstack/react-query';
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyThreadToCache,
+  setThreadRunningInLists,
+} from '@/domains/threads/cache';
+import type { MessageThread, ThreadsResponse } from '@/domains/threads/model';
+import { threadsKeys } from '@/domains/threads/queryKeys';
+
+const thread = (over: Partial<MessageThread> = {}): MessageThread => ({
+  id: 't1',
+  workSpaceId: 'w1',
+  name: 'Thread',
+  createdAt: new Date('2024-01-01T00:00:00Z'),
+  createdBy: 'User',
+  createdByUserId: 'u1',
+  isFlowRunning: false,
+  lastUpdatedAt: new Date('2024-01-01T00:00:00Z'),
+  lastUpdatedByUserId: 'u1',
+  totalMessages: 0,
+  pinned: false,
+  ...over,
+});
+
+describe('applyThreadToCache', () => {
+  it('writes to detail cache so observers re-render without a refetch', () => {
+    const qc = new QueryClient();
+    qc.setQueryData<MessageThread>(
+      threadsKeys.detail('w1', 't1'),
+      thread({ isFlowRunning: false })
+    );
+
+    applyThreadToCache(qc, thread({ isFlowRunning: true }));
+
+    const detail = qc.getQueryData<MessageThread>(
+      threadsKeys.detail('w1', 't1')
+    );
+    expect(detail?.isFlowRunning).toBe(true);
+  });
+
+  it('splices into a non-infinite list cache and returns true', () => {
+    const qc = new QueryClient();
+    qc.setQueryData<ThreadsResponse>(threadsKeys.list('w1'), {
+      data: [thread({ isFlowRunning: false })],
+      total: 1,
+    });
+
+    const found = applyThreadToCache(qc, thread({ isFlowRunning: true }));
+
+    expect(found).toBe(true);
+    const list = qc.getQueryData<ThreadsResponse>(threadsKeys.list('w1'));
+    expect(list?.data[0].isFlowRunning).toBe(true);
+  });
+
+  it('splices into infinite-list pages', () => {
+    const qc = new QueryClient();
+    const infiniteKey = threadsKeys.list('w1', { take: 30 });
+    qc.setQueryData(infiniteKey, {
+      pages: [{ data: [thread({ isFlowRunning: false })], total: 1 }],
+      pageParams: [0],
+    });
+
+    const found = applyThreadToCache(qc, thread({ isFlowRunning: true }));
+
+    expect(found).toBe(true);
+    const cached = qc.getQueryData<{
+      pages: ThreadsResponse[];
+    }>(infiniteKey);
+    expect(cached?.pages[0].data[0].isFlowRunning).toBe(true);
+  });
+
+  it('returns false when no list cache contains the thread (caller can refetch)', () => {
+    const qc = new QueryClient();
+    qc.setQueryData<ThreadsResponse>(threadsKeys.list('w1'), {
+      data: [thread({ id: 'other' })],
+      total: 1,
+    });
+
+    const found = applyThreadToCache(qc, thread({ id: 't1' }));
+
+    expect(found).toBe(false);
+  });
+
+  it("only touches list caches matching the thread's workspace", () => {
+    const qc = new QueryClient();
+    qc.setQueryData<ThreadsResponse>(threadsKeys.list('w1'), {
+      data: [thread({ workSpaceId: 'w1', isFlowRunning: false })],
+      total: 1,
+    });
+    qc.setQueryData<ThreadsResponse>(threadsKeys.list('w2'), {
+      data: [thread({ workSpaceId: 'w2', id: 't1', isFlowRunning: false })],
+      total: 1,
+    });
+
+    applyThreadToCache(qc, thread({ workSpaceId: 'w1', isFlowRunning: true }));
+
+    const w1 = qc.getQueryData<ThreadsResponse>(threadsKeys.list('w1'));
+    const w2 = qc.getQueryData<ThreadsResponse>(threadsKeys.list('w2'));
+    expect(w1?.data[0].isFlowRunning).toBe(true);
+    expect(w2?.data[0].isFlowRunning).toBe(false);
+  });
+});
+
+describe('setThreadRunningInLists', () => {
+  it('flips isFlowRunning in lists without touching the detail cache', () => {
+    const qc = new QueryClient();
+    qc.setQueryData<MessageThread>(
+      threadsKeys.detail('w1', 't1'),
+      thread({ isFlowRunning: false })
+    );
+    qc.setQueryData<ThreadsResponse>(threadsKeys.list('w1'), {
+      data: [thread({ isFlowRunning: false })],
+      total: 1,
+    });
+
+    setThreadRunningInLists(qc, 'w1', 't1', true);
+
+    // Detail cache stays untouched — gates the SSE, must remain
+    // server-confirmed.
+    expect(
+      qc.getQueryData<MessageThread>(threadsKeys.detail('w1', 't1'))
+        ?.isFlowRunning
+    ).toBe(false);
+    // Sidebar list reflects the optimistic flip.
+    expect(
+      qc.getQueryData<ThreadsResponse>(threadsKeys.list('w1'))?.data[0]
+        .isFlowRunning
+    ).toBe(true);
+  });
+
+  it('rolls back when toggled false', () => {
+    const qc = new QueryClient();
+    qc.setQueryData<ThreadsResponse>(threadsKeys.list('w1'), {
+      data: [thread({ isFlowRunning: true })],
+      total: 1,
+    });
+
+    setThreadRunningInLists(qc, 'w1', 't1', false);
+
+    expect(
+      qc.getQueryData<ThreadsResponse>(threadsKeys.list('w1'))?.data[0]
+        .isFlowRunning
+    ).toBe(false);
+  });
+});

--- a/src/domains/threads/cache.ts
+++ b/src/domains/threads/cache.ts
@@ -1,0 +1,145 @@
+import type { QueryClient } from '@tanstack/react-query';
+
+import type { MessageThread, ThreadsResponse } from './model';
+import { threadsKeys } from './queryKeys';
+
+type ThreadsListCache =
+  | ThreadsResponse
+  | { pages: ThreadsResponse[]; pageParams: unknown[] };
+
+/**
+ * Write a freshly-observed thread (from SignalR or an SSE thread frame)
+ * directly into the relevant query caches so subscribers paint without a
+ * refetch roundtrip.
+ *
+ * - Merges into `threadsKeys.detail(workspaceId, thread.id)`.
+ * - Splices into every threads-list cache for the workspace, handling both
+ *   finite `ThreadsResponse` and infinite `{ pages, pageParams }` shapes.
+ *
+ * Returns `true` when the thread was found in at least one list cache.
+ * Callers that need to surface brand-new threads (e.g. another user just
+ * created one) can fall back to invalidating the list queries when this
+ * returns `false`.
+ */
+export function applyThreadToCache(
+  qc: QueryClient,
+  thread: MessageThread
+): boolean {
+  qc.setQueryData<MessageThread>(
+    threadsKeys.detail(thread.workSpaceId, thread.id),
+    (old) => ({ ...(old ?? thread), ...thread })
+  );
+
+  let foundInList = false;
+  qc.setQueriesData<ThreadsListCache>(
+    {
+      predicate: (query) => {
+        const k = query.queryKey as unknown[];
+        return (
+          k[0] === 'threads' &&
+          k[1] === 'list' &&
+          (k[2] as { workspaceId?: string } | undefined)?.workspaceId ===
+            thread.workSpaceId
+        );
+      },
+    },
+    (old) => {
+      if (!old) return old;
+      if ('pages' in old && Array.isArray(old.pages)) {
+        let changed = false;
+        const pages = old.pages.map((page) => {
+          if (!page?.data) return page;
+          const idx = page.data.findIndex((t) => t.id === thread.id);
+          if (idx === -1) return page;
+          changed = true;
+          foundInList = true;
+          const nextData = page.data.slice();
+          nextData[idx] = { ...nextData[idx], ...thread };
+          return { ...page, data: nextData };
+        });
+        return changed ? { ...old, pages } : old;
+      }
+      const list = old as ThreadsResponse;
+      if (!list.data) return old;
+      const idx = list.data.findIndex((t) => t.id === thread.id);
+      if (idx === -1) return old;
+      foundInList = true;
+      const nextData = list.data.slice();
+      nextData[idx] = { ...nextData[idx], ...thread };
+      return { ...list, data: nextData };
+    }
+  );
+
+  return foundInList;
+}
+
+/**
+ * Invalidate every threads-list cache for a workspace. Use as a fallback when
+ * `applyThreadToCache` didn't find the thread in any list (i.e. brand-new
+ * thread) so the sidebar refetches and picks it up.
+ */
+export function invalidateWorkspaceThreadLists(
+  qc: QueryClient,
+  workspaceId: string
+): void {
+  qc.invalidateQueries({
+    predicate: (query) => {
+      const k = query.queryKey as unknown[];
+      return (
+        k[0] === 'threads' &&
+        k[1] === 'list' &&
+        (k[2] as { workspaceId?: string } | undefined)?.workspaceId ===
+          workspaceId
+      );
+    },
+  });
+}
+
+/**
+ * Optimistically flip a single thread's `isFlowRunning` flag in every list
+ * cache for the workspace (finite + infinite shapes). Used by `useSendMessage`
+ * so the sidebar dot lights up instantly without waiting for SignalR — the
+ * detail cache is intentionally NOT touched here, since that value gates the
+ * thread SSE and must stay server-confirmed.
+ */
+export function setThreadRunningInLists(
+  qc: QueryClient,
+  workspaceId: string,
+  threadId: string,
+  running: boolean
+): void {
+  qc.setQueriesData<ThreadsListCache>(
+    {
+      predicate: (query) => {
+        const k = query.queryKey as unknown[];
+        return (
+          k[0] === 'threads' &&
+          k[1] === 'list' &&
+          (k[2] as { workspaceId?: string } | undefined)?.workspaceId ===
+            workspaceId
+        );
+      },
+    },
+    (old) => {
+      if (!old) return old;
+      const patch = (t: MessageThread): MessageThread =>
+        t.id === threadId ? { ...t, isFlowRunning: running } : t;
+      if ('pages' in old && Array.isArray(old.pages)) {
+        let changed = false;
+        const pages = old.pages.map((page) => {
+          if (!page?.data) return page;
+          const idx = page.data.findIndex((t) => t.id === threadId);
+          if (idx === -1) return page;
+          changed = true;
+          return { ...page, data: page.data.map(patch) };
+        });
+        return changed ? { ...old, pages } : old;
+      }
+      const list = old as ThreadsResponse;
+      if (!list.data) return old;
+      const idx = list.data.findIndex((t) => t.id === threadId);
+      if (idx === -1) return old;
+      return { ...list, data: list.data.map(patch) };
+    }
+  );
+}

--- a/src/domains/threads/index.ts
+++ b/src/domains/threads/index.ts
@@ -1,4 +1,10 @@
+export {
+  applyThreadToCache,
+  invalidateWorkspaceThreadLists,
+  setThreadRunningInLists,
+} from './cache';
 export { ensureDraftThread, removeDraftThread } from './draftThread';
+export { mapSignalRThreadSummaryToModel } from './mapper';
 export type { MessageThread, ThreadsResponse } from './model';
 export * from './mutations';
 export {

--- a/src/domains/threads/mapper.ts
+++ b/src/domains/threads/mapper.ts
@@ -1,4 +1,4 @@
-import { ChatZod } from '@smartspace/api-client';
+import { ChatZod, SignalR } from '@smartspace/api-client';
 import type { z } from 'zod';
 
 import { utcDate } from '@/shared/utils/dateFromApi';
@@ -34,4 +34,26 @@ export function mapThreadsResponseDtoToModel(
   dto: ThreadsResponseDto
 ): ThreadsResponse {
   return { data: dto.data.map(mapThreadDtoToModel), total: dto.total };
+}
+
+/**
+ * Map the SignalR `receiveThreadUpdate` payload to our thread model so we
+ * can write it straight into the query cache without invalidating + refetching.
+ */
+export function mapSignalRThreadSummaryToModel(
+  summary: SignalR.MessageThreadSummary
+): MessageThread {
+  return {
+    id: summary.id,
+    createdAt: utcDate(summary.createdAt),
+    createdBy: summary.createdBy ?? '',
+    createdByUserId: summary.createdByUserId,
+    isFlowRunning: summary.isFlowRunning,
+    lastUpdatedAt: utcDate(summary.lastUpdatedAt),
+    lastUpdatedByUserId: summary.lastUpdatedByUserId,
+    name: summary.name ?? '',
+    totalMessages: summary.totalMessages,
+    pinned: summary.favorited,
+    workSpaceId: summary.workSpaceId,
+  };
 }

--- a/src/platform/realtime/RealtimeProvider.tsx
+++ b/src/platform/realtime/RealtimeProvider.tsx
@@ -104,9 +104,23 @@ export function RealtimeProvider({
       groupName: string,
       attempt = 0
     ): Promise<void> => {
-      if (!connection || !isConnected()) {
-        return; // lifecycle will re-join
+      if (!connection) return; // effect will retry once connection is built
+
+      // Wait out the initial connect. `onreconnected` handles the reconnect
+      // case; without this await the first joinGroup is silently dropped
+      // while conn.start() is still in flight and no rejoin fires on initial
+      // connect, leaving the client absent from the server's group.
+      if (!isConnected()) {
+        if (startPromise.current) {
+          try {
+            await startPromise.current;
+          } catch {
+            return;
+          }
+        }
+        if (!isConnected()) return;
       }
+
       try {
         const hub = createChatHub(connection);
         await hub[method](groupName);

--- a/src/platform/realtime/__tests__/RealtimeProvider.race.spec.tsx
+++ b/src/platform/realtime/__tests__/RealtimeProvider.race.spec.tsx
@@ -1,0 +1,111 @@
+/**
+ * Guards the "first joinGroup silently dropped while still Connecting" race.
+ *
+ * Before the fix, `subscribeToGroup` invoked the hub immediately. If the
+ * effect ran while `conn.start()` was still in flight (state === 'Connecting'),
+ * the bail-out branch returned silently. `onreconnected` only fires on
+ * reconnects, not initial connect, so the join never happened — the client
+ * stayed absent from the workspace group until something forced a reconnect.
+ */
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { invokeMock, ConnectionStub } = vi.hoisted(() => {
+  const invokeMock = vi.fn(async () => undefined);
+
+  class ConnectionStub {
+    state = 'Connecting';
+    connectionId = 'test';
+    invoke = invokeMock;
+    on = vi.fn();
+    off = vi.fn();
+    onreconnected = vi.fn();
+    onreconnecting = vi.fn();
+    onclose = vi.fn();
+    private resolveStart: (() => void) | null = null;
+
+    start = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          this.resolveStart = resolve;
+        })
+    );
+    stop = vi.fn(async () => undefined);
+
+    completeStart() {
+      this.state = 'Connected';
+      this.resolveStart?.();
+    }
+  }
+
+  return { invokeMock, ConnectionStub };
+});
+
+let conn: InstanceType<typeof ConnectionStub>;
+
+vi.mock('@microsoft/signalr', () => ({
+  HttpTransportType: { WebSockets: 1 },
+  HubConnectionState: { Connected: 'Connected' },
+  HubConnectionBuilder: class {
+    withUrl() {
+      return this;
+    }
+    withAutomaticReconnect() {
+      return this;
+    }
+    build() {
+      conn = new ConnectionStub();
+      return conn;
+    }
+  },
+}));
+
+import {
+  RealtimeProvider,
+  useRealtime,
+} from '@/platform/realtime/RealtimeProvider';
+
+const wrapper = (
+  getAccessToken = vi.fn(async () => 'tok')
+): React.FC<React.PropsWithChildren> =>
+  function Wrapper({ children }) {
+    return (
+      <RealtimeProvider
+        baseUrl="https://hub.test"
+        getAccessToken={getAccessToken}
+      >
+        {children}
+      </RealtimeProvider>
+    );
+  };
+
+describe('RealtimeProvider initial-connect race', () => {
+  beforeEach(() => {
+    invokeMock.mockClear();
+  });
+
+  afterEach(() => {
+    // Resolve any pending start promise so React Testing Library can clean up
+    conn?.completeStart();
+  });
+
+  it('does not invoke joinGroup until the connection is Connected', async () => {
+    const { result } = renderHook(() => useRealtime(), { wrapper: wrapper() });
+
+    // Fire-and-forget the subscribe. invokeWithRetry awaits startPromise
+    // before invoking, so JoinGroup must NOT have hit the wire yet while
+    // the connection is still in 'Connecting' state.
+    const subscribePromise = result.current.subscribeToGroup('workspace-1');
+    await Promise.resolve();
+    expect(invokeMock).not.toHaveBeenCalled();
+
+    // Flip the connection to Connected.
+    conn.completeStart();
+    await subscribePromise;
+
+    // Now JoinGroup should have been invoked exactly once with the workspace id.
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    expect(invokeMock).toHaveBeenCalledWith('JoinGroup', 'workspace-1');
+  });
+});

--- a/src/shared/utils/__tests__/sseStream.spec.ts
+++ b/src/shared/utils/__tests__/sseStream.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseSseStream } from '@/shared/utils/sseStream';
+
+function streamOf(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+async function collect(
+  body: ReadableStream<Uint8Array>,
+  signal?: AbortSignal
+): Promise<Array<{ id?: string; event?: string; data: string }>> {
+  const frames: Array<{ id?: string; event?: string; data: string }> = [];
+  for await (const frame of parseSseStream(body, signal)) frames.push(frame);
+  return frames;
+}
+
+describe('parseSseStream', () => {
+  it('yields a single data frame terminated by \\n\\n', async () => {
+    const frames = await collect(streamOf(['data: hello\n\n']));
+    expect(frames).toEqual([
+      { id: undefined, event: undefined, data: 'hello' },
+    ]);
+  });
+
+  it('joins multi-line data with \\n', async () => {
+    const frames = await collect(streamOf(['data: line1\ndata: line2\n\n']));
+    expect(frames[0].data).toBe('line1\nline2');
+  });
+
+  it('parses id, event, and data fields', async () => {
+    const frames = await collect(
+      streamOf(['id: cursor-1\nevent: chunk\ndata: {"x":1}\n\n'])
+    );
+    expect(frames).toEqual([
+      { id: 'cursor-1', event: 'chunk', data: '{"x":1}' },
+    ]);
+  });
+
+  it('handles frames split across chunk boundaries', async () => {
+    const frames = await collect(
+      streamOf(['data: par', 'tial', '-ok\n\ndata: next\n\n'])
+    );
+    expect(frames.map((f) => f.data)).toEqual(['partial-ok', 'next']);
+  });
+
+  it('flushes trailing frame without terminator', async () => {
+    const frames = await collect(streamOf(['data: tail']));
+    expect(frames).toEqual([{ id: undefined, event: undefined, data: 'tail' }]);
+  });
+
+  it('ignores comment lines starting with ":"', async () => {
+    const frames = await collect(streamOf([': keepalive\ndata: hi\n\n']));
+    expect(frames[0].data).toBe('hi');
+  });
+
+  it('normalizes CRLF line endings', async () => {
+    const frames = await collect(
+      streamOf(['data: one\r\n\r\ndata: two\r\n\r\n'])
+    );
+    expect(frames.map((f) => f.data)).toEqual(['one', 'two']);
+  });
+
+  it('stops when the signal is aborted', async () => {
+    const controller = new AbortController();
+    const body = new ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(new TextEncoder().encode('data: first\n\n'));
+        // Keep open — abort should end iteration.
+      },
+    });
+
+    const iter = parseSseStream(body, controller.signal);
+    const first = await iter.next();
+    expect(first.value?.data).toBe('first');
+
+    controller.abort();
+    const next = await iter.next();
+    expect(next.done).toBe(true);
+  });
+});

--- a/src/shared/utils/sseStream.ts
+++ b/src/shared/utils/sseStream.ts
@@ -1,0 +1,80 @@
+export type SseFrame = {
+  id?: string;
+  event?: string;
+  data: string;
+};
+
+/**
+ * Parses Server-Sent Event frames out of a ReadableStream<Uint8Array>.
+ *
+ * Implements the subset of the SSE spec we rely on: `id:`, `event:`, `data:`
+ * lines, with frames separated by a blank line. Multi-line `data:` fields are
+ * concatenated with `\n`. Comment lines (beginning with `:`) are ignored.
+ */
+export async function* parseSseStream(
+  body: ReadableStream<Uint8Array>,
+  signal?: AbortSignal
+): AsyncGenerator<SseFrame, void, void> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder('utf-8');
+  let buffer = '';
+
+  const onAbort = () => {
+    reader.cancel().catch(() => {
+      /* swallow */
+    });
+  };
+  signal?.addEventListener('abort', onAbort);
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      buffer = normalizeLineEndings(buffer);
+
+      let separatorIndex = buffer.indexOf('\n\n');
+      while (separatorIndex !== -1) {
+        const rawFrame = buffer.slice(0, separatorIndex);
+        buffer = buffer.slice(separatorIndex + 2);
+        const frame = parseFrame(rawFrame);
+        if (frame) yield frame;
+        separatorIndex = buffer.indexOf('\n\n');
+      }
+    }
+    // Flush any trailing frame without a terminating blank line
+    const trailing = buffer.trim();
+    if (trailing) {
+      const frame = parseFrame(trailing);
+      if (frame) yield frame;
+    }
+  } finally {
+    signal?.removeEventListener('abort', onAbort);
+    reader.releaseLock();
+  }
+}
+
+function normalizeLineEndings(s: string): string {
+  return s.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+function parseFrame(raw: string): SseFrame | null {
+  let id: string | undefined;
+  let event: string | undefined;
+  const dataLines: string[] = [];
+
+  for (const line of raw.split('\n')) {
+    if (!line || line.startsWith(':')) continue;
+    const colonIndex = line.indexOf(':');
+    const field = colonIndex === -1 ? line : line.slice(0, colonIndex);
+    let value = colonIndex === -1 ? '' : line.slice(colonIndex + 1);
+    if (value.startsWith(' ')) value = value.slice(1);
+
+    if (field === 'data') dataLines.push(value);
+    else if (field === 'event') event = value;
+    else if (field === 'id') id = value;
+  }
+
+  if (!dataLines.length && id === undefined && event === undefined) return null;
+  return { id, event, data: dataLines.join('\n') };
+}

--- a/src/ui/workspaces/useWorkspaceSubscriptions.ts
+++ b/src/ui/workspaces/useWorkspaceSubscriptions.ts
@@ -5,20 +5,15 @@ import { useNavigate } from '@tanstack/react-router';
 import { useWorkspaceRealtime } from '@/platform/realtime/useWorkspaceRealtime';
 import { useRouteIds } from '@/platform/routing/RouteIdsProvider';
 
-import {
-  type Comment,
-  commentsKeys,
-  mapSignalRCommentSummaryToModel,
-} from '@/domains/comments';
-import { useThreadMessageStream } from '@/domains/messages';
-import { messagesKeys } from '@/domains/messages/queryKeys';
+import { applyCommentToCache, commentsKeys } from '@/domains/comments';
+import { messagesKeys, useThreadMessageStream } from '@/domains/messages';
 import {
   applyThreadToCache,
   invalidateWorkspaceThreadLists,
   mapSignalRThreadSummaryToModel,
   threadDetailOptions,
+  threadsKeys,
 } from '@/domains/threads';
-import { threadsKeys } from '@/domains/threads/queryKeys';
 
 export function useWorkspaceSubscriptions() {
   // Derive ids from whichever workspace route is active: thread,
@@ -30,9 +25,10 @@ export function useWorkspaceSubscriptions() {
   const navigate = useNavigate();
 
   // Only hold the thread SSE open while the thread is actively running.
-  // The isFlowRunning flag is flipped optimistically by useSendMessage and
-  // canonically by SignalR's receiveThreadUpdate, so the stream opens/closes
-  // in sync with real backend state.
+  // `thread.isFlowRunning` here is server-confirmed: it's set by the initial
+  // detail GET, by SignalR's receiveThreadUpdate, or by the SSE's own thread
+  // frame. We deliberately don't optimistically flip it on send — the gate
+  // would open before the backend has actually started the flow.
   const { data: thread } = useQuery({
     ...threadDetailOptions({
       workspaceId: workspaceId || '',
@@ -70,31 +66,17 @@ export function useWorkspaceSubscriptions() {
       }
     },
     onCommentsUpdate: (summary) => {
-      // Splice the comment straight into the list cache. The previous handler
-      // invalidated `['comments', <threadId>]` which never matched the real
-      // key (`['comments', 'list', { threadId }]`), so comments weren't
-      // refetched at all on live updates.
-      const mapped = mapSignalRCommentSummaryToModel(summary);
-      const listKey = commentsKeys.list(summary.messageThreadId);
-      let applied = false;
-      qc.setQueryData<Comment[]>(listKey, (old) => {
-        if (!old) return old;
-        applied = true;
-        const idx = old.findIndex((c) => c.id === summary.id);
-        if (idx === -1) {
-          return [...old, mapped].sort(
-            (a, b) => a.createdAt.getTime() - b.createdAt.getTime()
-          );
-        }
-        const copy = old.slice();
-        copy[idx] = mapped;
-        return copy;
-      });
-      // If we've never fetched this thread's comments before, the cache
-      // entry doesn't exist yet — fall back to an invalidate so the next
-      // observer fetches fresh.
+      // The previous handler invalidated `['comments', <threadId>]` which
+      // never matched the real key (`['comments', 'list', { threadId }]`),
+      // so comments weren't refetched at all on live updates. Splice
+      // straight into the list cache via the shared helper, and fall back
+      // to invalidate when the user has never opened the comments panel
+      // (no cache entry to patch).
+      const applied = applyCommentToCache(qc, summary);
       if (!applied) {
-        qc.invalidateQueries({ queryKey: listKey });
+        qc.invalidateQueries({
+          queryKey: commentsKeys.list(summary.messageThreadId),
+        });
       }
     },
   });

--- a/src/ui/workspaces/useWorkspaceSubscriptions.ts
+++ b/src/ui/workspaces/useWorkspaceSubscriptions.ts
@@ -25,10 +25,11 @@ export function useWorkspaceSubscriptions() {
   const navigate = useNavigate();
 
   // Only hold the thread SSE open while the thread is actively running.
-  // `thread.isFlowRunning` here is server-confirmed: it's set by the initial
-  // detail GET, by SignalR's receiveThreadUpdate, or by the SSE's own thread
-  // frame. We deliberately don't optimistically flip it on send — the gate
-  // would open before the backend has actually started the flow.
+  // `thread.isFlowRunning` is set by the initial detail GET, by SignalR's
+  // receiveThreadUpdate, by the SSE's own thread frame, and (after a
+  // successful POST /messages) by useSendMessage — that last write is
+  // post-server-confirmation so the gate doesn't open against a flow the
+  // backend hasn't actually started yet.
   const { data: thread } = useQuery({
     ...threadDetailOptions({
       workspaceId: workspaceId || '',

--- a/src/ui/workspaces/useWorkspaceSubscriptions.ts
+++ b/src/ui/workspaces/useWorkspaceSubscriptions.ts
@@ -1,44 +1,101 @@
 // src/ui/workspaces/useWorkspaceSubscriptions.ts
-import { useQueryClient } from '@tanstack/react-query';
-import { useMatch, useNavigate } from '@tanstack/react-router';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
 
 import { useWorkspaceRealtime } from '@/platform/realtime/useWorkspaceRealtime';
+import { useRouteIds } from '@/platform/routing/RouteIdsProvider';
 
+import {
+  type Comment,
+  commentsKeys,
+  mapSignalRCommentSummaryToModel,
+} from '@/domains/comments';
+import { useThreadMessageStream } from '@/domains/messages';
 import { messagesKeys } from '@/domains/messages/queryKeys';
+import {
+  applyThreadToCache,
+  invalidateWorkspaceThreadLists,
+  mapSignalRThreadSummaryToModel,
+  threadDetailOptions,
+} from '@/domains/threads';
 import { threadsKeys } from '@/domains/threads/queryKeys';
 
 export function useWorkspaceSubscriptions() {
-  const match = useMatch({
-    from: '/_protected/workspace/$workspaceId/_layout/thread/$threadId',
-    shouldThrow: false,
-  });
-  const workspaceId = match?.params?.workspaceId;
-  const threadId = match?.params?.threadId;
+  // Derive ids from whichever workspace route is active: thread,
+  // workspace index, or the bare workspace layout. Matching only the
+  // thread route means the SignalR join never fires on the workspace
+  // home, so broadcasts reach zero clients for that tab.
+  const { workspaceId, threadId } = useRouteIds();
   const qc = useQueryClient();
   const navigate = useNavigate();
 
-  useWorkspaceRealtime(workspaceId, {
-    onThreadUpdate: (thread) => {
+  // Only hold the thread SSE open while the thread is actively running.
+  // The isFlowRunning flag is flipped optimistically by useSendMessage and
+  // canonically by SignalR's receiveThreadUpdate, so the stream opens/closes
+  // in sync with real backend state.
+  const { data: thread } = useQuery({
+    ...threadDetailOptions({
+      workspaceId: workspaceId || '',
+      threadId: threadId || '',
+    }),
+    enabled: !!workspaceId && !!threadId,
+  });
+  useThreadMessageStream(threadId || undefined, !!thread?.isFlowRunning);
+
+  useWorkspaceRealtime(workspaceId || undefined, {
+    onThreadUpdate: (summary) => {
       if (!workspaceId) return;
       // eslint-disable-next-line no-console
-      console.log('[SignalR] ReceiveThreadUpdate for thread:', thread.id);
-      qc.invalidateQueries({ queryKey: threadsKeys.list(workspaceId) });
-      qc.invalidateQueries({
-        queryKey: threadsKeys.detail(workspaceId, thread.id),
-      });
-      qc.invalidateQueries({ queryKey: messagesKeys.list(thread.id) });
+      console.log('[SignalR] ReceiveThreadUpdate for thread:', summary.id);
+
+      // SignalR is now a hint: the SSE's `thread` frame is authoritative for
+      // `isFlowRunning` on the thread the user is viewing. For other threads
+      // (no SSE open), SignalR still drives sidebar state — the direct cache
+      // write makes that instant regardless.
+      const foundInList = applyThreadToCache(
+        qc,
+        mapSignalRThreadSummaryToModel(summary)
+      );
+      if (!foundInList) invalidateWorkspaceThreadLists(qc, workspaceId);
+
+      // Mark messages stale for threads the user isn't actively viewing;
+      // the thread SSE handles the one they are viewing.
+      qc.invalidateQueries({ queryKey: messagesKeys.list(summary.id) });
     },
-    onThreadDeleted: (thread) => {
+    onThreadDeleted: (summary) => {
       if (!workspaceId) return;
       qc.invalidateQueries({ queryKey: threadsKeys.list(workspaceId) });
-      if (thread.id === threadId) {
+      if (summary.id === threadId) {
         navigate({ to: '/workspace/$workspaceId', params: { workspaceId } });
       }
     },
-    onCommentsUpdate: (comment) => {
-      qc.invalidateQueries({
-        queryKey: ['comments', comment.messageThreadId],
+    onCommentsUpdate: (summary) => {
+      // Splice the comment straight into the list cache. The previous handler
+      // invalidated `['comments', <threadId>]` which never matched the real
+      // key (`['comments', 'list', { threadId }]`), so comments weren't
+      // refetched at all on live updates.
+      const mapped = mapSignalRCommentSummaryToModel(summary);
+      const listKey = commentsKeys.list(summary.messageThreadId);
+      let applied = false;
+      qc.setQueryData<Comment[]>(listKey, (old) => {
+        if (!old) return old;
+        applied = true;
+        const idx = old.findIndex((c) => c.id === summary.id);
+        if (idx === -1) {
+          return [...old, mapped].sort(
+            (a, b) => a.createdAt.getTime() - b.createdAt.getTime()
+          );
+        }
+        const copy = old.slice();
+        copy[idx] = mapped;
+        return copy;
       });
+      // If we've never fetched this thread's comments before, the cache
+      // entry doesn't exist yet — fall back to an invalidate so the next
+      // observer fetches fresh.
+      if (!applied) {
+        qc.invalidateQueries({ queryKey: listKey });
+      }
     },
   });
 }


### PR DESCRIPTION
## Summary

Splits the chat data flow into two distinct channels and eliminates the invalidate→refetch roundtrips that were making indicators flicker:

- **Thread SSE** (`GET /MessageThreads/{id}/messages/stream`) is the **content channel**. Carries `snapshot`, full-message frames (chunk #0 with inputs populated), and **cumulative deltas** keyed by `(name, type)`. The terminal frame attaches the authoritative thread summary so flow state flips even if SignalR flakes. Gated on `thread.isFlowRunning` so idle threads don't hold an open connection.
- **SignalR is now coordination only.** `receiveThreadUpdate` writes the fresh `MessageThreadSummary` straight into detail + list caches via `applyThreadToCache`, and `receiveCommentsUpdate` splices the delivered `CommentSummary` into the comments list — both eliminating the previous invalidate → refetch roundtrip. (Also fixes a key-mismatch in `onCommentsUpdate` that was silently no-op'ing before — the invalidate targeted `['comments', <threadId>]` but the real cache key is `['comments', 'list', { threadId }]`.)
- **POST `/messages`** now hits the JSON endpoint via the SDK (`messagesThreadMessages`); the response is the server-authoritative initial Message used to swap the optimistic temp-id entry. Output content arrives via the thread SSE.
- **Workspace subscriptions:** `useWorkspaceSubscriptions` derives ids from `RouteIdsProvider` so the SignalR group join fires on the workspace home (not only when viewing a thread). `RealtimeProvider.invokeWithRetry` now awaits `startPromise.current` before invoking `joinGroup` — the initial join was being silently dropped while the hub was still in `Connecting` state, since `onreconnected` only fires on reconnects, not initial connect.
- **Optimistic UX:** the sidebar's running indicator is patched into the threads-list caches optimistically on send (detail cache stays server-confirmed so the SSE gate isn't tripped prematurely); the composer reads `mutation.isPending` so it flips instantly too.

## Channel split

| Concern | Channel | Latency target |
|---|---|---|
| Live message chunks in the thread you're viewing | SSE | sub-tick (server emits → frame parsed → render) |
| New message in a thread you're not viewing (sidebar preview, unread state) | SignalR → direct cache write | one SignalR roundtrip |
| Thread metadata: `isFlowRunning`, name, favourite, last-updated ordering | SignalR + SSE terminal frame (whichever first) | one roundtrip |
| Thread deleted | SignalR | one roundtrip |
| Comments | SignalR → direct cache splice | one roundtrip |
| Starting a new flow | POST `/messages` JSON | one HTTP call |

The thread SSE's `frame.thread` (on snapshot + terminal) is the authoritative source for `isFlowRunning` when the user is viewing a thread, so flow completion is no longer dependent on the SignalR broadcast reaching the client.

## Wire format handled

```ts
type ThreadStreamFrame = {
  snapshot?: Message[];                  // initial connection only
  messageId?: string;                    // present on chunk + terminal
  message?: Message | null;              // chunk #0 (full Message, inputs)
  delta?: { messageId, outputs, errors } // chunks #1+, cumulative by (name, type)
  terminal?: boolean;
  thread?: MessageThreadSummary;         // initial + terminal frames
};
```

Cumulative outputs are merged via [\`applyDeltaToMessage\`](src/domains/messages/mapper.ts) — replace by `(name, type)`, append if new. Errors are appended (not documented as cumulative).

## What got removed

- `?since=<cursor>` resume — backend's cumulative deltas mean the snapshot-on-reconnect already brings us up to date; cursor handshake was redundant. Hook and service have no cursor state.
- `receiveStreamStarted` / `receiveStreamCompleted` SignalR handlers — removed from the new SDK, no longer needed once every viewer holds the thread SSE open.

## Test coverage

49 test files, 191 tests, all passing.

New files:
- [\`src/shared/utils/sseStream.ts\`](src/shared/utils/sseStream.ts) + spec — generic `parseSseStream(body, signal)` async generator handling multi-line `data:`, CRLF, chunk boundaries, abort.
- [\`src/domains/messages/threadStream.ts\`](src/domains/messages/threadStream.ts) — `useThreadMessageStream(threadId, enabled)` hook.
- [\`src/domains/threads/cache.ts\`](src/domains/threads/cache.ts) — `applyThreadToCache`, `invalidateWorkspaceThreadLists`, `setThreadRunningInLists`.
- [\`src/domains/messages/__tests__/streamThreadMessages.spec.ts\`](src/domains/messages/__tests__/streamThreadMessages.spec.ts) — 5 tests covering 404, snapshot+upsert+thread+terminal flow, message → delta → terminal flow, request shape, malformed-frame skipping.
- New [\`applyDeltaToMessage\`](src/domains/messages/mapper.ts) tests covering "He → Hel → Hello" cumulative-replace and error append semantics.

## Test plan

- [ ] Send a message: composer + sidebar dot light up instantly.
- [ ] Response streams in token-by-token (or chunk-by-chunk depending on backend cadence) — DevTools Network → `/MessageThreads/{id}/messages/stream` shows frames arriving.
- [ ] Open the same thread in a second tab while a message is mid-flow — second tab sees in-progress state via SSE snapshot.
- [ ] Send a message while another user is on the same thread — they see the message + streaming response live.
- [ ] On thread end, all running indicators clear together (composer, sidebar, sidebar dot for thread item).
- [ ] Add a comment from another tab — receiving tab's comments drawer refetches without reload.
- [ ] Network blip mid-stream → SSE auto-reopens, snapshot replays the in-progress state, no duplicate frames.