### PR TITLE
chore(chat): close remaining platform leaks in chat tree

### DIFF
--- a/src/domains/messages/__tests__/mutations.spec.tsx
+++ b/src/domains/messages/__tests__/mutations.spec.tsx
@@ -1,11 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-vi.mock('@/platform/auth/session', () => ({
-  useUserId: () => 'test-user',
-  useUserDisplayName: () => 'Test User',
-}));
-
 import {
   useAddInputToMessage,
   useSendMessage,

--- a/src/domains/messages/mutations.ts
+++ b/src/domains/messages/mutations.ts
@@ -1,8 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
-import { useUserDisplayName, useUserId } from '@/platform/auth/session';
-import { useChatService } from '@/platform/chat';
+import { useChatIdentity, useChatService } from '@/platform/chat';
 
 import { FileInfo } from '@/domains/files';
 import {
@@ -26,8 +25,7 @@ type SendArgs = {
 
 export function useSendMessage() {
   const qc = useQueryClient();
-  const userId = useUserId();
-  const userName = useUserDisplayName();
+  const { userId, displayName: userName } = useChatIdentity();
   const service = useChatService();
 
   return useMutation<void, Error, SendArgs>({
@@ -196,8 +194,7 @@ type AddInputArgs = {
 
 export function useAddInputToMessage() {
   const qc = useQueryClient();
-  const userId = useUserId();
-  const userName = useUserDisplayName();
+  const { userId, displayName: userName } = useChatIdentity();
   const service = useChatService();
 
   const addInputToMessageMutation = useMutation<Message, Error, AddInputArgs>({

--- a/src/pages/WorkspaceThreadPage/chat.tsx
+++ b/src/pages/WorkspaceThreadPage/chat.tsx
@@ -3,6 +3,8 @@ import { Stack } from '@mui/material';
 import { useMemo } from 'react';
 import { Toaster } from 'sonner';
 
+import { isInTeams } from '@/platform/auth/msalConfig';
+
 import { useWorkspace, useWorkspaces } from '@/domains/workspaces/queries';
 
 import SidebarRightPanel from '@/ui/comments_draw/sidebar-right';
@@ -63,7 +65,7 @@ export default function ChatBotPage({
           sx={{ flex: 1, minWidth: 0, minHeight: 0, overflow: 'hidden' }}
         >
           <ChatHeaderBar />
-          <MessageList />
+          <MessageList applyHostBackgroundOverride={isInTeams()} />
           <MessageComposer />
         </Stack>
         <SidebarRightPanel />

--- a/src/ui/messages/MessageItem.tsx
+++ b/src/ui/messages/MessageItem.tsx
@@ -2,8 +2,7 @@
 
 import { FC, ReactNode } from 'react';
 
-// domains
-import { useRouteIds } from '@/platform/routing/RouteIdsProvider';
+import { useChatContext } from '@/platform/chat';
 
 import { FileInfo } from '@/domains/files';
 import { Message, MessageContentItem } from '@/domains/messages';
@@ -98,7 +97,7 @@ export const MessageItem: FC<MessageItemProps> = ({
   message,
   isLive = false,
 }) => {
-  const { workspaceId, threadId } = useRouteIds();
+  const { workspaceId, threadId } = useChatContext();
   const { data: workspace } = useWorkspace(workspaceId);
   const chatbotName = getChatbotName(workspace?.name);
   const { addInputToMessageMutation } = useAddInputToMessage();

--- a/src/ui/messages/MessageList.tsx
+++ b/src/ui/messages/MessageList.tsx
@@ -3,7 +3,6 @@ import { useMatch } from '@tanstack/react-router';
 import { AlertTriangle } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { isInTeams } from '@/platform/auth/msalConfig';
 import { useChatContext } from '@/platform/chat';
 
 import { useMessages } from '@/domains/messages';
@@ -19,7 +18,19 @@ import { getBackgroundGradientClasses } from '@/theme/tag-styles';
 
 import { MessageItem } from './MessageItem';
 
-export function MessageList() {
+/**
+ * Apply a solid-base + tag-driven gradient to the message body. Set this when
+ * embedding inside a host whose default page background can show through and
+ * skew the perceived chat color (e.g. Microsoft Teams web client). Defaults
+ * to false — the standard browser app doesn't need it.
+ */
+export type MessageListProps = {
+  applyHostBackgroundOverride?: boolean;
+};
+
+export function MessageList({
+  applyHostBackgroundOverride = false,
+}: MessageListProps = {}) {
   const { workspaceId, threadId } = useChatContext();
   const contentRef = useRef<HTMLDivElement | null>(null);
   const viewportRef = useRef<HTMLDivElement | null>(null);
@@ -52,21 +63,24 @@ export function MessageList() {
   } = useMessages(threadId);
 
   const { leftOpen, rightOpen } = useSidebar();
-  const inTeams = isInTeams();
 
-  // In Teams web, the host can cause the underlying page/background to look dark.
-  // To make it match the web UI, we render our own background on the message list area:
-  // default primary gradient, or tag-driven gradient when a workspace has tags.
-  const teamsBg = useMemo(() => {
-    if (!inTeams) return '';
+  // When the host page can bleed a dark background through (e.g. Teams web),
+  // render our own solid base + tag-driven gradient on the message body so
+  // the perceived chat color matches the standalone web UI. Driven by the
+  // `applyHostBackgroundOverride` prop — the chat tree itself stays
+  // host-agnostic.
+  const hostBg = useMemo(() => {
+    if (!applyHostBackgroundOverride) return '';
     const grad = getBackgroundGradientClasses({
       tags: activeWorkspace?.tags,
       name: activeWorkspace?.name,
     });
-    // In Teams web, set an explicit solid base color first, then layer the gradient on top.
-    // This prevents any dark host/iframe background from influencing the perceived color.
     return `bg-white bg-gradient-to-b from-white from-10% ${grad} via-40% to-100%`;
-  }, [inTeams, activeWorkspace?.tags, activeWorkspace?.name]);
+  }, [
+    applyHostBackgroundOverride,
+    activeWorkspace?.tags,
+    activeWorkspace?.name,
+  ]);
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = 'auto') => {
     const viewport = viewportRef.current;
@@ -140,7 +154,7 @@ export function MessageList() {
   if (isLoading) {
     return (
       <div
-        className={`ss-chat__body flex-shrink-10 flex-1 overflow-y-auto ${teamsBg}`}
+        className={`ss-chat__body flex-shrink-10 flex-1 overflow-y-auto ${hostBg}`}
         data-ss-layer="message-list"
       >
         <div className="space-y-8 p-4">
@@ -199,7 +213,7 @@ export function MessageList() {
 
   return (
     <div
-      className={`ss-chat__body ${teamsBg}`}
+      className={`ss-chat__body ${hostBg}`}
       data-ss-layer="message-list"
       style={{
         flex: 1,


### PR DESCRIPTION
## Summary

#201 introduced `<ChatProvider>` as the single seam for routing/auth knowledge in the chat tree, but three callers still imported from `@/platform/auth` or `@/platform/routing` directly. These leaks would prevent the planned `@smartspace/chat-ui` package extraction from compiling — the package can't reach back into the app.

This PR closes them.

- **`src/ui/messages/MessageItem.tsx`** — `useRouteIds()` → `useChatContext()`. Same `{ workspaceId, threadId }` shape, just sourced from the port.
- **`src/ui/messages/MessageList.tsx`** — `isInTeams()` removed; replaced with an `applyHostBackgroundOverride?: boolean` prop. The standalone web fork's `chat.tsx` page passes `isInTeams()` so behaviour is unchanged here. Admin/sandbox consumers can omit the prop entirely (defaults to `false`).
- **`src/domains/messages/mutations.ts`** — `useUserId` / `useUserDisplayName` from `@/platform/auth/session` → `useChatIdentity()` from `@/platform/chat`. Optimistic-message stamping now reads identity from the same context the rest of the chat tree uses.

## Test plan
- [x] `pnpm run typecheck` — 0 errors
- [x] `pnpm test` — 56 files / 218 tests pass
- [x] `pnpm run lint:all` — 0 errors (warnings unchanged)
- [x] `mutations.spec.tsx` no longer needs to `vi.mock` `@/platform/auth/session` — identity comes from the in-test `ChatProvider` via `buildChatHarness`
- [ ] Manual smoke test in dev environment — send a message, confirm the optimistic stamp shows the logged-in user's name (verifies `useChatIdentity` correctly forwards through `ChatProviderBridge`)

## Why now
Prep for the `@smartspace/chat-ui` package extraction. Without this, `src/ui/messages/` and `src/domains/messages/mutations.ts` would carry transitive imports into `@/platform/*` that the package can't resolve.