### PR TITLE
fix(streaming): default missing channels to {} on streamed message values

### DIFF
--- a/src/domains/messages/service.ts
+++ b/src/domains/messages/service.ts
@@ -28,11 +28,16 @@ const {
 const chatApi = ChatApi.getSmartSpaceChatAPI();
 
 /** Backend sends null createdByUserId on system-generated values; Zod schema requires string. */
+function coerceMessageValueDto(v: Record<string, unknown>): void {
+  if (v.createdByUserId == null) v.createdByUserId = '';
+  if (v.channels == null) v.channels = {};
+}
+
 function coerceMessageDto(raw: Record<string, unknown>): void {
   if (raw.createdByUserId == null) raw.createdByUserId = '';
   if (Array.isArray(raw.values)) {
     for (const v of raw.values as Record<string, unknown>[]) {
-      if (v.createdByUserId == null) v.createdByUserId = '';
+      coerceMessageValueDto(v);
     }
   }
 }
@@ -305,7 +310,7 @@ export async function streamThreadMessages({
         if (!targetId || !onDelta) continue;
         const outputs = (envelope.delta.outputs ?? []).map((raw) => {
           const obj = raw as Record<string, unknown>;
-          if (obj.createdByUserId == null) obj.createdByUserId = '';
+          coerceMessageValueDto(obj);
           return mapMessageValueDtoToModel(valueDtoSchema.parse(obj));
         });
         const errors = (envelope.delta.errors ?? []).map((raw) =>


### PR DESCRIPTION
## Summary

- The new \`@smartspace/api-client\` (0.1.0-dev.b434a43+) tightened the \`MessageValue\` Zod schema to require \`channels: Record<string, number>\`.
- Streamed delta frames from the chat-api don't always include \`channels\`, so \`valueDtoSchema.parse\` throws inside the SSE loop in \`streamThreadMessages\`.
- The surrounding \`try/catch\` silently swallows the throw, so per-token deltas stop applying and only the terminal snapshot frame renders. Net symptom: \"I get the message but no streaming.\"

## Fix

Mirror the existing defensive coercion already used for \`createdByUserId\`: default \`channels\` to \`{}\` before the schema parse. Applied to both:
- the full-message DTO coercer (snapshot + chunk #0 message frames)
- the per-output coercer in the delta path

## Why a client-side patch and not a server fix

A defensive client-side coercion is safe and immediate. Long-term, the chat-api should always emit \`channels: {}\` on streamed deltas — but that's a separate change to coordinate with the SDK contract.

## Test plan

- [x] Verified locally: streaming now renders per-delta against develop's chat-api with the new SDK.
- [ ] CI passes (lint, typecheck, tests, build)

## Heads-up unrelated to this PR

The SDK bump commit \`bc483ca\` (PR #227) added a stray \`package-lock.json\` because the internal bump workflow uses npm. The repo is pnpm-only — that file should be removed in a follow-up, and the bump workflow updated to use pnpm.