### PR TITLE
fix(streaming): always apply SignalR thread updates so isFlowRunning never sticks

### DIFF
--- a/src/domains/threads/__tests__/cache.spec.ts
+++ b/src/domains/threads/__tests__/cache.spec.ts
@@ -82,35 +82,6 @@ describe('applyThreadToCache', () => {
     expect(found).toBe(false);
   });
 
-  it('leaves the detail cache untouched when skipDetail is set', () => {
-    const qc = new QueryClient();
-    qc.setQueryData<MessageThread>(
-      threadsKeys.detail('w1', 't1'),
-      thread({ isFlowRunning: true })
-    );
-    qc.setQueryData<ThreadsResponse>(threadsKeys.list('w1'), {
-      data: [thread({ isFlowRunning: true })],
-      total: 1,
-    });
-
-    applyThreadToCache(qc, thread({ isFlowRunning: false }), {
-      skipDetail: true,
-    });
-
-    // Detail cache stays as-is — SSE remains authoritative for the viewed
-    // thread.
-    expect(
-      qc.getQueryData<MessageThread>(threadsKeys.detail('w1', 't1'))
-        ?.isFlowRunning
-    ).toBe(true);
-    // Sidebar list still reflects the SignalR hint so other tabs / list
-    // rows stay in sync.
-    expect(
-      qc.getQueryData<ThreadsResponse>(threadsKeys.list('w1'))?.data[0]
-        .isFlowRunning
-    ).toBe(false);
-  });
-
   it("only touches list caches matching the thread's workspace", () => {
     const qc = new QueryClient();
     qc.setQueryData<ThreadsResponse>(threadsKeys.list('w1'), {

--- a/src/domains/threads/cache.ts
+++ b/src/domains/threads/cache.ts
@@ -12,8 +12,7 @@ type ThreadsListCache =
  * directly into the relevant query caches so subscribers paint without a
  * refetch roundtrip.
  *
- * - Merges into `threadsKeys.detail(workspaceId, thread.id)` (unless
- *   `skipDetail` is set — see below).
+ * - Merges into `threadsKeys.detail(workspaceId, thread.id)`.
  * - Splices into every threads-list cache for the workspace, handling both
  *   finite `ThreadsResponse` and infinite `{ pages, pageParams }` shapes.
  *
@@ -21,26 +20,15 @@ type ThreadsListCache =
  * Callers that need to surface brand-new threads (e.g. another user just
  * created one) can fall back to invalidating the list queries when this
  * returns `false`.
- *
- * `skipDetail` exists so the SignalR `receiveThreadUpdate` path can refresh
- * sidebar list rows without overwriting the actively-viewed thread's detail
- * cache. SignalR can race ahead of the SSE for the viewed thread, flipping
- * `isFlowRunning: false` before the SSE delivers the terminal frame carrying
- * the new message — leaving a window where the typing indicator is gone but
- * the response hasn't painted yet. SSE thread frames remain authoritative
- * for detail.
  */
 export function applyThreadToCache(
   qc: QueryClient,
-  thread: MessageThread,
-  options?: { skipDetail?: boolean }
+  thread: MessageThread
 ): boolean {
-  if (!options?.skipDetail) {
-    qc.setQueryData<MessageThread>(
-      threadsKeys.detail(thread.workSpaceId, thread.id),
-      (old) => ({ ...(old ?? thread), ...thread })
-    );
-  }
+  qc.setQueryData<MessageThread>(
+    threadsKeys.detail(thread.workSpaceId, thread.id),
+    (old) => ({ ...(old ?? thread), ...thread })
+  );
 
   let foundInList = false;
   qc.setQueriesData<ThreadsListCache>(

--- a/src/ui/workspaces/useWorkspaceSubscriptions.ts
+++ b/src/ui/workspaces/useWorkspaceSubscriptions.ts
@@ -43,27 +43,26 @@ export function useWorkspaceSubscriptions() {
     onThreadUpdate: (summary) => {
       if (!workspaceId) return;
 
-      // SignalR is a hint; the SSE `thread` frame is authoritative for the
-      // viewed thread. SignalR commonly races ahead of SSE on terminal
-      // updates — if we let it write the detail cache (which the typing
-      // indicator reads from), `isFlowRunning` flips to false before the SSE
-      // delivers the new message, leaving the indicator gone and the
-      // response missing for ~tens-to-hundreds of ms. Skip the detail write
-      // for the viewed thread; still update list caches so the sidebar's
-      // running dot stays in sync for everyone else's tabs / other threads.
-      const isViewedThread = summary.id === threadId;
+      // SignalR is the safety net: the SSE `thread` frame is the preferred
+      // source of truth for the viewed thread, but the SSE doesn't always
+      // deliver a terminal thread summary (the connection can drop or the
+      // backend can return a stale summary if its DB write lags Redis), so
+      // we always apply SignalR's update to the detail cache. There is a
+      // small race window where SignalR's `isFlowRunning: false` paints
+      // before the SSE has delivered the final message frame — visible as a
+      // brief moment with no typing indicator and no response yet — but
+      // that's recoverable on the next frame, whereas a stuck `true` here
+      // requires the user to refresh the tab.
       const foundInList = applyThreadToCache(
         qc,
-        mapSignalRThreadSummaryToModel(summary),
-        { skipDetail: isViewedThread }
+        mapSignalRThreadSummaryToModel(summary)
       );
       if (!foundInList) invalidateWorkspaceThreadLists(qc, workspaceId);
 
-      // Mark messages stale for threads the user isn't actively viewing;
-      // the thread SSE handles the one they are viewing.
-      if (!isViewedThread) {
-        qc.invalidateQueries({ queryKey: messagesKeys.list(summary.id) });
-      }
+      // Refetch the messages list so other-tab activity surfaces; the
+      // viewed thread's SSE will overwrite this with authoritative state
+      // on its next frame.
+      qc.invalidateQueries({ queryKey: messagesKeys.list(summary.id) });
     },
     onThreadDeleted: (summary) => {
       if (!workspaceId) return;


### PR DESCRIPTION
## Summary
Reverts the `skipDetail` behaviour added in #230. That fix prevented a small race where SignalR's `isFlowRunning=false` painted before the SSE delivered the new message, but it relied on the SSE's terminal thread frame as the only path to flip `isFlowRunning` back to false for the viewed thread.

In practice that frame doesn't always arrive — the SSE connection can drop before terminal, or the backend's post-Complete fetch of the thread summary can return a stale running state if its DB write lags Redis. When it doesn't arrive, the typing indicator stays on and the composer stays disabled **until the user refreshes the page**. That regression is worse than the original race.

## Tradeoff
The original race re-appears: a brief moment where the indicator is gone before the new message paints. That's recoverable on the next frame; a stuck running state required a manual refresh. We can revisit a smarter fix (deferred SignalR write that yields to a real SSE terminal frame) once the backend's terminal-frame reliability is improved.

## Changes
- `useWorkspaceSubscriptions.onThreadUpdate` always writes detail and invalidates messages for the viewed thread.
- Drop the unused `skipDetail` option from `applyThreadToCache` and its test.

## Test plan
- [x] `pnpm run lint` — clean
- [x] `pnpm run typecheck` — clean
- [x] `pnpm exec vitest run src/domains/threads/__tests__/cache.spec.ts` — 7/7 pass
- [ ] Manual: send a message, wait for response, confirm typing indicator turns off and composer re-enables without a page refresh