### PR TITLE
chore(comments): show relative timestamps with absolute hover tooltip

### DIFF
--- a/src/ui/comments_draw/sidebar-right.tsx
+++ b/src/ui/comments_draw/sidebar-right.tsx
@@ -30,6 +30,7 @@ import {
   SidebarFooter,
   SidebarHeader,
 } from '@/shared/ui/mui-compat/sidebar';
+import { Tooltip } from '@/shared/ui/mui-compat/tooltip';
 import { isDraftThreadId } from '@/shared/utils/threadId';
 
 import type { MarkdownEditorHandle } from '@smartspace/chat-ui';
@@ -37,6 +38,7 @@ import {
   MarkdownEditor,
   getUserPhotoUrl,
   parseDateTime,
+  parseDateTimeHuman,
 } from '@smartspace/chat-ui';
 
 import { getInitials } from '../../shared/utils/initials';
@@ -221,9 +223,14 @@ export function SidebarRight() {
                         <p className="text-xs font-medium truncate">
                           {comment.createdBy}
                         </p>
-                        <p className="text-xs text-muted-foreground">
-                          {parseDateTime(comment.createdAt)}
-                        </p>
+                        <Tooltip
+                          title={parseDateTime(comment.createdAt)}
+                          enterDelay={300}
+                        >
+                          <p className="text-xs text-muted-foreground w-fit cursor-default">
+                            {parseDateTimeHuman(comment.createdAt)}
+                          </p>
+                        </Tooltip>
                       </div>
                     </div>
                     <p className="text-sm leading-relaxed flex flex-wrap gap-1">


### PR DESCRIPTION
## Summary

Comment timestamps in the comments drawer rendered the absolute datetime (`2026-05-06 14:23:11`) while threads list and notifications panel both use the "x ago" relative format. Switch comments to `parseDateTimeHuman` for consistency. The absolute timestamp lives in a `title` attribute so hovering still surfaces the exact time.

## Test plan

- [x] `pnpm run lint` — green
- [x] `pnpm run typecheck` — green
- [ ] Open the comments drawer on a thread; comment timestamps now read "x minutes ago" instead of an ISO-ish datetime
- [ ] Hover a comment timestamp; tooltip shows the absolute datetime