### PR TITLE
chore(chat-ui): version thread-summary writes to reject stale ones

### DIFF
--- a/packages/chat-ui/src/domains/threads/cache.ts
+++ b/packages/chat-ui/src/domains/threads/cache.ts
@@ -21,10 +21,36 @@ type ThreadsListCache =
  * created one) can fall back to invalidating the list queries when this
  * returns `false`.
  */
+/**
+ * True when a stale summary should be ignored — the cache already holds a
+ * write whose `summaryEmittedAt` is strictly newer than the incoming one.
+ * Equal-or-undefined timestamps fall through (incoming wins) so the function
+ * stays a no-op for legacy callers that never set the field.
+ */
+function isStaleSummary(
+  incoming: Pick<MessageThread, 'summaryEmittedAt'>,
+  existing: Pick<MessageThread, 'summaryEmittedAt'> | undefined
+): boolean {
+  if (!existing) return false;
+  if (typeof existing.summaryEmittedAt !== 'number') return false;
+  if (typeof incoming.summaryEmittedAt !== 'number') return false;
+  return incoming.summaryEmittedAt < existing.summaryEmittedAt;
+}
+
 export function applyThreadToCache(
   qc: QueryClient,
   thread: MessageThread
 ): boolean {
+  // Reject stale summaries (e.g. SignalR's lagged DB write landing after a
+  // fresher SSE thread frame). The detail-cache check is authoritative
+  // because every server-emitted summary writes there first.
+  const existingDetail = qc.getQueryData<MessageThread>(
+    threadsKeys.detail(thread.workSpaceId, thread.id)
+  );
+  if (isStaleSummary(thread, existingDetail)) {
+    return false;
+  }
+
   qc.setQueryData<MessageThread>(
     threadsKeys.detail(thread.workSpaceId, thread.id),
     (old) => ({ ...(old ?? thread), ...thread })
@@ -51,6 +77,7 @@ export function applyThreadToCache(
           if (!page?.data) return page;
           const idx = page.data.findIndex((t) => t.id === thread.id);
           if (idx === -1) return page;
+          if (isStaleSummary(thread, page.data[idx])) return page;
           changed = true;
           foundInList = true;
           const nextData = page.data.slice();
@@ -63,6 +90,7 @@ export function applyThreadToCache(
       if (!list.data) return old;
       const idx = list.data.findIndex((t) => t.id === thread.id);
       if (idx === -1) return old;
+      if (isStaleSummary(thread, list.data[idx])) return old;
       foundInList = true;
       const nextData = list.data.slice();
       nextData[idx] = { ...nextData[idx], ...thread };

--- a/packages/chat-ui/src/domains/threads/mapper.ts
+++ b/packages/chat-ui/src/domains/threads/mapper.ts
@@ -15,18 +15,20 @@ type ThreadsResponseDto = z.infer<typeof threadsListResponseSchema>;
 type ThreadDto = z.infer<typeof threadResponseSchema>;
 
 export function mapThreadDtoToModel(dto: ThreadDto): MessageThread {
+  const lastUpdatedAt = utcDate(dto.lastUpdatedAt);
   return {
     id: dto.id,
     createdAt: utcDate(dto.createdAt),
     createdBy: dto.createdBy ?? '',
     createdByUserId: dto.createdByUserId,
     isFlowRunning: dto.isFlowRunning,
-    lastUpdatedAt: utcDate(dto.lastUpdatedAt),
+    lastUpdatedAt,
     lastUpdatedByUserId: dto.lastUpdatedByUserId,
     name: dto.name ?? '',
     totalMessages: dto.totalMessages,
     pinned: dto.favorited,
     workSpaceId: dto.workSpaceId,
+    summaryEmittedAt: lastUpdatedAt.getTime(),
   };
 }
 
@@ -43,17 +45,19 @@ export function mapThreadsResponseDtoToModel(
 export function mapSignalRThreadSummaryToModel(
   summary: SignalR.MessageThreadSummary
 ): MessageThread {
+  const lastUpdatedAt = utcDate(summary.lastUpdatedAt);
   return {
     id: summary.id,
     createdAt: utcDate(summary.createdAt),
     createdBy: summary.createdBy ?? '',
     createdByUserId: summary.createdByUserId,
     isFlowRunning: summary.isFlowRunning,
-    lastUpdatedAt: utcDate(summary.lastUpdatedAt),
+    lastUpdatedAt,
     lastUpdatedByUserId: summary.lastUpdatedByUserId,
     name: summary.name ?? '',
     totalMessages: summary.totalMessages,
     pinned: summary.favorited,
     workSpaceId: summary.workSpaceId,
+    summaryEmittedAt: lastUpdatedAt.getTime(),
   };
 }

--- a/packages/chat-ui/src/domains/threads/model.ts
+++ b/packages/chat-ui/src/domains/threads/model.ts
@@ -10,6 +10,14 @@ export type MessageThread = {
   totalMessages: number;
   pinned: boolean;
   workSpaceId: string;
+  /**
+   * Monotonic version of when this summary was emitted (epoch ms). Used by
+   * `applyThreadToCache` to reject stale writes — e.g. a SignalR summary
+   * landing after a fresher SSE thread frame because the server's DB write
+   * lagged Redis. Mappers derive this from `lastUpdatedAt`; client-side
+   * writers like `ensureDraftThread` use `Date.now()`.
+   */
+  summaryEmittedAt: number;
 };
 
 export type ThreadsResponse = {

--- a/src/domains/threads/__tests__/cache.spec.ts
+++ b/src/domains/threads/__tests__/cache.spec.ts
@@ -1,0 +1,85 @@
+import { QueryClient } from '@tanstack/react-query';
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyThreadToCache,
+  type MessageThread,
+  threadsKeys,
+} from '@smartspace/chat-ui';
+
+const thread = (over: Partial<MessageThread> = {}): MessageThread => ({
+  id: 't1',
+  workSpaceId: 'w1',
+  name: 'Thread',
+  createdAt: new Date('2024-01-01T00:00:00Z'),
+  createdBy: 'me',
+  createdByUserId: 'u1',
+  isFlowRunning: false,
+  lastUpdatedAt: new Date('2024-01-01T00:00:00Z'),
+  lastUpdatedByUserId: 'u1',
+  totalMessages: 0,
+  pinned: false,
+  summaryEmittedAt: 1000,
+  ...over,
+});
+
+describe('applyThreadToCache stale-summary guard', () => {
+  it('rejects a write whose summaryEmittedAt is older than the existing detail cache', () => {
+    const qc = new QueryClient();
+    const fresh = thread({ summaryEmittedAt: 2000, isFlowRunning: false });
+    qc.setQueryData<MessageThread>(
+      threadsKeys.detail(fresh.workSpaceId, fresh.id),
+      fresh
+    );
+
+    const stale = thread({ summaryEmittedAt: 1000, isFlowRunning: true });
+    const applied = applyThreadToCache(qc, stale);
+
+    expect(applied).toBe(false);
+    const after = qc.getQueryData<MessageThread>(
+      threadsKeys.detail(fresh.workSpaceId, fresh.id)
+    );
+    // Detail cache still holds the fresher write.
+    expect(after?.isFlowRunning).toBe(false);
+    expect(after?.summaryEmittedAt).toBe(2000);
+  });
+
+  it('accepts a write whose summaryEmittedAt is newer than the existing detail cache', () => {
+    const qc = new QueryClient();
+    const old = thread({ summaryEmittedAt: 1000, isFlowRunning: true });
+    qc.setQueryData<MessageThread>(
+      threadsKeys.detail(old.workSpaceId, old.id),
+      old
+    );
+
+    const fresh = thread({ summaryEmittedAt: 2000, isFlowRunning: false });
+    applyThreadToCache(qc, fresh);
+
+    const after = qc.getQueryData<MessageThread>(
+      threadsKeys.detail(old.workSpaceId, old.id)
+    );
+    expect(after?.isFlowRunning).toBe(false);
+    expect(after?.summaryEmittedAt).toBe(2000);
+  });
+
+  it('accepts a write when the existing cache entry has no summaryEmittedAt (legacy)', () => {
+    const qc = new QueryClient();
+    const legacy = thread({
+      isFlowRunning: true,
+      // simulate a legacy cached value without the version field
+      summaryEmittedAt: undefined as unknown as number,
+    });
+    qc.setQueryData<MessageThread>(
+      threadsKeys.detail(legacy.workSpaceId, legacy.id),
+      legacy
+    );
+
+    const incoming = thread({ summaryEmittedAt: 1000, isFlowRunning: false });
+    applyThreadToCache(qc, incoming);
+
+    const after = qc.getQueryData<MessageThread>(
+      threadsKeys.detail(legacy.workSpaceId, legacy.id)
+    );
+    expect(after?.isFlowRunning).toBe(false);
+  });
+});

--- a/src/domains/threads/draftThread.ts
+++ b/src/domains/threads/draftThread.ts
@@ -148,6 +148,7 @@ export function ensureDraftThread(
     totalMessages: 0,
     pinned: false,
     workSpaceId: workspaceId,
+    summaryEmittedAt: now.getTime(),
   };
 
   queryClient.setQueryData(


### PR DESCRIPTION
## Summary

PR 6 of the seven-PR post-#248 cleanup sequence — the most invasive one.

The chat-ui has multiple writers to the thread detail/list caches (SignalR \`receiveThreadUpdate\`, the SSE thread frame, the message-send mutation's optimistic patch, the draft-thread bootstrap). When SignalR's DB write lags Redis, a stale summary can land after a fresher SSE thread frame and clobber it — visible as \`isFlowRunning\` flickering or a running indicator that won't clear.

- Add \`summaryEmittedAt: number\` to \`MessageThread\`.
- Mappers derive it from \`lastUpdatedAt\` (the only server-side monotonic field on the summary). \`ensureDraftThread\` uses \`Date.now()\`.
- \`applyThreadToCache\` rejects incoming writes whose \`summaryEmittedAt\` is strictly older than what the cache already holds. Equal-or-undefined timestamps fall through so the function stays a no-op for legacy callers.
- Adds three unit tests at \`src/domains/threads/__tests__/cache.spec.ts\` covering older-rejected, newer-accepted, and legacy-no-version-field paths.

## Test plan

- [x] \`pnpm run lint\` — green
- [x] \`pnpm run typecheck\` — green
- [x] \`pnpm test\` — green (new tests included)
- [ ] Manual: send a message in a thread, watch the running indicator. The terminal SSE frame should clear it cleanly without re-flashing back on (which previously could happen if a lagged SignalR \`isFlowRunning: true\` summary landed after the SSE terminal).
- [ ] Manual: open a thread in two tabs. Activity in one tab should still update the other's thread list (older summaries now ignored, but newer ones still apply).
- [ ] Manual: create a new thread (draft). The \`Date.now()\` summaryEmittedAt should let the first server summary supersede it cleanly.