### PR TITLE
fix(messages): hide sources block when empty

### DIFF
--- a/src/ui/messages/MessageBubble.tsx
+++ b/src/ui/messages/MessageBubble.tsx
@@ -194,7 +194,7 @@ export const MessageBubble: FC<MessageBubbleProps> = (props) => {
           </div>
         )}
 
-        <ChatMessageSources sources={sources} />
+        {sources.length > 0 && <ChatMessageSources sources={sources} />}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Skip mounting `<ChatMessageSources>` from `MessageBubble` when the `sources` array is empty.
- Defensive guard at the call site; `ChatMessageSources` already returned `null` for empty/filtered-empty input, so behavior is unchanged for the empty case but the intent is clearer at the call site.

## Test plan
- [ ] Open a chat thread with an assistant message that has no sources — confirm no Sources block (header/border) renders.
- [ ] Open a thread with a message that has sources — confirm the Sources block still renders and is collapsible as before.