### PR TITLE
perf(memory): shorter gcTime + clean up Milkdown DOM listeners

### DIFF
--- a/src/platform/reactQueryClient.ts
+++ b/src/platform/reactQueryClient.ts
@@ -22,7 +22,12 @@ export const queryClient = new QueryClient({
         return isTransient(error) && failureCount < 2;
       },
       staleTime: 60_000, // 1 min
-      gcTime: 10 * 60_000, // 10 min
+      // 2 min — every visited thread caches its full message list under
+      // its own key, so a generous gcTime piles up retained messages
+      // (and their channels/values) when the user hops threads. 2 min
+      // is short enough to release abandoned threads quickly while still
+      // letting "back/forward between two threads" hit a warm cache.
+      gcTime: 2 * 60_000,
     },
     mutations: {
       // Never retry auth errors; retry at most once on transient failures

--- a/src/shared/ui/markdown/MarkdownEditor.tsx
+++ b/src/shared/ui/markdown/MarkdownEditor.tsx
@@ -374,6 +374,18 @@ function EditorInner({
               dom.addEventListener('keyup', handle);
               dom.addEventListener('click', handle);
               dom.addEventListener('keydown', handleKeyDown);
+              // Pair every addEventListener with a removeEventListener via
+              // the listener plugin's `destroy` hook. `useEditor` rebuilds
+              // the editor on every `[isEditable]` flip and on unmount; the
+              // old `view.dom` would otherwise hang on to closure refs over
+              // setMentionCoords/setMentionOpen (and through them the whole
+              // component scope). With many thread switches that grew into
+              // a real retention problem.
+              lm.destroy(() => {
+                dom.removeEventListener('keyup', handle);
+                dom.removeEventListener('click', handle);
+                dom.removeEventListener('keydown', handleKeyDown);
+              });
             } catch {
               /* ignore get view errors */
             }


### PR DESCRIPTION
## Summary
Two retention sources fixed together to address the Chrome memory growth seen in the chat UI.

### `reactQueryClient.ts` — drop default `gcTime` from 10 min to 2 min
Every visited thread caches its full message list under its own key (`messages` keyed by `threadId`). A 10-minute window means each thread hopped through sits in cache the full window holding its values/channels arrays. 2 min is short enough to release abandoned threads quickly while still letting "back/forward between two threads" hit a warm cache.

### `MarkdownEditor.tsx` — pair `addEventListener` with `removeEventListener` via listener-plugin `destroy`
`lm.mounted` attaches `keyup`/`click`/`keydown` to `view.dom` for the mention popover. `useEditor` rebuilds the editor on every `[isEditable]` flip and on unmount, but the old listeners had no teardown — they kept closures over `setMentionCoords`/`setMentionOpen`, retaining the whole component scope. Compounded across thread switching this was a real growth path. Now `lm.destroy(...)` removes each listener when the editor is destroyed.

## Test plan
- [x] `pnpm run lint` — clean
- [x] `pnpm run typecheck` — clean
- [x] `pnpm test` — full suite passes
- [ ] Manual: heap snapshot diff after 10+ thread switches; confirm Milkdown editor instances/listeners aren't accumulating
- [ ] Manual: confirm mention popover still triggers on `@` after the editor has been re-mounted (e.g. by toggling editable state)