### PR TITLE
fix(streaming): stop SignalR overwriting viewed thread's isFlowRunning

### DIFF
--- a/src/domains/threads/__tests__/cache.spec.ts
+++ b/src/domains/threads/__tests__/cache.spec.ts
@@ -82,6 +82,35 @@ describe('applyThreadToCache', () => {
     expect(found).toBe(false);
   });
 
+  it('leaves the detail cache untouched when skipDetail is set', () => {
+    const qc = new QueryClient();
+    qc.setQueryData<MessageThread>(
+      threadsKeys.detail('w1', 't1'),
+      thread({ isFlowRunning: true })
+    );
+    qc.setQueryData<ThreadsResponse>(threadsKeys.list('w1'), {
+      data: [thread({ isFlowRunning: true })],
+      total: 1,
+    });
+
+    applyThreadToCache(qc, thread({ isFlowRunning: false }), {
+      skipDetail: true,
+    });
+
+    // Detail cache stays as-is — SSE remains authoritative for the viewed
+    // thread.
+    expect(
+      qc.getQueryData<MessageThread>(threadsKeys.detail('w1', 't1'))
+        ?.isFlowRunning
+    ).toBe(true);
+    // Sidebar list still reflects the SignalR hint so other tabs / list
+    // rows stay in sync.
+    expect(
+      qc.getQueryData<ThreadsResponse>(threadsKeys.list('w1'))?.data[0]
+        .isFlowRunning
+    ).toBe(false);
+  });
+
   it("only touches list caches matching the thread's workspace", () => {
     const qc = new QueryClient();
     qc.setQueryData<ThreadsResponse>(threadsKeys.list('w1'), {

--- a/src/domains/threads/cache.ts
+++ b/src/domains/threads/cache.ts
@@ -12,7 +12,8 @@ type ThreadsListCache =
  * directly into the relevant query caches so subscribers paint without a
  * refetch roundtrip.
  *
- * - Merges into `threadsKeys.detail(workspaceId, thread.id)`.
+ * - Merges into `threadsKeys.detail(workspaceId, thread.id)` (unless
+ *   `skipDetail` is set — see below).
  * - Splices into every threads-list cache for the workspace, handling both
  *   finite `ThreadsResponse` and infinite `{ pages, pageParams }` shapes.
  *
@@ -20,15 +21,26 @@ type ThreadsListCache =
  * Callers that need to surface brand-new threads (e.g. another user just
  * created one) can fall back to invalidating the list queries when this
  * returns `false`.
+ *
+ * `skipDetail` exists so the SignalR `receiveThreadUpdate` path can refresh
+ * sidebar list rows without overwriting the actively-viewed thread's detail
+ * cache. SignalR can race ahead of the SSE for the viewed thread, flipping
+ * `isFlowRunning: false` before the SSE delivers the terminal frame carrying
+ * the new message — leaving a window where the typing indicator is gone but
+ * the response hasn't painted yet. SSE thread frames remain authoritative
+ * for detail.
  */
 export function applyThreadToCache(
   qc: QueryClient,
-  thread: MessageThread
+  thread: MessageThread,
+  options?: { skipDetail?: boolean }
 ): boolean {
-  qc.setQueryData<MessageThread>(
-    threadsKeys.detail(thread.workSpaceId, thread.id),
-    (old) => ({ ...(old ?? thread), ...thread })
-  );
+  if (!options?.skipDetail) {
+    qc.setQueryData<MessageThread>(
+      threadsKeys.detail(thread.workSpaceId, thread.id),
+      (old) => ({ ...(old ?? thread), ...thread })
+    );
+  }
 
   let foundInList = false;
   qc.setQueriesData<ThreadsListCache>(

--- a/src/ui/workspaces/useWorkspaceSubscriptions.ts
+++ b/src/ui/workspaces/useWorkspaceSubscriptions.ts
@@ -42,22 +42,28 @@ export function useWorkspaceSubscriptions() {
   useWorkspaceRealtime(workspaceId || undefined, {
     onThreadUpdate: (summary) => {
       if (!workspaceId) return;
-      // eslint-disable-next-line no-console
-      console.log('[SignalR] ReceiveThreadUpdate for thread:', summary.id);
 
-      // SignalR is now a hint: the SSE's `thread` frame is authoritative for
-      // `isFlowRunning` on the thread the user is viewing. For other threads
-      // (no SSE open), SignalR still drives sidebar state — the direct cache
-      // write makes that instant regardless.
+      // SignalR is a hint; the SSE `thread` frame is authoritative for the
+      // viewed thread. SignalR commonly races ahead of SSE on terminal
+      // updates — if we let it write the detail cache (which the typing
+      // indicator reads from), `isFlowRunning` flips to false before the SSE
+      // delivers the new message, leaving the indicator gone and the
+      // response missing for ~tens-to-hundreds of ms. Skip the detail write
+      // for the viewed thread; still update list caches so the sidebar's
+      // running dot stays in sync for everyone else's tabs / other threads.
+      const isViewedThread = summary.id === threadId;
       const foundInList = applyThreadToCache(
         qc,
-        mapSignalRThreadSummaryToModel(summary)
+        mapSignalRThreadSummaryToModel(summary),
+        { skipDetail: isViewedThread }
       );
       if (!foundInList) invalidateWorkspaceThreadLists(qc, workspaceId);
 
       // Mark messages stale for threads the user isn't actively viewing;
       // the thread SSE handles the one they are viewing.
-      qc.invalidateQueries({ queryKey: messagesKeys.list(summary.id) });
+      if (!isViewedThread) {
+        qc.invalidateQueries({ queryKey: messagesKeys.list(summary.id) });
+      }
     },
     onThreadDeleted: (summary) => {
       if (!workspaceId) return;


### PR DESCRIPTION
## Summary
- SignalR `receiveThreadUpdate` was racing ahead of the SSE for the actively-viewed thread, flipping `isFlowRunning: false` in the detail cache before the SSE delivered the terminal frame carrying the new message. The typing indicator vanished but the response hadn't painted yet — most visible when streaming is off, since deltas haven't already painted partial content.
- Make the code match the existing comment in `threadStream.ts` ("SSE thread frames are source of truth, SignalR is a hint"). For the viewed thread, skip the detail-cache write and skip the messages-list invalidate — both of which the SSE handles authoritatively. Sidebar list caches still get the SignalR hint so other rows stay in sync.

## Changes
- `applyThreadToCache` gains an opt-in `{ skipDetail?: boolean }` so callers can splice into list caches without touching detail.
- `useWorkspaceSubscriptions.onThreadUpdate` passes `skipDetail: true` and skips `messagesKeys.list` invalidation when `summary.id === threadId`.
- Removes a stray `console.log` that was left in the SignalR handler.
- New test covering the `skipDetail` path.

## Test plan
- [x] `pnpm exec vitest run src/domains/threads/__tests__/cache.spec.ts` — 8/8 pass
- [x] `pnpm run lint` — clean
- [x] `pnpm run typecheck` — clean
- [ ] Manual: send a message with streaming OFF on the backend, verify the response and the indicator-off transition land in the same paint (no gap)
- [ ] Manual: confirm sidebar running-dot still updates promptly for other (non-viewed) threads when their flows finish