### PR TITLE
chore(chat-ui): post-248 PR 1 — quick wins

### DIFF
--- a/packages/chat-ui/src/domains/messages/mutations.ts
+++ b/packages/chat-ui/src/domains/messages/mutations.ts
@@ -41,10 +41,10 @@ export function useSendMessage() {
 
       // Optimistic message
       const optimistic: Message = {
-        id: `temp-${Date.now()}`,
+        id: `temp-${crypto.randomUUID()}`,
         values: [
           {
-            id: `temp-${Date.now()}-prompt`,
+            id: `temp-${crypto.randomUUID()}-prompt`,
             type: MessageValueType.INPUT,
             name: 'prompt',
             value: contentList,
@@ -56,7 +56,7 @@ export function useSendMessage() {
           ...(files?.length
             ? [
                 {
-                  id: `temp-${Date.now()}-files`,
+                  id: `temp-${crypto.randomUUID()}-files`,
                   type: MessageValueType.INPUT,
                   name: 'files',
                   value: files,
@@ -70,7 +70,7 @@ export function useSendMessage() {
           ...(variables && Object.keys(variables).length
             ? [
                 {
-                  id: `temp-${Date.now()}-vars`,
+                  id: `temp-${crypto.randomUUID()}-vars`,
                   type: MessageValueType.INPUT,
                   name: 'variables',
                   value: variables,

--- a/packages/chat-ui/src/domains/workspaces/queries.ts
+++ b/packages/chat-ui/src/domains/workspaces/queries.ts
@@ -21,7 +21,10 @@ export const workspaceDetailOptions = ({
 
 export function useWorkspace(workspaceId: string) {
   const service = useChatService();
-  return useQuery(workspaceDetailOptions({ service, workspaceId }));
+  return useQuery({
+    ...workspaceDetailOptions({ service, workspaceId }),
+    enabled: !!workspaceId,
+  });
 }
 
 export const taggableUsersOptions = ({

--- a/src/domains/comments/mutations.ts
+++ b/src/domains/comments/mutations.ts
@@ -7,7 +7,6 @@ import type { Comment, MentionUser } from './model';
 import { commentsKeys } from './queryKeys';
 import { addComment } from './service';
 
-
 export function useAddComment(threadId: string) {
   const queryClient = useQueryClient();
   const activeUserId = useUserId();
@@ -34,10 +33,14 @@ export function useAddComment(threadId: string) {
       return await addComment(threadId, content, mentionedUsers);
     },
     onMutate: async ({ threadId, content, mentionedUsers = [] }) => {
-      await queryClient.cancelQueries({ queryKey: commentsKeys.list(threadId) });
+      await queryClient.cancelQueries({
+        queryKey: commentsKeys.list(threadId),
+      });
 
-      const previous = queryClient.getQueryData<Comment[]>(commentsKeys.list(threadId));
-      const tempId = `temp-${Date.now()}`;
+      const previous = queryClient.getQueryData<Comment[]>(
+        commentsKeys.list(threadId)
+      );
+      const tempId = `temp-${crypto.randomUUID()}`;
       const optimisticComment: Comment = {
         id: tempId,
         content,
@@ -50,7 +53,7 @@ export function useAddComment(threadId: string) {
 
       queryClient.setQueryData(
         commentsKeys.list(threadId),
-        (old: Comment[] | undefined) => ([...(old ?? []), optimisticComment]),
+        (old: Comment[] | undefined) => [...(old ?? []), optimisticComment]
       );
 
       return { threadId, tempId, previous };
@@ -69,7 +72,7 @@ export function useAddComment(threadId: string) {
           const next = list.slice();
           next[idx] = realComment;
           return next;
-        },
+        }
       );
     },
     onError: (_error, variables, ctx) => {
@@ -79,7 +82,8 @@ export function useAddComment(threadId: string) {
       } else if (ctx?.tempId) {
         queryClient.setQueryData(
           commentsKeys.list(variables.threadId),
-          (old: Comment[] | undefined) => (old ?? []).filter((c) => c.id !== ctx.tempId),
+          (old: Comment[] | undefined) =>
+            (old ?? []).filter((c) => c.id !== ctx.tempId)
         );
       }
       // eslint-disable-next-line no-console
@@ -87,10 +91,4 @@ export function useAddComment(threadId: string) {
       toast.error('Failed to add comment. Please try again.');
     },
   });
-
 }
-
-
-
-
-

--- a/src/routes/_protected/workspace/$workspaceId/_layout.tsx
+++ b/src/routes/_protected/workspace/$workspaceId/_layout.tsx
@@ -11,6 +11,7 @@ import {
 
 import { PageSkeleton } from '@/ui/feedback/Skeletons';
 import { PendingThreadsProvider } from '@/ui/threads/PendingThreadsContext';
+import { useWorkspaceSubscriptions } from '@/ui/workspaces/useWorkspaceSubscriptions';
 
 import { getBackgroundGradientClasses } from '@/theme/tag-styles';
 
@@ -38,6 +39,11 @@ export function ChatProviderBridge({ children }: { children: ReactNode }) {
       {children}
     </ChatProvider>
   );
+}
+
+function WorkspaceSubscriptionsHost() {
+  useWorkspaceSubscriptions();
+  return null;
 }
 
 function WorkspaceBodyBackground() {
@@ -86,6 +92,7 @@ export const Route = createFileRoute(
     <RouteIdsProvider>
       <ChatProviderBridge>
         <PendingThreadsProvider>
+          <WorkspaceSubscriptionsHost />
           <WorkspaceBodyBackground />
           <Suspense fallback={<PageSkeleton />}>
             <Outlet />

--- a/src/ui/workspaces/WorkspaceSwitcher.vm.ts
+++ b/src/ui/workspaces/WorkspaceSwitcher.vm.ts
@@ -14,8 +14,6 @@ import { useSidebar } from '@/shared/ui/mui-compat/sidebar';
 import type { Workspace } from '@smartspace/chat-ui';
 import { messagesKeys, threadsKeys, workspaceKeys } from '@smartspace/chat-ui';
 
-import { useWorkspaceSubscriptions } from './useWorkspaceSubscriptions';
-
 export function useWorkspaceSwitcherVm() {
   const [open, setOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
@@ -27,8 +25,6 @@ export function useWorkspaceSwitcherVm() {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const { workspaceId } = useRouteIds();
-
-  useWorkspaceSubscriptions();
 
   const queryClient = useQueryClient();
 


### PR DESCRIPTION
## Summary

PR 1 of the seven-PR post-#248 cleanup sequence. Three independent, low-risk wins:

- **3.1 — UUID for optimistic ids.** `temp-${Date.now()}` collides when multiple optimistic items are constructed in the same tick. Switched message + comment optimistic ids to `crypto.randomUUID()`.
- **7.2 — `useWorkspace` enable gate.** Added `enabled: !!workspaceId` so the query no longer fires with an empty key.
- **7.1 — Move `useWorkspaceSubscriptions` to workspace layout.** Realtime now binds to the workspace layout lifetime instead of the switcher's render lifetime.

## Test plan

- [x] `pnpm run lint` — green
- [x] `pnpm run typecheck` — green
- [x] `pnpm test` — green
- [ ] Manual smoke: send a message, receive an SSE response, switch workspaces; threads/messages still render and update in realtime