### PR TITLE
feat(ui): unify composer/message-list/sidebar running indicators

### DIFF
--- a/src/domains/messages/mutations.ts
+++ b/src/domains/messages/mutations.ts
@@ -6,6 +6,7 @@ import { useUserDisplayName, useUserId } from '@/platform/auth/session';
 import { FileInfo } from '@/domains/files';
 import {
   type MessageThread,
+  setThreadOptimisticRunning,
   setThreadRunningInLists,
   threadsKeys,
 } from '@/domains/threads';
@@ -94,11 +95,15 @@ export function useSendMessage() {
         optimistic,
       ]);
 
-      // Light up the sidebar's running indicator instantly. We patch the
-      // thread-list caches only — NOT the detail cache, which gates the
-      // thread SSE (that value must stay server-confirmed so we don't open
-      // the SSE before the backend has actually started the flow). The
-      // composer's spinner is already covered by `mutation.isPending`.
+      // Light up every running indicator (composer spinner, message-list
+      // typing dots, sidebar dot) on the same render. The optimistic flag
+      // lives in its own cache cell, so the SSE gate — which reads server-
+      // confirmed `isFlowRunning` from the detail cache — stays untouched
+      // and we don't open the stream before the backend has actually
+      // started the flow. The list-cache patch keeps cross-tab SignalR
+      // semantics consistent for sidebars that aren't reading the unified
+      // selector.
+      setThreadOptimisticRunning(qc, threadId, true);
       setThreadRunningInLists(qc, workspaceId, threadId, true);
 
       // cancel in-flight refetches for this list so they don't race the optimistic insert
@@ -114,10 +119,11 @@ export function useSendMessage() {
           variables,
         });
       } catch (err) {
-        // rollback: remove optimistics, undo the running flag in lists
+        // rollback: remove optimistics, undo the running flags
         qc.setQueryData<Message[]>(messagesKeys.list(threadId), (old = []) =>
           old.filter((x) => !x.optimistic)
         );
+        setThreadOptimisticRunning(qc, threadId, false);
         setThreadRunningInLists(qc, workspaceId, threadId, false);
         toast.error('There was an error posting your message');
         throw err;
@@ -150,6 +156,12 @@ export function useSendMessage() {
         threadsKeys.detail(workspaceId, threadId),
         (old) => (old ? { ...old, isFlowRunning: true } : old)
       );
+
+      // Detail cache now holds the server-confirmed truth — drop the
+      // optimistic flag so the unified selector relies purely on
+      // `isFlowRunning` from here. SSE/SignalR terminal frames will flip
+      // it false to stop every indicator together.
+      setThreadOptimisticRunning(qc, threadId, false);
 
       // Reconcile thread list ordering / last-message preview and thread detail
       // (isFlowRunning). Message content continues to arrive via the thread SSE.

--- a/src/domains/threads/cache.ts
+++ b/src/domains/threads/cache.ts
@@ -96,6 +96,23 @@ export function invalidateWorkspaceThreadLists(
 }
 
 /**
+ * Client-only flag for "we just hit send for this thread, server hasn't
+ * confirmed yet". Stored in its own cache cell (not on `MessageThread`)
+ * so the SSE gate — which reads server-confirmed `isFlowRunning` from the
+ * detail cache — stays unaffected. The unified UI selector
+ * `useThreadIsRunning` ORs this with `thread.isFlowRunning` so the composer,
+ * message list typing dots, and sidebar dot all light up at the same instant
+ * on send and turn off together when the flow's terminal frame arrives.
+ */
+export function setThreadOptimisticRunning(
+  qc: QueryClient,
+  threadId: string,
+  running: boolean
+): void {
+  qc.setQueryData<boolean>(threadsKeys.optimisticRunning(threadId), running);
+}
+
+/**
  * Optimistically flip a single thread's `isFlowRunning` flag in every list
  * cache for the workspace (finite + infinite shapes). Used by `useSendMessage`
  * so the sidebar dot lights up instantly without waiting for SignalR — the

--- a/src/domains/threads/index.ts
+++ b/src/domains/threads/index.ts
@@ -1,6 +1,7 @@
 export {
   applyThreadToCache,
   invalidateWorkspaceThreadLists,
+  setThreadOptimisticRunning,
   setThreadRunningInLists,
 } from './cache';
 export { ensureDraftThread, removeDraftThread } from './draftThread';
@@ -12,6 +13,7 @@ export {
   threadsListOptions,
   useInfiniteThreads,
   useThread,
+  useThreadIsRunning,
   useThreads,
 } from './queries';
 export { threadsKeys, THREAD_LIST_PAGE_SIZE } from './queryKeys';

--- a/src/domains/threads/queries.ts
+++ b/src/domains/threads/queries.ts
@@ -104,6 +104,34 @@ export const useThreads = (workspaceId: string) => {
   return useQuery(threadsListOptions(workspaceId));
 };
 
+/**
+ * Unified "is this thread running?" signal for UI consumers (composer,
+ * message list typing dots, sidebar dot). ORs the client-only optimistic
+ * flag (set the instant the user hits send) with server-confirmed
+ * `isFlowRunning` from the detail cache, so all three indicators start
+ * and stop on the same render. The optimistic cell is cleared by
+ * `useSendMessage` once POST returns and the detail cache holds the
+ * authoritative value.
+ */
+export const useThreadIsRunning = (
+  workspaceId: string | undefined,
+  threadId: string | undefined
+): boolean => {
+  const { data: thread } = useThread({
+    workspaceId: workspaceId ?? '',
+    threadId: threadId ?? '',
+    enabled: !!workspaceId && !!threadId,
+  });
+  const { data: optimistic } = useQuery({
+    queryKey: threadsKeys.optimisticRunning(threadId ?? ''),
+    queryFn: () => false,
+    initialData: false,
+    staleTime: Infinity,
+    enabled: !!threadId,
+  });
+  return !!optimistic || !!thread?.isFlowRunning;
+};
+
 export const useInfiniteThreads = (
   workspaceId: string,
   options?: {

--- a/src/domains/threads/queryKeys.ts
+++ b/src/domains/threads/queryKeys.ts
@@ -12,6 +12,9 @@ export const threadsKeys = {
   detail: (workspaceId: string, threadId: string) =>
     [...threadsKeys.details(), { workspaceId, threadId }] as const,
 
+  optimisticRunning: (threadId: string) =>
+    [...threadsKeys.all, 'optimisticRunning', threadId] as const,
+
   mutations: () => [...threadsKeys.all, 'mutations'] as const,
   setPin: (threadId: string) =>
     [...threadsKeys.mutations(), 'setPin', { threadId }] as const,

--- a/src/ui/messages/MessageComposer.vm.ts
+++ b/src/ui/messages/MessageComposer.vm.ts
@@ -3,7 +3,7 @@ import { useMemo, useState } from 'react';
 import { useRouteIds } from '@/platform/routing/RouteIdsProvider';
 
 import { useSendMessage } from '@/domains/messages/mutations';
-import { useThread } from '@/domains/threads/queries';
+import { useThreadIsRunning } from '@/domains/threads/queries';
 import { useWorkspace } from '@/domains/workspaces/queries';
 
 import { useIsMobile } from '@/shared/hooks/useIsMobile';
@@ -33,7 +33,7 @@ export function useMessageComposerVm(props: MessageComposerVmProps = {}) {
   const isMobile = useIsMobile();
   const { leftOpen, rightOpen } = useSidebar();
   const { data: workspace } = useWorkspace(workspaceId);
-  const { data: thread } = useThread({ workspaceId, threadId });
+  const isRunning = useThreadIsRunning(workspaceId, threadId);
 
   const isUploadingFiles = props.isUploadingFiles ?? false;
 
@@ -45,11 +45,11 @@ export function useMessageComposerVm(props: MessageComposerVmProps = {}) {
   /** Derived: can we send? */
   const sendDisabled = useMemo(() => {
     const nothingToSend = !newMessage.trim() && !props.hasAttachments;
-    const flowBlocked = !!thread?.isFlowRunning || sendMessage.isPending;
+    const flowBlocked = isRunning || sendMessage.isPending;
     return isUploadingFiles || flowBlocked || nothingToSend;
   }, [
     isUploadingFiles,
-    thread?.isFlowRunning,
+    isRunning,
     sendMessage.isPending,
     newMessage,
     props.hasAttachments,
@@ -86,7 +86,7 @@ export function useMessageComposerVm(props: MessageComposerVmProps = {}) {
   const canSend = (text: string, files?: { id: string; name: string }[]) => {
     const hasFiles = (files?.length ?? 0) > 0 || !!props.hasAttachments;
     const nothingToSend = !text.trim() && !hasFiles;
-    const flowBlocked = !!thread?.isFlowRunning || sendMessage.isPending;
+    const flowBlocked = isRunning || sendMessage.isPending;
     return !(isUploadingFiles || flowBlocked || nothingToSend);
   };
 
@@ -118,9 +118,9 @@ export function useMessageComposerVm(props: MessageComposerVmProps = {}) {
     setNewMessage,
     handleKeyDown,
     handleSendMessage,
-    isSending: sendMessage.isPending || !!thread?.isFlowRunning,
+    isSending: isRunning,
     supportsFiles: !!workspace?.supportsFiles,
-    disabled: thread?.isFlowRunning,
+    disabled: isRunning,
     isDraftThread,
     variables,
     setVariables,

--- a/src/ui/messages/MessageList.tsx
+++ b/src/ui/messages/MessageList.tsx
@@ -7,7 +7,7 @@ import { isInTeams } from '@/platform/auth/msalConfig';
 import { useRouteIds } from '@/platform/routing/RouteIdsProvider';
 
 import { useMessages } from '@/domains/messages';
-import { useThread } from '@/domains/threads/queries';
+import { useThread, useThreadIsRunning } from '@/domains/threads/queries';
 import { useWorkspace } from '@/domains/workspaces/queries';
 
 import { useIsMobile } from '@/shared/hooks/useIsMobile';
@@ -43,6 +43,7 @@ export function MessageList() {
     isFetching: threadFetching,
     error: threadError,
   } = useThread({ workspaceId, threadId });
+  const isRunning = useThreadIsRunning(workspaceId, threadId);
   const {
     data: messages,
     isPending: messagesPending,
@@ -107,10 +108,10 @@ export function MessageList() {
   // When the thread starts "running" (typing indicator appears) but message count doesn't change,
   // still ensure we reveal the loading dots if the user is at the bottom.
   useEffect(() => {
-    if (!thread?.isFlowRunning) return;
+    if (!isRunning) return;
     if (!isAtBottom) return;
     requestAnimationFrame(() => scrollToBottom('smooth'));
-  }, [thread?.isFlowRunning, isAtBottom, scrollToBottom]);
+  }, [isRunning, isAtBottom, scrollToBottom]);
 
   // Also keep pinned when content height changes (streaming tokens, images, typing indicator).
   useEffect(() => {
@@ -243,7 +244,7 @@ export function MessageList() {
           >
             {safeMessages.map((message, index) => {
               const isLastMessage = index === safeMessages.length - 1;
-              const isLive = isLastMessage && !!thread?.isFlowRunning;
+              const isLive = isLastMessage && isRunning;
               return (
                 <div
                   className="ss-chat__message w-full"
@@ -251,7 +252,7 @@ export function MessageList() {
                 >
                   <MessageItem message={message} isLive={isLive} />
 
-                  {isLastMessage && thread?.isFlowRunning && (
+                  {isLastMessage && isRunning && (
                     <div className="p-3 min-h-3">
                       <div className="flex space-x-2 p-1">
                         {[0, 300, 600].map((delay) => (

--- a/src/ui/threads/ThreadItem.vm.ts
+++ b/src/ui/threads/ThreadItem.vm.ts
@@ -7,6 +7,7 @@ import { useRouteIds } from '@/platform/routing/RouteIdsProvider';
 
 import type { MessageThread } from '@/domains/threads';
 import { useDeleteThread, useSetPin } from '@/domains/threads/mutations';
+import { useThreadIsRunning } from '@/domains/threads/queries';
 
 import { useSidebar } from '@/shared/ui/mui-compat/sidebar';
 
@@ -26,7 +27,12 @@ export function useThreadItemVm({
   const { mutate: setPin, isPending: isSetPinPending } = useSetPin();
   const { mutateAsync: deleteThread } = useDeleteThread();
 
-  const isRunning = thread.isFlowRunning;
+  // Unified running signal: ORs the optimistic flag (set the instant the
+  // user hits send) with the server-confirmed `isFlowRunning`, so the
+  // sidebar dot lights up on the same render as the composer spinner and
+  // message-list typing dots, and they all turn off together when the
+  // SSE/SignalR terminal frame arrives.
+  const isRunning = useThreadIsRunning(thread.workSpaceId, thread.id);
 
   const goToThread = useCallback(() => {
     const wsId = thread.workSpaceId;


### PR DESCRIPTION
## Summary

The composer spinner, message-list typing dots, and sidebar dot each read a different signal for "is this thread running?", so they started and stopped at noticeably different moments — the message-list dots in particular lagged until POST returned, because the detail cache's `isFlowRunning` gates the thread SSE and is intentionally not flipped optimistically.

This PR adds a dedicated `optimisticRunning` cache cell (its own React Query key, in the threads domain) that `useSendMessage` flips at t=0 and clears once the detail cache holds the server-confirmed value. A new `useThreadIsRunning` selector ORs it with `isFlowRunning`, and all three UI consumers now read the same signal so they light up and turn off on the same render. The SSE gate still reads only the server-confirmed `isFlowRunning`, so we never open the stream prematurely.

- New cache key + helper: [queryKeys.ts](src/domains/threads/queryKeys.ts), [cache.ts](src/domains/threads/cache.ts) (`setThreadOptimisticRunning`)
- New selector: [queries.ts](src/domains/threads/queries.ts) (`useThreadIsRunning`)
- Mutation wires both flags on send + clears optimistic on settle: [mutations.ts](src/domains/messages/mutations.ts)
- UI consumers switched to the selector: [MessageComposer.vm.ts](src/ui/messages/MessageComposer.vm.ts), [MessageList.tsx](src/ui/messages/MessageList.tsx), [ThreadItem.vm.ts](src/ui/threads/ThreadItem.vm.ts)

## Test plan

- [ ] `pnpm run typecheck` — passes
- [ ] `pnpm run lint` — passes
- [ ] `pnpm exec vitest run src/domains/threads src/domains/messages` — 38 tests pass
- [ ] Manually send a message in a workspace and confirm composer spinner, message-list typing dots, and sidebar dot all appear on the same frame
- [ ] Confirm all three indicators clear together when the flow finishes (SSE/SignalR terminal frame)
- [ ] Confirm a failed POST clears all three indicators on rollback
- [ ] Confirm cross-tab/other-user starts still light the sidebar dot via the existing SignalR `applyThreadToCache` path
- [ ] Confirm SSE doesn't open until the detail cache's `isFlowRunning` flips true (i.e. after POST returns), not on the optimistic flag