### PR TITLE
chore(chat-ui): drop @tanstack/react-router coupling from MessageList

### DIFF
--- a/packages/chat-ui/src/messages/MessageList.tsx
+++ b/packages/chat-ui/src/messages/MessageList.tsx
@@ -1,5 +1,4 @@
 import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
-import { useMatch } from '@tanstack/react-router';
 import { AlertTriangle } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -33,11 +32,24 @@ export type MessageListProps = {
    * sidebars, so it omits the prop and gets the natural 70% width.
    */
   expandedLayout?: boolean;
+  /**
+   * Set to `true` while the host is mid-redirect from a "no thread selected"
+   * route to the first thread of a workspace — the message list shows a
+   * loading skeleton instead of the empty-state during that brief window so
+   * users don't see a "No messages yet" flash.
+   *
+   * Standalone web fork passes this from `useMatch('/.../_layout/')` to
+   * detect the workspace-index route specifically. The sandbox/admin doesn't
+   * have multi-thread navigation, so it omits the prop entirely (defaults
+   * `false` — no router coupling).
+   */
+  isChoosingThread?: boolean;
 };
 
 export function MessageList({
   applyHostBackgroundOverride = false,
   expandedLayout = false,
+  isChoosingThread = false,
 }: MessageListProps = {}) {
   const { workspaceId, threadId } = useChatContext();
   const contentRef = useRef<HTMLDivElement | null>(null);
@@ -49,10 +61,6 @@ export function MessageList({
   const isMobile = useIsMobile();
 
   const { data: activeWorkspace } = useWorkspace(workspaceId);
-  const workspaceIndexMatch = useMatch({
-    from: '/_protected/workspace/$workspaceId/_layout/',
-    shouldThrow: false,
-  });
 
   const [isAtBottom, setIsAtBottom] = useState(true);
 
@@ -148,10 +156,8 @@ export function MessageList({
     return () => ro.disconnect();
   }, [isAtBottom, scrollToBottom]);
 
-  // When switching workspaces, we briefly land on /workspace/$workspaceId/ (no threadId) while the route loader
-  // redirects to the first thread. During that transition we should show a loading skeleton, not "No messages yet".
-  const isChoosingThread = !!workspaceId && !threadId && !!workspaceIndexMatch;
   // Avoid flicker: if we already have data, keep rendering it while refetching.
+  // `isChoosingThread` is opt-in via prop — see MessageListProps for usage.
   const isLoading =
     isChoosingThread ||
     ((threadPending || threadFetching) && !thread) ||

--- a/src/pages/WorkspaceThreadPage/chat.tsx
+++ b/src/pages/WorkspaceThreadPage/chat.tsx
@@ -1,5 +1,6 @@
 // src/features/workspaces/Chat.tsx
 import { Stack } from '@mui/material';
+import { useMatch } from '@tanstack/react-router';
 import { useMemo } from 'react';
 import { Toaster } from 'sonner';
 
@@ -28,6 +29,13 @@ export default function ChatBotPage({
   const { data: workspaces, isLoading: workspacesLoading } = useWorkspaces();
   const { data: activeWorkspace } = useWorkspace(workspaceId);
   const { leftOpen, rightOpen } = useSidebar();
+  // While the route loader is redirecting from /workspace/$workspaceId/ to
+  // its first thread, MessageList shouldn't show "no messages yet" — pass
+  // the indicator explicitly so the package stays router-agnostic.
+  const workspaceIndexMatch = useMatch({
+    from: '/_protected/workspace/$workspaceId/_layout/',
+    shouldThrow: false,
+  });
   const { firstThread, isInitialLoading: threadsInitialLoading } =
     useThreadsListVm({
       workspaceId,
@@ -71,6 +79,9 @@ export default function ChatBotPage({
           <MessageList
             applyHostBackgroundOverride={isInTeams()}
             expandedLayout={leftOpen || rightOpen}
+            isChoosingThread={
+              !!workspaceId && !threadId && !!workspaceIndexMatch
+            }
           />
           <MessageComposer expandedLayout={leftOpen || rightOpen} />
         </Stack>


### PR DESCRIPTION
## Summary

Consumer audit on the admin app side flagged that the published \`@smartspace/chat-ui@dev\` dist bundles \`@tanstack/react-router\`. Admin uses \`react-router-dom\`, so this prevents the package from rendering there without wrapping the chat subtree in a stub TanStack Router context.

The match was checking "are we on the workspace-index route?" — purely to avoid a 'No messages yet' flash during the brief window where the route loader redirects to the first thread of a workspace. App-specific UX detail; not core to the chat tree, and the sandbox/admin doesn't have multi-thread navigation at all.

## Change

\`MessageList\` now takes an opt-in \`isChoosingThread?: boolean\` prop instead of calling \`useMatch\` directly:

- **Standalone web fork** (this app): \`chat.tsx\` reads \`useMatch('/.../_layout/')\` and passes the value down. UX unchanged.
- **Sandbox / admin / any other consumer**: omits the prop, gets default \`false\`, never sees the router. No need for a TanStack Router context anywhere.

## What this unblocks

After merge → next \`@smartspace/chat-ui@dev\` publish drops \`@tanstack/react-router\` from the dist. Verify with:

\`\`\`bash
npm view @smartspace/chat-ui@dev version
# grep the published bundle:
# (no '@tanstack/react-router' should appear)
\`\`\`

The admin app's smoke test (mounting \`<ChatProvider>\` + \`<MessageList>\` against a fake service) can then run without the router workaround.

## Test plan
- [x] \`pnpm run typecheck\` — clean
- [x] \`pnpm --filter @smartspace/chat-ui build\` — clean; \`@tanstack/react-router\` no longer in dist
- [x] \`grep '@tanstack/react-router' packages/chat-ui/src/\` returns no hits
- [ ] After merge: smoke-test the standalone web fork on dev — verify the workspace-index loading skeleton still appears during the brief redirect window (should be unchanged because chat.tsx now passes \`isChoosingThread\` from \`useMatch\`)

## Note for the consumer side

This unblocks the router half of the admin/sandbox integration. The remaining package-side concern flagged by the consumer audit is Tailwind wiring — \`dist/index.css\` only contains the Milkdown styles, not compiled Tailwind. The admin app needs to add the package to its Tailwind \`content\` array (or set up Tailwind for the chat subtree) so the package's class names resolve. That's a consumer-side fix, separate from this PR.