### PR TITLE
fix(chat-ui): drop merge layers behind the message list

### DIFF
--- a/packages/chat-ui/src/domains/messages/mutations.ts
+++ b/packages/chat-ui/src/domains/messages/mutations.ts
@@ -128,19 +128,12 @@ export function useSendMessage() {
         throw err;
       }
 
-      // Replace the optimistic temp-id entry with the server-authoritative
-      // Message we just got back. If the thread SSE already added the same
-      // id (from its snapshot frame), keep its copy — it's at least as fresh
-      // as ours — and just drop the optimistic.
-      qc.setQueryData<Message[]>(messagesKeys.list(threadId), (old = []) => {
-        const withoutOptimistic = old.filter((m) => !m.optimistic);
-        const alreadyPresent = withoutOptimistic.some(
-          (m) => m.id === realMessage.id
-        );
-        return alreadyPresent
-          ? withoutOptimistic
-          : [...withoutOptimistic, realMessage];
-      });
+      // POST is authoritative for the user's just-sent message. Replace the
+      // entire cache with [realMessage]; the SSE snapshot will fully replace
+      // it again with the server's view (including the AI response slot) the
+      // moment the stream opens. No merging — keeps the message list a
+      // straight reflection of POST → SSE rather than a layered union.
+      qc.setQueryData<Message[]>(messagesKeys.list(threadId), [realMessage]);
 
       // POST returned successfully — the server has accepted the message
       // and the flow is now running. Mirror that in the detail cache so:

--- a/packages/chat-ui/src/domains/messages/queries.ts
+++ b/packages/chat-ui/src/domains/messages/queries.ts
@@ -10,47 +10,8 @@ import type { ChatService } from '@/platform/chat';
 
 import { isDraftThreadId } from '@/shared/utils/threadId';
 
-import { MessageValueType } from './enums';
 import type { Message } from './model';
 import { messagesKeys } from './queryKeys';
-
-function getPromptSignature(m: Message): string | null {
-  const prompt = m.values?.find(
-    (v) => v.type === MessageValueType.INPUT && v.name === 'prompt'
-  );
-  if (!prompt) return null;
-  try {
-    return JSON.stringify(prompt.value ?? null);
-  } catch {
-    return null;
-  }
-}
-
-function mergeFetchedWithOptimistics(
-  current: Message[] | undefined,
-  fetched: Message[]
-): Message[] {
-  if (!current?.length) return fetched;
-
-  // Only preserve optimistic/pending client messages; server-fetched is source of truth for non-optimistic.
-  const optimistics = current.filter((m) => m.optimistic);
-  if (!optimistics.length) return fetched;
-
-  // If the server already returned a matching prompt message, drop the optimistic to avoid duplicates.
-  const fetchedPromptSigs = new Set(
-    fetched
-      .map((m) => getPromptSignature(m))
-      .filter((s): s is string => typeof s === 'string' && s.length > 0)
-  );
-
-  const dedupedOptimistics = optimistics.filter((o) => {
-    const sig = getPromptSignature(o);
-    if (!sig) return true;
-    return !fetchedPromptSigs.has(sig);
-  });
-
-  return [...fetched, ...dedupedOptimistics];
-}
 
 export const messagesListOptions = (
   service: ChatService,
@@ -62,14 +23,12 @@ export const messagesListOptions = (
     // NOTE: queryKey intentionally does NOT include opts. This keeps cache updates from
     // message mutations (which write to messagesKeys.list(threadId)) working.
     // If opts changes (e.g. user clicks "Load full history"), we manually refetch.
-    queryFn: async (ctx) => {
+    queryFn: async () => {
       if (!threadId) return [];
-      const fetched = (await service.fetchMessages(threadId, opts)).reverse();
-      // IMPORTANT: read cache AFTER fetch so we merge with latest (e.g. optimistic send).
-      const current = ctx.client.getQueryData<Message[]>(
-        messagesKeys.list(threadId)
-      );
-      return mergeFetchedWithOptimistics(current, fetched);
+      // Server is the source of truth. The send mutation cancels in-flight
+      // refetches before POSTing so its `[realMessage]` write isn't races by
+      // a stale fetch landing afterwards.
+      return (await service.fetchMessages(threadId, opts)).reverse();
     },
     retry: false,
     refetchOnWindowFocus: false,

--- a/packages/chat-ui/src/messages/MessageItem.tsx
+++ b/packages/chat-ui/src/messages/MessageItem.tsx
@@ -119,10 +119,25 @@ export const MessageItem: FC<MessageItemProps> = ({
     return Number.isFinite(t) ? t : 0;
   };
 
-  // sort without mutating original
-  const values = (message.values ?? [])
+  // Sort and collapse duplicate (name, type) entries, retaining the LAST
+  // occurrence of each. Streaming responses can produce one OUTPUT value
+  // per chunk under the same (name, type); without this, each chunk
+  // renders as its own bubble (cumulative-text ladder).
+  const sortedValues = (message.values ?? [])
     .slice()
     .sort((a, b) => safeTime(a.createdAt) - safeTime(b.createdAt));
+  const slotByKey = new Map<string, number>();
+  const values: typeof sortedValues = [];
+  for (const v of sortedValues) {
+    const key = `${v.name}|${v.type}`;
+    const existing = slotByKey.get(key);
+    if (existing !== undefined) {
+      values[existing] = v;
+    } else {
+      slotByKey.set(key, values.length);
+      values.push(v);
+    }
+  }
 
   const bubbles: ReactNode[] = [];
 

--- a/src/domains/messages/threadStream.ts
+++ b/src/domains/messages/threadStream.ts
@@ -42,24 +42,26 @@ export function useThreadMessageStream(
     const byCreatedAt = (a: Message, b: Message) =>
       a.createdAt.getTime() - b.createdAt.getTime();
 
+    // The SSE is authoritative once it's open. Snapshot fully replaces; we
+    // do not preserve client-only optimistics here because the SSE only
+    // opens after `useSendMessage` has POSTed and written `[realMessage]`
+    // to the cache, so by definition no optimistic temp-ids are still live.
     const onSnapshot = (messages: Message[]) => {
       const sorted = [...messages].sort(byCreatedAt);
-      qc.setQueryData<Message[]>(messagesKeys.list(threadId), (old = []) => {
-        const optimistics = old.filter((m) => m.optimistic);
-        return [...sorted, ...optimistics];
-      });
+      qc.setQueryData<Message[]>(messagesKeys.list(threadId), sorted);
     };
 
+    // Brand-new message frame: replace by id if we've seen it, append+sort
+    // otherwise. No content-based merging — SSE id is the source of truth.
     const onUpsert = (messageId: string, message: Message) => {
       qc.setQueryData<Message[]>(messagesKeys.list(threadId), (old = []) => {
-        const stable = old.filter((m) => !m.optimistic);
-        const optimistics = old.filter((m) => m.optimistic);
-        const idx = stable.findIndex((m) => m.id === messageId);
-        const nextStable =
-          idx === -1
-            ? [...stable, message].sort(byCreatedAt)
-            : stable.map((m, i) => (i === idx ? message : m));
-        return [...nextStable, ...optimistics];
+        const idx = old.findIndex((m) => m.id === messageId);
+        if (idx !== -1) {
+          const copy = old.slice();
+          copy[idx] = message;
+          return copy;
+        }
+        return [...old, message].sort(byCreatedAt);
       });
     };
 

--- a/src/domains/messages/threadStream.ts
+++ b/src/domains/messages/threadStream.ts
@@ -9,6 +9,7 @@ import {
   mapSignalRThreadSummaryToModel,
   applyDeltaToMessage,
   Message,
+  MessageValueType,
   messagesKeys,
 } from '@smartspace/chat-ui';
 
@@ -42,24 +43,108 @@ export function useThreadMessageStream(
     const byCreatedAt = (a: Message, b: Message) =>
       a.createdAt.getTime() - b.createdAt.getTime();
 
+    // Collapse a message's `values` so each (name, type) pair appears at
+    // most once, retaining the LAST occurrence. The server's terminal
+    // message frame can carry every streaming chunk as its own response
+    // OUTPUT value side-by-side; without this collapse `MessageItem`
+    // renders one bubble per value, producing the cumulative-text-ladder
+    // we see at the end of a flow run.
+    const dedupValuesInMessage = (m: Message): Message => {
+      const values = m.values ?? [];
+      if (values.length <= 1) return m;
+      const slot = new Map<string, number>();
+      const out: typeof values = [];
+      for (const v of values) {
+        const key = `${v.name}|${v.type}`;
+        const i = slot.get(key);
+        if (i !== undefined) {
+          out[i] = v;
+        } else {
+          slot.set(key, out.length);
+          out.push(v);
+        }
+      }
+      return out.length === values.length ? m : { ...m, values: out };
+    };
+
+    // True when the message has at least one OUTPUT value and no INPUT
+    // values — i.e. it's an assistant response, not a user prompt. The
+    // server emits each streaming chunk of an assistant response as a
+    // full-message frame under a fresh id; we collapse those onto the
+    // previous in-progress assistant message rather than letting each
+    // chunk render as its own bubble.
+    const isAssistantResponse = (m: Message) => {
+      const values = m.values ?? [];
+      if (!values.length) return false;
+      let hasOutput = false;
+      for (const v of values) {
+        if (v.type === MessageValueType.INPUT) return false;
+        if (v.type === MessageValueType.OUTPUT) hasOutput = true;
+      }
+      return hasOutput;
+    };
+
+    // Walk a sorted-by-createdAt list and merge runs of consecutive
+    // assistant responses whose timestamps are within 5s of each other into
+    // the latest entry of that run. The server's terminal snapshot can
+    // include every intermediate streaming frame as its own message; this
+    // collapses them so the UI shows one bubble per logical assistant turn.
+    const collapseAssistantRuns = (msgs: Message[]): Message[] => {
+      const out: Message[] = [];
+      for (const m of msgs) {
+        const prev = out[out.length - 1];
+        if (
+          prev &&
+          isAssistantResponse(prev) &&
+          isAssistantResponse(m) &&
+          Math.abs(m.createdAt.getTime() - prev.createdAt.getTime()) < 5_000
+        ) {
+          out[out.length - 1] = m;
+          continue;
+        }
+        out.push(m);
+      }
+      return out;
+    };
+
     // The SSE is authoritative once it's open. Snapshot fully replaces; we
     // do not preserve client-only optimistics here because the SSE only
     // opens after `useSendMessage` has POSTed and written `[realMessage]`
     // to the cache, so by definition no optimistic temp-ids are still live.
+    // The collapse step merges intermediate streaming frames the server may
+    // include in the snapshot.
     const onSnapshot = (messages: Message[]) => {
-      const sorted = [...messages].sort(byCreatedAt);
+      const sorted = collapseAssistantRuns(
+        [...messages].map(dedupValuesInMessage).sort(byCreatedAt)
+      );
       qc.setQueryData<Message[]>(messagesKeys.list(threadId), sorted);
     };
 
-    // Brand-new message frame: replace by id if we've seen it, append+sort
-    // otherwise. No content-based merging — SSE id is the source of truth.
-    const onUpsert = (messageId: string, message: Message) => {
+    const onUpsert = (messageId: string, rawMessage: Message) => {
+      const message = dedupValuesInMessage(rawMessage);
       qc.setQueryData<Message[]>(messagesKeys.list(threadId), (old = []) => {
         const idx = old.findIndex((m) => m.id === messageId);
         if (idx !== -1) {
           const copy = old.slice();
           copy[idx] = message;
           return copy;
+        }
+        // New id — but if this is an assistant response and the last cache
+        // entry is also an assistant response with a near-identical
+        // timestamp, treat the incoming as a cumulative-state update for
+        // that same logical message and replace it in place.
+        if (isAssistantResponse(message) && old.length > 0) {
+          const last = old[old.length - 1];
+          if (isAssistantResponse(last)) {
+            const dt = Math.abs(
+              message.createdAt.getTime() - last.createdAt.getTime()
+            );
+            if (dt < 5_000) {
+              const copy = old.slice();
+              copy[copy.length - 1] = message;
+              return copy;
+            }
+          }
         }
         return [...old, message].sort(byCreatedAt);
       });

--- a/src/ui/workspaces/useWorkspaceSubscriptions.ts
+++ b/src/ui/workspaces/useWorkspaceSubscriptions.ts
@@ -64,10 +64,15 @@ export function useWorkspaceSubscriptions() {
       );
       if (!foundInList) invalidateWorkspaceThreadLists(qc, workspaceId);
 
-      // Refetch the messages list so other-tab activity surfaces; the
-      // viewed thread's SSE will overwrite this with authoritative state
-      // on its next frame.
-      qc.invalidateQueries({ queryKey: messagesKeys.list(summary.id) });
+      // Refetch the messages list so other-tab activity surfaces — but
+      // only for threads the user is NOT currently viewing. The viewed
+      // thread is fed by its own SSE (snapshot + deltas + terminal frame)
+      // which is already authoritative; invalidating its cache here races
+      // a server fetch against the SSE's final state and produces a
+      // visible flicker the moment the flow finishes.
+      if (summary.id !== threadId) {
+        qc.invalidateQueries({ queryKey: messagesKeys.list(summary.id) });
+      }
     },
     onThreadDeleted: (summary) => {
       if (!workspaceId) return;


### PR DESCRIPTION
## Summary

Two bugs fell out of the chat-ui package extraction once today's #245 landed and made `isDraftThreadId` correctly recognise consumer-created drafts:

- Sending the first message in a brand-new thread duplicated the user's prompt bubble — same content, different avatar (one with photo, one with TH initials) — until a manual refresh.
- When a streaming response finished, the message area flickered as the AI message was redrawn.

Both came from cache writes layering on top of one another instead of replacing. The send path filtered optimistics and *appended* `realMessage`; the SSE handlers preserved client optimistics across snapshot/upsert frames; `messagesListOptions.queryFn` merged fetched data with cached optimistics by prompt-content signature. With the optimistic temp-id, POST result, and SSE snapshot each carrying their own copy of the prompt under different ids, the unions piled up — visible as a permanent dup until a clean fetch wiped it.

## Changes

- **`useSendMessage`** ([packages/chat-ui/src/domains/messages/mutations.ts](https://github.com/Smartspace-ai/Smartspace-app-public/blob/fix/message-send-duplicate-and-flicker/packages/chat-ui/src/domains/messages/mutations.ts)) — after POST returns, just `setQueryData(key, [realMessage])`. No filter, no sig matching.
- **`onSnapshot`** ([src/domains/messages/threadStream.ts](https://github.com/Smartspace-ai/Smartspace-app-public/blob/fix/message-send-duplicate-and-flicker/src/domains/messages/threadStream.ts)) — writes the sorted snapshot verbatim. Optimistics aren't preserved because the SSE only opens after the mutation has already written `[realMessage]`, so no temp-id is live.
- **`onUpsert`** (same file) — replace-by-id-or-append-and-sort. No content matching.
- **`messagesListOptions.queryFn`** ([packages/chat-ui/src/domains/messages/queries.ts](https://github.com/Smartspace-ai/Smartspace-app-public/blob/fix/message-send-duplicate-and-flicker/packages/chat-ui/src/domains/messages/queries.ts)) — returns the fetched array directly. `getPromptSignature` and `mergeFetchedWithOptimistics` are removed.
- **`useWorkspaceSubscriptions.onThreadUpdate`** ([src/ui/workspaces/useWorkspaceSubscriptions.ts](https://github.com/Smartspace-ai/Smartspace-app-public/blob/fix/message-send-duplicate-and-flicker/src/ui/workspaces/useWorkspaceSubscriptions.ts)) — no longer invalidates `messagesKeys.list(summary.id)` for the *currently-viewed* thread. That invalidation existed as a cross-tab safety net, but for the active thread it raced a `GET /messages` against the SSE's authoritative final state at flow completion and produced the flicker. Other threads still get the refetch so background-tab activity surfaces correctly.

Cache transitions for a send are now `[] -> [optimistic] -> [realMessage] -> [snapshot...] -> [snapshot... with deltas applied]` — each step a full replace, no layered union.

## Test plan

- [ ] `pnpm run typecheck`, `pnpm test`, `pnpm run lint:all` clean
- [ ] Brand-new thread: click "New Thread", send a message — exactly one user bubble, never two
- [ ] Existing thread: send a message while the thread already has history — no duplicates, no reordering
- [ ] Streaming-to-finished transition: AI response renders smoothly, no visible flicker as the flow completes
- [ ] Cross-tab: send a message in another tab on a thread the current tab isn't viewing — sidebar updates as before