### PR TITLE
ci: detect-before-mint in channel-sync workflow

### DIFF
--- a/.github/workflows/check-package-json-channel.yml
+++ b/.github/workflows/check-package-json-channel.yml
@@ -9,7 +9,7 @@ on:
       - pnpm-lock.yaml
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   sync:
@@ -23,23 +23,10 @@ jobs:
     name: Swap '@smartspace/*' SDK pins from 'dev' to 'main'
     runs-on: ubuntu-latest
     steps:
-      - name: Generate CI_DISPATCH_APP token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.CI_DISPATCH_APP_ID }}
-          private-key: ${{ secrets.CI_DISPATCH_APP_PRIVATE_KEY }}
-          owner: Smartspace-ai
-          repositories: Smartspace-app-public
-
-      - name: Checkout PR branch
+      - name: Checkout PR branch (read-only)
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          # App token (contents: write) so the auto-fix push re-triggers
-          # other PR workflows. The default GITHUB_TOKEN is anti-recursive
-          # and won't.
-          token: ${{ steps.app-token.outputs.token }}
 
       - name: Detect 'dev' SDK pins
         id: detect
@@ -48,8 +35,28 @@ jobs:
             echo "needs-swap=true" >> "$GITHUB_OUTPUT"
           else
             echo "needs-swap=false" >> "$GITHUB_OUTPUT"
-            echo "OK: no develop-channel SDK pins in package.json"
+            echo "OK: no develop-channel SDK pins in package.json — nothing to do."
           fi
+
+      - name: Generate CI_DISPATCH_APP token
+        if: steps.detect.outputs.needs-swap == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CI_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.CI_DISPATCH_APP_PRIVATE_KEY }}
+          owner: Smartspace-ai
+          repositories: Smartspace-app-public
+
+      - name: Re-checkout with App token (for push)
+        if: steps.detect.outputs.needs-swap == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          # App token (contents: write) so the auto-fix push re-triggers
+          # other PR workflows. The default GITHUB_TOKEN is anti-recursive
+          # and won't.
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup pnpm
         if: steps.detect.outputs.needs-swap == 'true'


### PR DESCRIPTION
## Summary

Restructure the channel-sync workflow so it can run cleanly even when the `CI_DISPATCH_APP_*` secrets aren't (yet) configured — by only attempting to mint the App token when there's actual work to do.

## Background

The current workflow attempts the App-token mint as its first step. If the secrets are missing, it fails immediately with `Error: Input required and not supplied: app-id` — even when the PR has nothing for the workflow to swap. That produced false-positive red Xs on PRs like Smartspace-app#1312 (where the SDK pin was already manually swapped, so the workflow had nothing to do).

## What changes

Workflow step order:

| Old | New |
|---|---|
| 1. Mint App token | 1. Checkout (default GITHUB_TOKEN, read-only) |
| 2. Checkout w/ App token | 2. Detect `'dev'` pins |
| 3. Detect | 3. (only if needs-swap) Mint App token |
| 4-6. Swap + push | 4. (only if needs-swap) Re-checkout w/ App token |
|     | 5-7. Swap + push |

Top-level `permissions: contents: write` also drops to `contents: read` — the App token grants write when needed.

## Practical effect

- PRs that already have the right SDK pin: workflow exits in ~5 seconds, green, no App token required.
- PRs that need a swap: workflow mints App token mid-run, swaps, pushes back. Same end behaviour as today, just deferred.
- Repos without `CI_DISPATCH_APP_*` secrets configured can land this without breaking PR checks.