### PR TITLE
fix(ui): hide trailing status bubble once the flow stops

### DIFF
--- a/src/ui/messages/MessageItem.tsx
+++ b/src/ui/messages/MessageItem.tsx
@@ -21,6 +21,15 @@ import { MessageStatus } from './MessageStatus';
 
 interface MessageItemProps {
   message: Message;
+  /**
+   * True when this is the most recent message in the thread AND the flow
+   * is still running. Gates the trailing transient status node — without
+   * this, a stuck `status` value in `message.values` (e.g. one tool's
+   * "running" status that arrived after another tool's content during a
+   * parallel-tool-call run, with no clearing frame from the backend)
+   * would render as a permanent bubble below the response.
+   */
+  isLive?: boolean;
 }
 
 /** shallow-enough equality for small channel maps like { stream: 0 } */
@@ -85,7 +94,10 @@ function coerceSources(x: unknown): MessageResponseSource[] {
   return x.filter(isMessageResponseSource);
 }
 
-export const MessageItem: FC<MessageItemProps> = ({ message }) => {
+export const MessageItem: FC<MessageItemProps> = ({
+  message,
+  isLive = false,
+}) => {
   const { workspaceId, threadId } = useRouteIds();
   const { data: workspace } = useWorkspace(workspaceId);
   const chatbotName = getChatbotName(workspace?.name);
@@ -298,8 +310,13 @@ export const MessageItem: FC<MessageItemProps> = ({ message }) => {
     );
   }
 
-  // Show the last status indicator if no content followed it
-  if (lastStatusNode) {
+  // Show the trailing transient status only while this message is live
+  // (last in the thread + flow still running). Once the flow ends, any
+  // status value left over in `message.values` is stale — typically from
+  // parallel tool calls where one tool's status arrived after another's
+  // content and there was no clearing frame to overwrite it. Without this
+  // gate that stale status would render as a permanent bubble.
+  if (lastStatusNode && isLive) {
     bubbles.push(lastStatusNode);
   }
 

--- a/src/ui/messages/MessageList.tsx
+++ b/src/ui/messages/MessageList.tsx
@@ -241,30 +241,34 @@ export function MessageList() {
                 : ''
             } px-2 sm:px-3 md:px-4 transition-[max-width] duration-300 ease-in-out`}
           >
-            {safeMessages.map((message, index) => (
-              <div
-                className="ss-chat__message w-full"
-                key={message.id || index}
-              >
-                <MessageItem message={message} />
+            {safeMessages.map((message, index) => {
+              const isLastMessage = index === safeMessages.length - 1;
+              const isLive = isLastMessage && !!thread?.isFlowRunning;
+              return (
+                <div
+                  className="ss-chat__message w-full"
+                  key={message.id || index}
+                >
+                  <MessageItem message={message} isLive={isLive} />
 
-                {index === safeMessages.length - 1 && thread?.isFlowRunning && (
-                  <div className="p-3 min-h-3">
-                    <div className="flex space-x-2 p-1">
-                      {[0, 300, 600].map((delay) => (
-                        <div
-                          key={delay}
-                          className="h-2 w-2 rounded-full bg-primary/40 animate-bounce"
-                          style={{ animationDelay: `${delay}ms` }}
-                        />
-                      ))}
+                  {isLastMessage && thread?.isFlowRunning && (
+                    <div className="p-3 min-h-3">
+                      <div className="flex space-x-2 p-1">
+                        {[0, 300, 600].map((delay) => (
+                          <div
+                            key={delay}
+                            className="h-2 w-2 rounded-full bg-primary/40 animate-bounce"
+                            style={{ animationDelay: `${delay}ms` }}
+                          />
+                        ))}
+                      </div>
                     </div>
-                  </div>
-                )}
+                  )}
 
-                <div ref={messagesEndRef} className="h-1" />
-              </div>
-            ))}
+                  <div ref={messagesEndRef} className="h-1" />
+                </div>
+              );
+            })}
           </div>
         </ScrollAreaPrimitive.Viewport>
 


### PR DESCRIPTION
## Summary
- Status values are transient — `MessageItem` keeps only the latest one and pushes it as a trailing node ("cleared when content follows").
- With parallel tool calls, statuses from different tools collide on the `(name, type)` key and the latest write wins. If a tool's status arrives after another tool's content and isn't followed by a clearing frame from the backend, it sticks in `message.values` and renders as a permanent bubble below the response after the flow ends.
- Gate the trailing status push on a new `isLive` prop (last message AND `isFlowRunning`), threading it through from `MessageList`. Same condition the typing indicator already uses.

## Out of scope
- The deeper question — parallel tool statuses overwriting each other mid-flow because `applyDeltaToMessage` only keys by `(name, type)` and ignores `channels`, plus the backend not emitting a clearing frame on tool finish — is unchanged by this fix. Worth a follow-up if multi-status visibility is desired.

## Test plan
- [x] `pnpm run lint` — clean
- [x] `pnpm run typecheck` — clean
- [x] `pnpm test` — full suite passes
- [ ] Manual: trigger a flow with parallel tool calls; confirm status bubble disappears once `isFlowRunning` flips false; confirm typing-indicator behavior is unchanged