### PR TITLE
chore(chat-ui): wrap window.__ssDownloadFile in useEffect

### DIFF
--- a/packages/chat-ui/src/messages/MessageComposer.tsx
+++ b/packages/chat-ui/src/messages/MessageComposer.tsx
@@ -22,7 +22,6 @@ import { createPortal } from 'react-dom';
 import type { FileInfo } from '@/domains/files/model';
 import { useFileMutations } from '@/domains/files/mutations';
 
-
 import type { MarkdownEditorHandle } from '@/shared/markdown/MarkdownEditor';
 import { MarkdownEditor } from '@/shared/markdown/MarkdownEditor';
 import { Button as UIButton } from '@/shared/mui-compat/button';
@@ -162,12 +161,16 @@ export default function MessageComposer({
     workspaceId,
     threadId: isDraftThread ? undefined : threadId,
   });
-  // Provide a global downloader for ssImage node views (non-React context)
-  if (typeof window !== 'undefined') {
-    window.__ssDownloadFile = async (id: string) => {
-      return await getFileBlobUrl(id);
+  // Provide a global downloader for ssImage node views (non-React context).
+  // Milkdown's image node view reads `window.__ssDownloadFile` by name on
+  // first render, so an effect-based assignment runs early enough.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.__ssDownloadFile = (id: string) => getFileBlobUrl(id);
+    return () => {
+      if (window.__ssDownloadFile) delete window.__ssDownloadFile;
     };
-  }
+  }, [getFileBlobUrl]);
   const onUploadFiles = async (files: File[]) => {
     const res = await uploadFilesMutation.mutateAsync(files);
     return res.map(({ id, name }) => ({ id, name }));


### PR DESCRIPTION
## Summary

PR 5 of the seven-PR post-#248 cleanup sequence.

The bare \`window.__ssDownloadFile = ...\` assignment in \`MessageComposer\` ran on every render and never cleaned up. Move it into a \`useEffect\` keyed on \`getFileBlobUrl\` so it only re-binds when the downloader changes, and clean up on unmount.

Milkdown's image node view reads \`window.__ssDownloadFile\` by name on first render — not at module init — so an effect-based assignment lands before the read.

Object-URL revocation is intentionally deferred (PR plan note); current "leak" is tab-bounded.

## Test plan

- [x] \`pnpm run lint\` — green
- [x] \`pnpm run typecheck\` — green
- [x] \`pnpm test\` — green
- [ ] Manual: open a thread with markdown messages that include image attachments — images should still render (the ssImage node view still gets its downloader).
- [ ] Manual: paste / upload an image into the composer; render preview works.
- [ ] Manual: navigate between threads; image-bearing messages still render.