### PR TITLE
chore(domains): drop export * re-exports of @smartspace/chat-ui from domain barrels

### DIFF
--- a/src/domains/files/index.ts
+++ b/src/domains/files/index.ts
@@ -1,4 +1,5 @@
-// App-side files domain barrel — pure re-export from the package.
-// The legacy SDK-bound service stays at @/domains/files/service for the
+// App-side files domain barrel — currently no app-only exports. Files
+// surface (FileInfo, useFileMutations, etc.) lives at `@smartspace/chat-ui`;
+// the legacy SDK-bound service stays at `@/domains/files/service` for the
 // defaultChatService delegation.
-export * from '@smartspace/chat-ui';
+export {};

--- a/src/domains/messages/index.ts
+++ b/src/domains/messages/index.ts
@@ -1,8 +1,6 @@
-// App-side messages domain barrel.
-//
-// Re-exports the package's chat-side surface plus the app-only service
-// + the legacy useThreadMessageStream hook (still in app because it
-// depends on @/platform/log and the SDK-bound streamThreadMessages).
-export * from '@smartspace/chat-ui';
+// App-side messages domain barrel — exports the app-only SDK-bound service
+// and the legacy `useThreadMessageStream` hook. Package chat-side exports
+// (model, queries, mutations, mappers, queryKeys) live at `@smartspace/chat-ui`
+// and should be imported from there directly.
 export * from './service';
 export { useThreadMessageStream } from './threadStream';

--- a/src/domains/threads/index.ts
+++ b/src/domains/threads/index.ts
@@ -1,12 +1,7 @@
-// App-side threads domain barrel.
-//
-// Re-exports the package's chat-side surface (model, queryKeys, cache helpers,
-// chat queries) AND the app-only sidebar surface (paginated lists, mutations,
-// draft thread helpers, service). This keeps `@/domains/threads` working for
-// every existing call site without touching them.
-export * from '@smartspace/chat-ui';
-
-// Sidebar / non-chat exports stay in app.
+// App-side threads domain barrel — exports the app-only sidebar surface
+// (paginated lists, mutations, draft thread helpers, service). Package
+// chat-side exports (model, queryKeys, cache helpers, chat queries) live
+// at `@smartspace/chat-ui` and should be imported from there directly.
 export { ensureDraftThread, removeDraftThread } from './draftThread';
 export { useDeleteThread, useRenameThread, useSetPin } from './mutations';
 export { threadsListOptions, useInfiniteThreads, useThreads } from './queries';

--- a/src/domains/workspaces/index.ts
+++ b/src/domains/workspaces/index.ts
@@ -1,8 +1,6 @@
-// App-side workspaces domain barrel.
-//
-// Re-exports the package's chat-side surface (model, queryKeys, useWorkspace,
-// taggable users) plus the app-only sidebar surface (workspacesListOptions /
-// useWorkspaces / fetchWorkspaces).
-export * from '@smartspace/chat-ui';
+// App-side workspaces domain barrel — exports the app-only sidebar surface
+// (paginated workspaces list, fetch helpers). Package chat-side exports
+// (model, queryKeys, useWorkspace, taggable users) live at `@smartspace/chat-ui`
+// and should be imported from there directly.
 export { useWorkspaces, workspacesListOptions } from './queries';
 export { fetchTaggableUsers, fetchWorkspace, fetchWorkspaces } from './service';

--- a/src/pages/WorkspaceThreadPage/chat.tsx
+++ b/src/pages/WorkspaceThreadPage/chat.tsx
@@ -6,7 +6,7 @@ import { Toaster } from 'sonner';
 
 import { isInTeams } from '@/platform/auth/msalConfig';
 
-import { useWorkspace, useWorkspaces } from '@/domains/workspaces';
+import { useWorkspaces } from '@/domains/workspaces';
 
 import SidebarRightPanel from '@/ui/comments_draw/sidebar-right';
 import ChatHeaderBar from '@/ui/header/chat-header';
@@ -17,7 +17,11 @@ import { useSidebar } from '@/shared/ui/mui-compat/sidebar';
 
 import { getBackgroundGradientClasses } from '@/theme/tag-styles';
 
-import { MessageComposer, MessageList } from '@smartspace/chat-ui';
+import {
+  MessageComposer,
+  MessageList,
+  useWorkspace,
+} from '@smartspace/chat-ui';
 
 export default function ChatBotPage({
   workspaceId,

--- a/src/ui/workspaces/WorkspaceSwitcher.vm.ts
+++ b/src/ui/workspaces/WorkspaceSwitcher.vm.ts
@@ -7,12 +7,17 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useRouteIds } from '@/platform/routing/RouteIdsProvider';
 
 import { commentsKeys } from '@/domains/comments/queryKeys';
-import { useWorkspace, useWorkspaces } from '@/domains/workspaces';
+import { useWorkspaces } from '@/domains/workspaces';
 
 import { useSidebar } from '@/shared/ui/mui-compat/sidebar';
 
 import type { Workspace } from '@smartspace/chat-ui';
-import { messagesKeys, threadsKeys, workspaceKeys } from '@smartspace/chat-ui';
+import {
+  messagesKeys,
+  threadsKeys,
+  useWorkspace,
+  workspaceKeys,
+} from '@smartspace/chat-ui';
 
 import { useWorkspaceSubscriptions } from './useWorkspaceSubscriptions';
 


### PR DESCRIPTION
## Summary

PR 4 of the seven-PR post-#248 cleanup sequence.

The threads / messages / files / workspaces domain barrels each laundered the entire `@smartspace/chat-ui` public surface via `export *`. That made the layered-architecture lint rules toothless — every package symbol was importable from `@/domains/...`, hiding cross-domain leaks.

- Replace the `export *` lines with the app-only sidebar surface (paginated lists, mutations, draft helpers, services, `useThreadMessageStream`).
- Only one real call-site relied on the star: `useWorkspace` was being imported from `@/domains/workspaces` in `WorkspaceSwitcher.vm.ts` and `chat.tsx`. Repointed both to `@smartspace/chat-ui` directly.
- `@/domains/files` had no app-only exports left, so it's now an empty `export {}` barrel (kept rather than deleted to avoid churn from anything importing the path-as-side-effect).

The boundaries plugin is now actually load-bearing.

## Test plan

- [x] `pnpm run lint` — green
- [x] `pnpm run typecheck` — green (this is the real check — typecheck would have surfaced any caller that was leaning on the star)
- [x] `pnpm test` — green
- [ ] Manual smoke: open a workspace, list of workspaces in switcher renders, switch between them, threads + messages still load, comments drawer still works