### PR TITLE
chore(chat-ui): drop unused opts param from useMessages

### DIFF
--- a/packages/chat-ui/src/domains/messages/queries.ts
+++ b/packages/chat-ui/src/domains/messages/queries.ts
@@ -37,21 +37,13 @@ export const messagesListOptions = (
     staleTime: 30_000,
   });
 
-export function useMessages(
-  threadId: string,
-  opts?: { take?: number; skip?: number; skipWhenNewThread?: boolean }
-) {
+export function useMessages(threadId: string) {
   const service = useChatService();
   const isDraft = isDraftThreadId(threadId);
-  const skipFetch = opts?.skipWhenNewThread || !threadId || isDraft;
-  const listOpts =
-    opts?.take != null || opts?.skip != null
-      ? { take: opts.take, skip: opts.skip }
-      : undefined;
   return useQuery({
-    ...messagesListOptions(service, threadId, listOpts),
-    enabled: !opts?.skipWhenNewThread && !!threadId && !isDraft,
-    initialData: skipFetch ? [] : undefined,
+    ...messagesListOptions(service, threadId),
+    enabled: !!threadId && !isDraft,
+    initialData: !threadId || isDraft ? [] : undefined,
   });
 }
 


### PR DESCRIPTION
## Summary

PR 3 of the seven-PR post-#248 cleanup sequence.

`useMessages` accepted `take` / `skip` / `skipWhenNewThread` options that no caller passed. Paged loading is handled by `useInfiniteMessages`, and `messagesListOptions` stays exported for `ensureQueryData` consumers that need it. Tighten the hook signature to take only `threadId`.

This is a public-API change for `@smartspace/chat-ui` — worth a quick check with sandbox/admin-app forks if any consume it, but the only repo caller (`MessageList.tsx`) already calls it with no opts.

## Test plan

- [x] `pnpm run lint` — green
- [x] `pnpm run typecheck` — green
- [x] `pnpm test` — green
- [ ] Manual smoke: open a thread, messages render; switch threads, new thread's messages render; send a message + confirm POST→SSE flow still works