### PR TITLE
ci: backport App-token swap to develop

### DIFF
--- a/.github/workflows/check-package-json-channel.yml
+++ b/.github/workflows/check-package-json-channel.yml
@@ -23,13 +23,23 @@ jobs:
     name: Swap '@smartspace/*' SDK pins from 'dev' to 'main'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate CI_DISPATCH_APP token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CI_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.CI_DISPATCH_APP_PRIVATE_KEY }}
+          owner: Smartspace-ai
+          repositories: Smartspace-app-public
+
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          # PAT (contents: write) so the auto-fix push re-triggers other PR
-          # workflows. The default GITHUB_TOKEN is anti-recursive and won't.
-          token: ${{ secrets.SDK_CHANNEL_SYNC_PAT }}
+          # App token (contents: write) so the auto-fix push re-triggers
+          # other PR workflows. The default GITHUB_TOKEN is anti-recursive
+          # and won't.
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Detect 'dev' SDK pins
         id: detect


### PR DESCRIPTION
## Summary

Cherry-picks `7802663` from `chore/sdk-channel-pin` onto develop. This commit was made on the chore branch *after* #238 was already merged, so it never reached develop on its own.

The change swaps `check-package-json-channel.yml` from using `secrets.SDK_CHANNEL_SYNC_PAT` to using `actions/create-github-app-token@v1` with the existing `CI_DISPATCH_APP` credentials — same pattern as `internal-notify-app.yml`.

## Why this is needed

After #239 lands on main, main has the App-token version of the workflow. Develop is currently stuck on the older `SDK_CHANNEL_SYNC_PAT` reference. While that "stale" version on develop never executes (the channel-sync workflow only runs on PRs targeting main, and PR-target workflows are read from the BASE branch's HEAD, i.e. main), keeping the two branches consistent avoids confusion when reading the file on develop and prevents the stale version from creeping back in via future merges.

## What this changes

- `.github/workflows/check-package-json-channel.yml`: replace `token: ${{ secrets.SDK_CHANNEL_SYNC_PAT }}` with the `actions/create-github-app-token@v1` block + `token: ${{ steps.app-token.outputs.token }}`.