### PR TITLE
chore(chat-ui): polish ss-attach image loading + cache blob URLs across thread switches

### DIFF
--- a/packages/chat-ui/src/domains/files/mutations.ts
+++ b/packages/chat-ui/src/domains/files/mutations.ts
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -11,6 +11,7 @@ import { filesKeys } from './queryKeys';
 export const useFileMutations = (scope: FileScope) => {
   const { workspaceId, threadId } = scope;
   const service = useChatService();
+  const queryClient = useQueryClient();
 
   const [uploadedFiles, setUploadedFiles] = useState<FileInfo[]>([]);
   const [fileProgress, setFileProgress] = useState<Record<string, number>>({});
@@ -85,12 +86,25 @@ export const useFileMutations = (scope: FileScope) => {
         : ('uploading' as const),
     }));
 
+  // Cache blob URLs by file id across thread switches / remounts. File bytes
+  // are immutable per id, so the entry never goes stale and we keep it for
+  // the session (gcTime: Infinity). The blob memory survives until the page
+  // unloads, which is fine for a chat session.
   const getFileBlobUrl = useCallback(
-    async (id: string) => {
-      const blob = await service.downloadFile(id, { workspaceId, threadId });
-      return URL.createObjectURL(blob);
-    },
-    [service, workspaceId, threadId]
+    (id: string) =>
+      queryClient.fetchQuery({
+        queryKey: filesKeys.downloadBlob(id),
+        queryFn: async () => {
+          const blob = await service.downloadFile(id, {
+            workspaceId,
+            threadId,
+          });
+          return URL.createObjectURL(blob);
+        },
+        staleTime: Infinity,
+        gcTime: Infinity,
+      }),
+    [queryClient, service, workspaceId, threadId]
   );
 
   return {

--- a/packages/chat-ui/src/shared/markdown/extensions/ssImage.ts
+++ b/packages/chat-ui/src/shared/markdown/extensions/ssImage.ts
@@ -150,7 +150,8 @@ export const ssImageView = $view(ssImageNode, (ctx) => (node) => {
   removeBtn.type = 'button';
   removeBtn.className = 'ss-attach__remove';
   removeBtn.setAttribute('aria-label', 'Remove image');
-  removeBtn.textContent = '×';
+  removeBtn.innerHTML =
+    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="6" y1="6" x2="18" y2="18"/><line x1="18" y1="6" x2="6" y2="18"/></svg>';
   removeBtn.addEventListener('mousedown', (e) => {
     // prevent ProseMirror from moving selection/caret weirdly
     e.preventDefault();
@@ -171,8 +172,11 @@ export const ssImageView = $view(ssImageNode, (ctx) => (node) => {
     }
   });
 
-  // Show lightweight placeholder while downloading (do not set img.src yet)
+  // Show lightweight placeholder while downloading (do not set img.src yet).
+  // Hide the bare <img> so the broken-image icon/alt text doesn't render
+  // beneath the spinner.
   img.style.background = 'rgba(0,0,0,0.04)';
+  img.style.visibility = 'hidden';
   let hasSetRealSrc = false;
 
   // Hide spinner once image loads (or errors)
@@ -180,11 +184,13 @@ export const ssImageView = $view(ssImageNode, (ctx) => (node) => {
     if (!hasSetRealSrc) return;
     spinner.remove();
     img.style.background = '';
+    img.style.visibility = '';
   });
   img.addEventListener('error', () => {
     if (!hasSetRealSrc) return;
     spinner.remove();
     img.style.background = 'rgba(255,0,0,0.06)';
+    img.style.visibility = '';
   });
 
   // Fetch via app API (window hook to avoid bundling React inside NodeView)

--- a/packages/chat-ui/src/shared/markdown/renderers/SsImage.tsx
+++ b/packages/chat-ui/src/shared/markdown/renderers/SsImage.tsx
@@ -95,6 +95,7 @@ export function SsImage(props: ImgProps) {
         title={title}
         width={finalWidth as number | string | undefined}
         height={finalHeight as number | string | undefined}
+        style={!resolvedSrc && !errored ? { visibility: 'hidden' } : undefined}
       />
     </span>
   );

--- a/packages/chat-ui/src/shared/markdown/styles.css
+++ b/packages/chat-ui/src/shared/markdown/styles.css
@@ -4,14 +4,17 @@
 }
 
 .ss-attach {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   vertical-align: middle;
-  border-radius: 6px;
-  background: color-mix(in srgb, var(--muted), white 80%);
-  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: hsl(var(--muted, 0 0% 96%));
+  border: 1px solid hsl(var(--border, 0 0% 89%));
   overflow: hidden;
+  min-width: 32px;
+  min-height: 32px;
 }
 
 .ss-attach--image {
@@ -21,6 +24,70 @@
 .ss-attach__img {
   display: block;
   object-fit: contain;
+  border-radius: 6px;
+}
+
+/* Loading spinner overlay shared by Milkdown node view and read-only renderer */
+.ss-attach__spinner {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 22px;
+  height: 22px;
+  margin: -11px 0 0 -11px;
+  border-radius: 50%;
+  border: 2px solid hsl(var(--muted-foreground, 0 0% 40%) / 0.25);
+  border-top-color: hsl(var(--foreground, 0 0% 10%));
+  animation: ss-attach-spin 0.7s linear infinite;
+  pointer-events: none;
+  z-index: 1;
+  box-sizing: border-box;
+}
+
+@keyframes ss-attach-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Remove (X) button — only present in editable Milkdown node view. */
+.ss-attach__remove {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border-radius: 50%;
+  border: 1px solid hsl(var(--border, 0 0% 89%));
+  background: rgba(255, 255, 255, 0.95);
+  color: hsl(var(--muted-foreground, 0 0% 40%));
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  font: inherit;
+  opacity: 0;
+  transition: opacity 0.15s ease, color 0.15s ease, background 0.15s ease;
+  z-index: 2;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+
+.ss-attach:hover .ss-attach__remove,
+.ss-attach__remove:focus-visible {
+  opacity: 1;
+}
+
+.ss-attach__remove:hover {
+  color: #dc2626;
+  background: #fff;
+}
+
+.ss-attach__remove svg {
+  width: 12px;
+  height: 12px;
+  display: block;
 }
 
 .md-editor .ProseMirror {

--- a/packages/chat-ui/src/styles.css
+++ b/packages/chat-ui/src/styles.css
@@ -147,14 +147,17 @@
 }
 
 .ss-attach {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   vertical-align: middle;
-  border-radius: 6px;
-  background: color-mix(in srgb, var(--muted), white 80%);
-  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: hsl(var(--muted, 0 0% 96%));
+  border: 1px solid hsl(var(--border, 0 0% 89%));
   overflow: hidden;
+  min-width: 32px;
+  min-height: 32px;
 }
 
 .ss-attach--image {
@@ -164,6 +167,70 @@
 .ss-attach__img {
   display: block;
   object-fit: contain;
+  border-radius: 6px;
+}
+
+/* Loading spinner overlay shared by Milkdown node view and read-only renderer */
+.ss-attach__spinner {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 22px;
+  height: 22px;
+  margin: -11px 0 0 -11px;
+  border-radius: 50%;
+  border: 2px solid hsl(var(--muted-foreground, 0 0% 40%) / 0.25);
+  border-top-color: hsl(var(--foreground, 0 0% 10%));
+  animation: ss-attach-spin 0.7s linear infinite;
+  pointer-events: none;
+  z-index: 1;
+  box-sizing: border-box;
+}
+
+@keyframes ss-attach-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Remove (X) button — only present in editable Milkdown node view. */
+.ss-attach__remove {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border-radius: 50%;
+  border: 1px solid hsl(var(--border, 0 0% 89%));
+  background: rgba(255, 255, 255, 0.95);
+  color: hsl(var(--muted-foreground, 0 0% 40%));
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  font: inherit;
+  opacity: 0;
+  transition: opacity 0.15s ease, color 0.15s ease, background 0.15s ease;
+  z-index: 2;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+
+.ss-attach:hover .ss-attach__remove,
+.ss-attach__remove:focus-visible {
+  opacity: 1;
+}
+
+.ss-attach__remove:hover {
+  color: #dc2626;
+  background: #fff;
+}
+
+.ss-attach__remove svg {
+  width: 12px;
+  height: 12px;
+  display: block;
 }
 
 .md-editor .ProseMirror {


### PR DESCRIPTION
## Summary

- **Loading / border / remove-X visuals.** Style the shared `.ss-attach` wrapper (used by both the Milkdown editable node view and the read-only react-markdown renderer) so loading state shows a centered circular spinner inside a bordered frame, and the inline remove button is a circular top-right X with an SVG glyph instead of the previous `×` text glyph dangling outside the image.
- **Hide the broken-image / alt-text bleed-through while loading.** Set `visibility: hidden` on the `<img>` until the blob URL resolves so the browser's broken-image icon and alt-text filename don't render under the spinner.
- **Fix CSS variable usage.** The shadcn-style design tokens (`--border`, `--muted`, `--muted-foreground`, `--foreground`) are stored as raw HSL channels (`252.61 90% 92.16%`). The new rules wrap them in `hsl(...)` so the border, background, and spinner stroke actually paint instead of silently falling back.
- **Cache file blob URLs across thread switches.** Route `getFileBlobUrl` through `queryClient.fetchQuery` keyed on file id with `staleTime: Infinity` / `gcTime: Infinity`. File bytes are immutable per id, so re-renders, parallel `<SsImage>` instances, and switching threads-and-back all hit the cache instead of re-downloading and re-minting blob URLs.

## Test plan

- [ ] In a chat composer, paste an image (e.g. `Win + Shift + S`, then `Ctrl + V`). Confirm: bordered frame appears immediately, centered spinner spins, no filename / broken-image icon visible during load, image fades in once download completes.
- [ ] Hover the inserted image. Confirm: circular X appears in the top-right inside the border. Click it — image is removed from the editor.
- [ ] Send the message and verify the same image renders cleanly inside the read-only message bubble (border + spinner during load, no alt-text flash).
- [ ] Open a workspace thread that already contains image messages. Confirm spinners show, then images load.
- [ ] Switch to another thread, then switch back to the original thread. Confirm images appear **instantly with no spinner flash** (cache hit).
- [ ] Open the same thread on a fresh page load (refresh). Confirm images load with a spinner the first time (cache cold).
- [ ] Open a thread with multiple instances of the same file id (e.g. quoted/forwarded). Confirm only one network request is made.
- [ ] Toggle dark mode (if available) and confirm the border / spinner stroke / X button colors still read well.
- [ ] DevTools → Network: trigger a thread switch and confirm previously-loaded `downloadFile` requests aren't repeated.