### PR TITLE
fix(build): drop react manualChunks split causing useState crash

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -133,13 +133,12 @@ export default defineConfig(({ mode }) => ({
         manualChunks(id) {
           if (!id.includes('node_modules')) return;
 
-          // React core (imported everywhere)
-          if (
-            id.includes('/react/') ||
-            id.includes('/react-dom/') ||
-            id.includes('/scheduler/')
-          )
-            return 'react';
+          // Note: React core is intentionally NOT split into its own chunk.
+          // Doing so caused `Cannot read properties of undefined (reading 'useState')`
+          // in the vendor chunk at runtime — CJS-interop'd consumers (react-is,
+          // use-sync-external-store, prop-types, etc.) ended up in `vendor` and
+          // received an undefined React namespace when React lived in a sibling
+          // chunk. Letting Rollup co-locate React with its consumers fixes it.
 
           // UI libraries
           if (id.includes('/@mui/')) return 'mui';


### PR DESCRIPTION
## Summary
- Removes the `react`/`react-dom`/`scheduler` branch from `manualChunks` in `vite.config.mts`.
- Recent commit [`1fe16aa`](https://github.com/Smartspace-ai/Smartspace-app-public/commit/1fe16aa) split React into its own chunk. On the deployed build this caused `Uncaught TypeError: Cannot read properties of undefined (reading 'useState')` thrown from `vendor-*.js`, leaving the app stuck on the loading screen with no network requests.
- Local `pnpm run serve` was unaffected because Vite's dev server doesn't apply `manualChunks` — that config only runs during `vite build`. The dev/prod asymmetry is the fingerprint of a chunk-splitting bug.

## Why it broke
React consumers that don't match `/react/`, `/react-dom/`, or `/scheduler/` (e.g. `react-is`, `use-sync-external-store`, `prop-types`, plus any CJS dep that does `var React = require('react')`) landed in the catch-all `vendor` chunk. With React hoisted into a sibling chunk, Rollup's CJS-interop wrapping handed those consumers an undefined React namespace at evaluation time, so `React.useState` blew up.

The other feature-scoped chunks (mui, emotion, radix, tanstack, etc.) are kept — letting Rollup co-locate React with its consumers fixes the crash without losing the rest of the splitting benefits.

## Test plan
- [ ] `pnpm run build && pnpm run preview` locally and confirm the app boots past the loading screen (this reproduces the deployed crash on `develop`).
- [ ] Deploy to dev and verify the loading screen clears and network requests fire.
- [ ] Spot-check `dist/smartspace/assets/` for the absence of a `react-*.js` chunk and presence of the other feature chunks.