### PR TITLE
fix(chat-ui): commit CSS source, automate build, fix desktop sidebar

### DIFF
--- a/packages/chat-ui/package.json
+++ b/packages/chat-ui/package.json
@@ -25,8 +25,10 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsup",
-    "prepare": "tsup",
+    "build": "pnpm run build:js && pnpm run build:css",
+    "build:js": "tsup",
+    "build:css": "tailwindcss -i src/styles.css -o dist/index.css --minify",
+    "prepare": "pnpm run build",
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
@@ -68,6 +70,8 @@
   },
   "devDependencies": {
     "@smartspace/api-client": "dev",
+    "tailwindcss": "^3.4.10",
+    "tailwindcss-animate": "^1.0.7",
     "tsup": "^8.5.0",
     "typescript": "5.5.4"
   }

--- a/packages/chat-ui/src/styles.css
+++ b/packages/chat-ui/src/styles.css
@@ -1,0 +1,409 @@
+/*
+ * Master CSS for @smartspace/chat-ui.
+ *
+ * Tailwind processes this file at build time (`tailwindcss -i src/styles.css
+ * -o dist/index.css`) and emits a fully-resolved stylesheet containing:
+ *   - Tailwind base / components / utilities classes used by the package
+ *   - The CSS variables (`--background`, `--foreground`, ...) the chat-ui
+ *     components reference via `bg-background`, `text-foreground`, etc.
+ *   - The package's own component CSS (markdown editor, attachments,
+ *     chat-variables form), inlined below.
+ *
+ * Note: the package's custom CSS is intentionally inlined here rather than
+ * pulled in via `@import './foo.css'`. The Tailwind v3 CLI doesn't bundle
+ * postcss-import in a way that resolves arbitrary local @imports — they get
+ * silently dropped during the build, so `dist/index.css` would ship without
+ * the markdown / attachment / chat-variables styling. Inlining keeps a single
+ * source of truth and the build deterministic with no extra plugins. If/when
+ * we add a postcss pipeline for autoprefixer or similar, this can move back
+ * to @imports.
+ *
+ * Consumers `import '@smartspace/chat-ui/styles.css'` once and get everything
+ * the rendered components need — no Tailwind setup required on their end.
+ */
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 250.59 54.84% 6.08%;
+
+    --primary: 252.13 88.59% 57.45%;
+    --primary-foreground: 254.27 90% 96.08%;
+
+    --card: 247.5 80% 98.04%;
+    --card-foreground: 250.59 54.84% 6.08%;
+
+    --popover: 0 0% 100%;
+    --popover-foreground: 250.59 54.84% 6.08%;
+
+    --secondary: 252.48 86.67% 94.12%;
+    --secondary-foreground: 0 0% 0%;
+
+    --muted: 254.27 90% 96.08%;
+    --muted-foreground: 0 0% 40%;
+
+    --accent: 254.27 90% 96.08%;
+    --accent-foreground: 252.05 57.45% 9.22%;
+
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+
+    --border: 252.61 90% 92.16%;
+    --input: 251.85 25% 82.75%;
+    --ring: 252.13 88.59% 57.45%;
+
+    --radius: 0.5rem;
+
+    --sidebar-background: 252.13 100% 99.22%;
+    --sidebar-foreground: 250.59 54.84% 6.08%;
+    --sidebar-primary: 252.13 88.59% 57.45%;
+    --sidebar-primary-foreground: 254.27 90% 96.08%;
+    --sidebar-accent: 252.13 88.59% 57.45%;
+    --sidebar-accent-foreground: 254.27 90% 96.08%;
+    --sidebar-border: 252.61 90% 92.16%;
+    --sidebar-ring: 252.13 88.59% 57.45%;
+  }
+
+  .dark {
+    --background: 0 0% 0%;
+    --foreground: 252.48 86.67% 94.12%;
+
+    --primary: 252.13 88.59% 57.45%;
+    --primary-foreground: 254.27 90% 96.08%;
+
+    --card: 257.14 22.58% 6.08%;
+    --card-foreground: 252.48 86.67% 94.12%;
+
+    --popover: 0 0% 0%;
+    --popover-foreground: 252.48 86.67% 94.12%;
+
+    --secondary: 252.55 57.41% 21.18%;
+    --secondary-foreground: 0 0% 100%;
+
+    --muted: 0 0% 9.8%;
+    --muted-foreground: 0 0% 50.2%;
+
+    --accent: 252.55 57.41% 21.18%;
+    --accent-foreground: 252.48 86.67% 94.12%;
+
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+
+    --border: 252.61 58.06% 12.16%;
+    --input: 250 16.67% 21.18%;
+    --ring: 252.13 88.59% 57.45%;
+  }
+}
+
+/* ===========================================================================
+ * Inlined from src/chat-variables/VariablesForm.css
+ * Inlined (not @imported) because Tailwind v3 CLI's bundled postcss-import
+ * silently drops these. See top-of-file note.
+ * ========================================================================= */
+
+/* Horizontal wrap layout for variables (no forced stretching) */
+.jsonforms-compact .ss-jsonforms-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+/* Each variable is its own flex item */
+.jsonforms-compact .ss-jsonforms-cell {
+  flex: 0 0 auto;
+  min-width: 0;
+}
+
+/* Let long/tall fields take a full row when present */
+.jsonforms-compact .ss-jsonforms-textarea {
+  flex: 1 1 100%;
+}
+
+/* Keep compact fields at a comfortable fixed width */
+.jsonforms-compact .compact-field {
+  width: 280px;
+  max-width: 100%;
+}
+
+/* On very small screens, let it shrink gracefully */
+@media (max-width: 480px) {
+  .jsonforms-compact .compact-field {
+    width: 100%;
+  }
+}
+
+/* ===========================================================================
+ * Inlined from src/shared/markdown/styles.css
+ * ========================================================================= */
+
+/* Base editor container */
+.md-editor {
+  position: relative;
+}
+
+.ss-attach {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--muted), white 80%);
+  border: 1px solid var(--border);
+  overflow: hidden;
+}
+
+.ss-attach--image {
+  padding: 2px;
+}
+
+.ss-attach__img {
+  display: block;
+  object-fit: contain;
+}
+
+.md-editor .ProseMirror {
+  /* Height controls via CSS variables set on the root element */
+  min-height: var(--md-min-height, 1.6em);
+  max-height: var(--md-max-height, none);
+  overflow: auto; /* will only scroll when max-height is exceeded */
+  /* Expose padding as variables for consistent placeholder alignment */
+  --md-pad-v: 12px;
+  --md-pad-h: 14px;
+  padding: var(--md-pad-v) var(--md-pad-h);
+  border: 1px solid #e3e3e3;
+  border-radius: 10px;
+  line-height: 1.6;
+  outline: none;
+}
+
+/* Focus ring */
+.md-editor .ProseMirror:focus {
+  border-color: #b9d6ff;
+  box-shadow: 0 0 0 3px rgba(70, 128, 255, 0.15);
+}
+
+/* Readonly appearance: remove border and padding to blend into bubbles */
+.md-editor.md-editor--readonly .ProseMirror {
+  border: none;
+  padding: 0;
+  box-shadow: none;
+}
+
+/* Bare composer appearance (no border or padding regardless of editable) */
+.md-editor.md-editor--bare .ProseMirror {
+  border: none;
+  padding: 0;
+  box-shadow: none;
+  /* Ensure placeholder aligns to the start of content when bare */
+  --md-pad-v: 0px;
+  --md-pad-h: 0px;
+}
+
+/* Links (autolinked bare URLs and markdown-syntax links) */
+.md-editor .ProseMirror a {
+  color: #2563eb;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+/* Read-only: error state for ss-file image attachments. The SsImage renderer
+   sets `data-error` when the file resolver hook rejects. */
+.ss-markdown .ss-attach__img[data-error] {
+  background: rgba(220, 38, 38, 0.08);
+}
+
+/* Custom inline file-tag */
+.file-tag {
+  display: inline-block;
+  padding: 0 6px;
+  border-radius: 6px;
+  border: 1px solid #a7b7e9;
+  background: #eef2ff;
+  font-size: 0.9em;
+  color: #2b3a8a;
+  user-select: text; /* allow selection across it */
+  white-space: nowrap;
+}
+
+/* Ghost placeholder for empty editable state */
+.md-editor__ghost {
+  position: absolute;
+  top: var(--md-pad-v); /* align with ProseMirror padding */
+  left: var(--md-pad-h); /* align with ProseMirror padding */
+  right: var(--md-pad-h);
+  color: #9aa2af;
+  pointer-events: none;
+  user-select: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font: inherit;
+  line-height: inherit;
+}
+
+/* Normalize top margin so caret height is consistent when empty */
+.md-editor .ProseMirror > :first-child {
+  margin-top: 0;
+}
+
+/* Mention (placeholder) – tweak as desired */
+.mention {
+  background: #f0f9ff;
+  border: 1px solid #bae6fd;
+  border-radius: 6px;
+  padding: 0 6px;
+  color: #0369a1;
+}
+
+/* Code block wrapper — shared by the Milkdown editor node view
+   (`.md-editor` scope) and the react-markdown read-only renderer
+   (`.ss-markdown` scope). Keep selectors in sync. */
+.md-editor .ss-code-block,
+.ss-markdown .ss-code-block {
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 8px;
+  background: #0b1020;
+  color: #e6edf3;
+  margin: 0.75em 0;
+  overflow: hidden;
+}
+
+.md-editor .ss-code-block__header,
+.ss-markdown .ss-code-block__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 10px;
+  background: rgba(255, 255, 255, 0.06);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 12px;
+  line-height: 1;
+}
+
+.md-editor .ss-code-block__lang,
+.ss-markdown .ss-code-block__lang {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #9ba3af;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.md-editor .ss-code-block__actions,
+.ss-markdown .ss-code-block__actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.md-editor .ss-code-block__toggle,
+.md-editor .ss-code-block__copy,
+.ss-markdown .ss-code-block__toggle,
+.ss-markdown .ss-code-block__copy {
+  appearance: none;
+  background: rgba(255, 255, 255, 0.1);
+  color: #e6edf3;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 12px;
+  cursor: pointer;
+  font-family: inherit;
+  line-height: 1;
+}
+
+.md-editor .ss-code-block__toggle:hover,
+.md-editor .ss-code-block__copy:hover,
+.ss-markdown .ss-code-block__toggle:hover,
+.ss-markdown .ss-code-block__copy:hover {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.md-editor .ss-code-block pre,
+.ss-markdown .ss-code-block pre {
+  margin: 0;
+  padding: 12px 14px;
+  background: transparent;
+  color: inherit;
+  overflow-x: auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre;
+}
+
+.md-editor .ss-code-block pre code,
+.ss-markdown .ss-code-block pre code {
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  font: inherit;
+}
+
+.md-editor .ss-code-block__iframe,
+.ss-markdown .ss-code-block__iframe {
+  display: block;
+  width: 100%;
+  /* Initial height before the height reporter postMessages in the real size
+     (capped in JS by MAX_IFRAME_HEIGHT). */
+  height: 500px;
+  border: 0;
+  background: #ffffff;
+  /* Kill the baseline gap under replaced elements (iframe is inline by
+     default), which otherwise adds ~4px of empty space below the preview. */
+  vertical-align: top;
+}
+
+/* Inline code in read-only messages — matches the Milkdown editor's
+   inline code treatment. */
+.ss-markdown :not(pre) > code {
+  background: rgba(135, 131, 120, 0.15);
+  color: #c7254e;
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.9em;
+}
+
+/* Read-only: anchors should feel clickable. */
+.ss-markdown a {
+  color: #2563eb;
+  text-decoration: underline;
+}
+
+/* Read-only: give <details>/<summary> sensible defaults. */
+.ss-markdown details {
+  margin: 0.75em 0;
+}
+
+.ss-markdown summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+/* Inline code */
+.md-editor .ProseMirror :not(pre) > code {
+  background: rgba(135, 131, 120, 0.15);
+  color: #c7254e;
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.9em;
+}
+
+/* Mentions popup */
+.md-mention-menu {
+  background: hsl(var(--background, 0 0% 100%));
+  color: var(--foreground, #111);
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 8px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
+  min-width: 220px;
+  max-width: 320px;
+  overflow: hidden;
+  z-index: 1000;
+}

--- a/packages/chat-ui/tailwind.config.js
+++ b/packages/chat-ui/tailwind.config.js
@@ -1,0 +1,84 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: ['class'],
+  // Scan the package's source so Tailwind generates utilities for every class
+  // any component uses. The published build runs `tailwindcss -i src/styles.css
+  // -o dist/index.css`, so the consumer doesn't need their own Tailwind setup.
+  content: ['./src/**/*.{ts,tsx}'],
+  theme: {
+    container: {
+      center: true,
+      padding: '2rem',
+      screens: {
+        '2xl': '1400px',
+      },
+    },
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+        sidebar: {
+          DEFAULT: 'hsl(var(--sidebar-background))',
+          foreground: 'hsl(var(--sidebar-foreground))',
+          primary: 'hsl(var(--sidebar-primary))',
+          'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
+          accent: 'hsl(var(--sidebar-accent))',
+          'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
+          border: 'hsl(var(--sidebar-border))',
+          ring: 'hsl(var(--sidebar-ring))',
+        },
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+      keyframes: {
+        'accordion-down': {
+          from: { height: '0' },
+          to: { height: 'var(--radix-accordion-content-height)' },
+        },
+        'accordion-up': {
+          from: { height: 'var(--radix-accordion-content-height)' },
+          to: { height: '0' },
+        },
+      },
+      animation: {
+        'accordion-down': 'accordion-down 0.2s ease-out',
+        'accordion-up': 'accordion-up 0.2s ease-out',
+      },
+    },
+  },
+  plugins: [require('tailwindcss-animate')],
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -457,6 +457,12 @@ importers:
       '@smartspace/api-client':
         specifier: dev
         version: 0.1.0-dev.00e0c7c(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
+      tailwindcss:
+        specifier: ^3.4.10
+        version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
+      tailwindcss-animate:
+        specifier: ^1.0.7
+        version: 1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.30(@swc/helpers@0.5.21))(jiti@2.4.2)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.5.4)(yaml@2.8.3)

--- a/src/shared/ui/mui-compat/sidebar.tsx
+++ b/src/shared/ui/mui-compat/sidebar.tsx
@@ -16,10 +16,14 @@ import {
 
 import { useIsMobile } from '@/shared/hooks/useIsMobile';
 import { Button } from '@/shared/ui/mui-compat/button';
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/shared/ui/mui-compat/sheet';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/shared/ui/mui-compat/sheet';
 import { TooltipProvider } from '@/shared/ui/mui-compat/tooltip';
 import { cn } from '@/shared/utils/utils';
-
 
 const SIDEBAR_COOKIE_NAME = 'sidebar';
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1 year
@@ -177,7 +181,10 @@ const SidebarProvider = forwardRef<
       if (!vv) return;
       const update = () => {
         // Useful for mobile layouts (esp. on-screen keyboard); consumers can use var(--ss-viewport-height)
-        document.documentElement.style.setProperty('--ss-viewport-height', `${vv.height}px`);
+        document.documentElement.style.setProperty(
+          '--ss-viewport-height',
+          `${vv.height}px`
+        );
       };
       update();
       vv.addEventListener('resize', update);
@@ -185,11 +192,13 @@ const SidebarProvider = forwardRef<
       return () => {
         vv.removeEventListener('resize', update);
         vv.removeEventListener('scroll', update);
-        try { document.documentElement.style.removeProperty('--ss-viewport-height'); } catch { /* ignore */ }
+        try {
+          document.documentElement.style.removeProperty('--ss-viewport-height');
+        } catch {
+          /* ignore */
+        }
       };
     }, [isMobile, openMobileLeft, openMobileRight]);
-
-    
 
     useEffect(() => {
       const handleKeyDown = (event: KeyboardEvent) => {
@@ -335,55 +344,48 @@ const Sidebar = forwardRef<
             className="p-0 bg-sidebar text-sidebar-foreground"
           >
             <SheetHeader>
-              <SheetTitle className="sr-only">{side === 'left' ? 'Left sidebar' : 'Right sidebar'}</SheetTitle>
+              <SheetTitle className="sr-only">
+                {side === 'left' ? 'Left sidebar' : 'Right sidebar'}
+              </SheetTitle>
             </SheetHeader>
-            <div className="flex h-full w-full flex-col min-h-0">{children}</div>
+            <div className="flex h-full w-full flex-col min-h-0">
+              {children}
+            </div>
           </SheetContent>
         </Sheet>
       );
     }
 
-    // Desktop view
+    // Desktop view: in-flow flex column whose width animates between
+    // SIDEBAR_WIDTH (open) and 0 (collapsed). Inner panel keeps a fixed
+    // width so content stays put while the wrapper clips it via
+    // overflow:hidden. Avoids the fragile fixed-position + spacer +
+    // group-data selector trick that previously didn't reflect state
+    // changes when the chat-ui package CSS was loaded alongside the
+    // consumer's Tailwind output.
+    const desktopWidth = isOpen ? SIDEBAR_WIDTH : '0px';
     return (
       <div
         ref={ref}
-        className="group peer hidden md:block text-sidebar-foreground"
         data-state={isOpen ? 'expanded' : 'collapsed'}
         data-collapsible={!isOpen ? collapsible : ''}
         data-variant={variant}
         data-side={side}
+        data-sidebar="root"
+        className="block text-sidebar-foreground shrink-0 self-stretch overflow-hidden transition-[width] duration-300 ease-in-out"
+        style={{ width: desktopWidth }}
       >
-        {/* This handles the sidebar gap on desktop */}
         <div
+          data-sidebar="sidebar"
           className={cn(
-            'duration-300 relative h-svh w-[--sidebar-width] bg-transparent transition-[width] ease-in-out',
-            'group-data-[collapsible=offcanvas]:w-0',
-            'group-data-[side=right]:rotate-180',
-            variant === 'floating' || variant === 'inset'
-              ? 'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4))]'
-              : 'group-data-[collapsible=icon]:w-[--sidebar-width-icon]'
-          )}
-        />
-        <div
-          className={cn(
-            'duration-300 fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] transition-[left,right,width,transform] ease-in-out md:flex',
-            side === 'left'
-              ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
-              : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',
-            // Adjust the padding for floating and inset variants
-            variant === 'floating' || variant === 'inset'
-              ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4)_+2px)]'
-              : 'group-data-[collapsible=icon]:w-[--sidebar-width-icon] group-data-[side=left]:border-r group-data-[side=right]:border-l',
+            'flex h-full flex-col bg-sidebar',
+            side === 'left' ? 'border-r' : 'border-l',
             className
           )}
+          style={{ width: SIDEBAR_WIDTH }}
           {...props}
         >
-          <div
-            data-sidebar="sidebar"
-            className="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
-          >
-            {children}
-          </div>
+          {children}
         </div>
       </div>
     );
@@ -712,6 +714,5 @@ export {
   SidebarProvider,
   SidebarRail,
   SidebarSeparator,
-  SidebarTrigger
+  SidebarTrigger,
 };
-


### PR DESCRIPTION
## Summary

Follow-ups to #245 that finish wiring up the chat-ui package CSS and fix a sidebar regression that #245 introduced.

- **Commit the chat-ui CSS source**: `packages/chat-ui/src/styles.css` (Tailwind input + inlined component CSS) and `packages/chat-ui/tailwind.config.js`. #245 added `import '@smartspace/chat-ui/styles.css'` in `src/main.tsx`, but the sources that produce `dist/index.css` were never checked in — a fresh clone could not rebuild the bundle.
- **Automate the CSS build**: `packages/chat-ui/package.json` now has `build:js` (tsup) + `build:css` (`tailwindcss -i src/styles.css -o dist/index.css --minify`). `build` and `prepare` run both, so `dist/index.css` exists after `pnpm install` on a fresh checkout. Adds `tailwindcss` + `tailwindcss-animate` as devDeps of the package so the build is self-contained.
- **Fix desktop sidebar toggle**: rewrite `Sidebar` in `src/shared/ui/mui-compat/sidebar.tsx` to use in-flow flex sizing (animated inline `width`) instead of `position: fixed` + spacer + `group-data-[collapsible=offcanvas]:left-[calc(...)]` arbitrary-value selectors. With the chat-ui CSS now loaded alongside the consumer's Tailwind output, those selectors stopped reflecting state changes, so clicking the thread/comments triggers on desktop did nothing visually (state toggled, panel did not move). Mobile path (Radix `Sheet`) is unchanged.

## Test plan

- [ ] `pnpm install` on a fresh clone produces `packages/chat-ui/dist/index.css`
- [ ] `pnpm run lint`, `pnpm run typecheck`, `pnpm test`, `pnpm run build` all pass
- [ ] Desktop: clicking the left (thread list) and right (comments) drawer triggers toggles each drawer open and closed
- [ ] Desktop: width transition animates smoothly (300ms)
- [ ] Mobile: Sheet still slides in from the side as before
- [ ] No regression in chat layout when both drawers are open