### PR TITLE
fix: end-of-flow flicker, stuck running indicator, send-time list nuke

### DIFF
--- a/packages/chat-ui/src/domains/messages/mutations.ts
+++ b/packages/chat-ui/src/domains/messages/mutations.ts
@@ -128,12 +128,24 @@ export function useSendMessage() {
         throw err;
       }
 
-      // POST is authoritative for the user's just-sent message. Replace the
-      // entire cache with [realMessage]; the SSE snapshot will fully replace
-      // it again with the server's view (including the AI response slot) the
-      // moment the stream opens. No merging — keeps the message list a
-      // straight reflection of POST → SSE rather than a layered union.
-      qc.setQueryData<Message[]>(messagesKeys.list(threadId), [realMessage]);
+      // Reconcile the optimistic placeholder with the server's realMessage in
+      // place — drop the optimistic, append realMessage if it isn't already
+      // there, otherwise leave the existing entry alone. We previously
+      // replaced the cache with `[realMessage]` and let the SSE snapshot
+      // restore history, but with the (now in use) `/Messages/start`
+      // endpoint the POST resolves in ~50ms while the SSE snapshot can take
+      // a few hundred ms longer; the gap was producing a visible "all old
+      // messages flicker" the moment the user hit send. The duplicate guard
+      // covers the edge case where the SSE happens to deliver `realMessage`
+      // before the POST resolve has run this writer (e.g. SignalR opened the
+      // stream early).
+      qc.setQueryData<Message[]>(messagesKeys.list(threadId), (old = []) => {
+        const withoutOptimistic = old.filter((m) => !m.optimistic);
+        if (withoutOptimistic.some((m) => m.id === realMessage.id)) {
+          return withoutOptimistic;
+        }
+        return [...withoutOptimistic, realMessage];
+      });
 
       // POST returned successfully — the server has accepted the message
       // and the flow is now running. Mirror that in the detail cache so:

--- a/packages/chat-ui/src/domains/messages/mutations.ts
+++ b/packages/chat-ui/src/domains/messages/mutations.ts
@@ -15,6 +15,35 @@ import { MessageValueType } from './enums';
 import { Message, MessageContentItem } from './model';
 import { messagesKeys } from './queryKeys';
 
+/**
+ * Reconcile an optimistic placeholder with a server-confirmed message.
+ *
+ * Drops every entry flagged `optimistic: true` from `old`, then merges
+ * `incoming` into the remaining list:
+ *
+ * - **No match by id** → append.
+ * - **Match exists** → behaviour controlled by `onDuplicate`:
+ *   - `keep-existing` (default): leave the existing entry untouched. Used by
+ *     `useSendMessage` so a richer SSE-delivered version isn't overwritten
+ *     by the sparse `POST /Messages/start` response.
+ *   - `replace`: overwrite the existing entry with `incoming`. Used by
+ *     `useAddInputToMessage`, where the mutation response carries the
+ *     latest server state we want to commit.
+ */
+function reconcileWithMessage(
+  old: Message[],
+  incoming: Message,
+  onDuplicate: 'keep-existing' | 'replace' = 'keep-existing'
+): Message[] {
+  const stable = old.filter((m) => !m.optimistic);
+  const idx = stable.findIndex((m) => m.id === incoming.id);
+  if (idx === -1) return [...stable, incoming];
+  if (onDuplicate === 'keep-existing') return stable;
+  const copy = stable.slice();
+  copy[idx] = incoming;
+  return copy;
+}
+
 type SendArgs = {
   workspaceId: string;
   threadId: string;
@@ -128,24 +157,19 @@ export function useSendMessage() {
         throw err;
       }
 
-      // Reconcile the optimistic placeholder with the server's realMessage in
-      // place — drop the optimistic, append realMessage if it isn't already
-      // there, otherwise leave the existing entry alone. We previously
-      // replaced the cache with `[realMessage]` and let the SSE snapshot
-      // restore history, but with the (now in use) `/Messages/start`
-      // endpoint the POST resolves in ~50ms while the SSE snapshot can take
-      // a few hundred ms longer; the gap was producing a visible "all old
-      // messages flicker" the moment the user hit send. The duplicate guard
-      // covers the edge case where the SSE happens to deliver `realMessage`
-      // before the POST resolve has run this writer (e.g. SignalR opened the
-      // stream early).
-      qc.setQueryData<Message[]>(messagesKeys.list(threadId), (old = []) => {
-        const withoutOptimistic = old.filter((m) => !m.optimistic);
-        if (withoutOptimistic.some((m) => m.id === realMessage.id)) {
-          return withoutOptimistic;
-        }
-        return [...withoutOptimistic, realMessage];
-      });
+      // Reconcile the optimistic placeholder with the server's realMessage
+      // in place. We previously replaced the cache with `[realMessage]` and
+      // relied on the SSE snapshot to restore history, but with the (now
+      // in use) `/Messages/start` endpoint the POST resolves in ~50ms
+      // while the SSE snapshot can take a few hundred ms longer; the gap
+      // was producing a visible "all old messages flicker" the moment the
+      // user hit send. `reconcileWithMessage`'s default `keep-existing`
+      // duplicate strategy ensures that if the SSE happened to deliver
+      // realMessage first (carrying richer in-progress state) we don't
+      // overwrite it with the sparse POST response.
+      qc.setQueryData<Message[]>(messagesKeys.list(threadId), (old = []) =>
+        reconcileWithMessage(old, realMessage)
+      );
 
       // POST returned successfully — the server has accepted the message
       // and the flow is now running. Mirror that in the detail cache so:
@@ -187,7 +211,6 @@ export function useSendMessage() {
   });
 }
 
-// Optional: keep addInputToMessage in a separate hook
 type AddInputArgs = {
   workspaceId?: string; // only needed if you invalidate thread lists
   threadId: string;
@@ -240,14 +263,9 @@ export function useAddInputToMessage() {
       });
     },
     onSuccess: (message, { threadId }) => {
-      qc.setQueryData<Message[]>(messagesKeys.list(threadId), (old = []) => {
-        const stable = old.filter((x) => !x.optimistic);
-        const idx = stable.findIndex((x) => x.id === message.id);
-        if (idx === -1) return [...stable, message];
-        const copy = stable.slice();
-        copy[idx] = message;
-        return copy;
-      });
+      qc.setQueryData<Message[]>(messagesKeys.list(threadId), (old = []) =>
+        reconcileWithMessage(old, message, 'replace')
+      );
     },
     onError: (_e, { threadId }) => {
       // rollback optimistic patch

--- a/packages/chat-ui/src/domains/threads/cache.ts
+++ b/packages/chat-ui/src/domains/threads/cache.ts
@@ -21,10 +21,54 @@ type ThreadsListCache =
  * created one) can fall back to invalidating the list queries when this
  * returns `false`.
  */
+/**
+ * True when a stale summary should be ignored. The guard is intentionally
+ * narrow: we only reject writes that would resurrect a settled `running:
+ * false` back to `true`. That's the only direction the original race can
+ * cause harm in — a stale SignalR `receiveThreadUpdate` arriving after the
+ * SSE terminal frame already wrote `false`.
+ *
+ * Naively rejecting every older-timestamp write breaks the SSE terminal
+ * frame itself: `summaryEmittedAt` is derived from the server's
+ * `lastUpdatedAt` (DB row timestamp), but mid-flow SignalR broadcasts can
+ * carry fresher timestamps than the terminal frame, so a strict
+ * "incoming.ts < existing.ts" rule rejects the very write that should
+ * clear the running indicator. We sidestep that by only flagging writes
+ * that change the running flag in the dangerous direction.
+ *
+ * Equal-or-undefined timestamps always fall through so the function stays
+ * a no-op for callers that don't set the field.
+ */
+function isStaleSummary(
+  incoming: Pick<MessageThread, 'summaryEmittedAt' | 'isFlowRunning'>,
+  existing:
+    | Pick<MessageThread, 'summaryEmittedAt' | 'isFlowRunning'>
+    | undefined
+): boolean {
+  if (!existing) return false;
+  if (typeof existing.summaryEmittedAt !== 'number') return false;
+  if (typeof incoming.summaryEmittedAt !== 'number') return false;
+  if (incoming.summaryEmittedAt >= existing.summaryEmittedAt) return false;
+  // Only block stale writes that would flip a settled "not running" back
+  // to "running". Same-direction or `running → not running` writes go
+  // through even when the timestamp is older.
+  return existing.isFlowRunning === false && incoming.isFlowRunning === true;
+}
+
 export function applyThreadToCache(
   qc: QueryClient,
   thread: MessageThread
 ): boolean {
+  // Reject stale summaries (e.g. SignalR's lagged DB write landing after a
+  // fresher SSE thread frame). The detail-cache check is authoritative
+  // because every server-emitted summary writes there first.
+  const existingDetail = qc.getQueryData<MessageThread>(
+    threadsKeys.detail(thread.workSpaceId, thread.id)
+  );
+  if (isStaleSummary(thread, existingDetail)) {
+    return false;
+  }
+
   qc.setQueryData<MessageThread>(
     threadsKeys.detail(thread.workSpaceId, thread.id),
     (old) => ({ ...(old ?? thread), ...thread })
@@ -51,6 +95,7 @@ export function applyThreadToCache(
           if (!page?.data) return page;
           const idx = page.data.findIndex((t) => t.id === thread.id);
           if (idx === -1) return page;
+          if (isStaleSummary(thread, page.data[idx])) return page;
           changed = true;
           foundInList = true;
           const nextData = page.data.slice();
@@ -63,6 +108,7 @@ export function applyThreadToCache(
       if (!list.data) return old;
       const idx = list.data.findIndex((t) => t.id === thread.id);
       if (idx === -1) return old;
+      if (isStaleSummary(thread, list.data[idx])) return old;
       foundInList = true;
       const nextData = list.data.slice();
       nextData[idx] = { ...nextData[idx], ...thread };

--- a/packages/chat-ui/src/domains/threads/mapper.ts
+++ b/packages/chat-ui/src/domains/threads/mapper.ts
@@ -15,18 +15,20 @@ type ThreadsResponseDto = z.infer<typeof threadsListResponseSchema>;
 type ThreadDto = z.infer<typeof threadResponseSchema>;
 
 export function mapThreadDtoToModel(dto: ThreadDto): MessageThread {
+  const lastUpdatedAt = utcDate(dto.lastUpdatedAt);
   return {
     id: dto.id,
     createdAt: utcDate(dto.createdAt),
     createdBy: dto.createdBy ?? '',
     createdByUserId: dto.createdByUserId,
     isFlowRunning: dto.isFlowRunning,
-    lastUpdatedAt: utcDate(dto.lastUpdatedAt),
+    lastUpdatedAt,
     lastUpdatedByUserId: dto.lastUpdatedByUserId,
     name: dto.name ?? '',
     totalMessages: dto.totalMessages,
     pinned: dto.favorited,
     workSpaceId: dto.workSpaceId,
+    summaryEmittedAt: lastUpdatedAt.getTime(),
   };
 }
 
@@ -43,17 +45,19 @@ export function mapThreadsResponseDtoToModel(
 export function mapSignalRThreadSummaryToModel(
   summary: SignalR.MessageThreadSummary
 ): MessageThread {
+  const lastUpdatedAt = utcDate(summary.lastUpdatedAt);
   return {
     id: summary.id,
     createdAt: utcDate(summary.createdAt),
     createdBy: summary.createdBy ?? '',
     createdByUserId: summary.createdByUserId,
     isFlowRunning: summary.isFlowRunning,
-    lastUpdatedAt: utcDate(summary.lastUpdatedAt),
+    lastUpdatedAt,
     lastUpdatedByUserId: summary.lastUpdatedByUserId,
     name: summary.name ?? '',
     totalMessages: summary.totalMessages,
     pinned: summary.favorited,
     workSpaceId: summary.workSpaceId,
+    summaryEmittedAt: lastUpdatedAt.getTime(),
   };
 }

--- a/packages/chat-ui/src/domains/threads/model.ts
+++ b/packages/chat-ui/src/domains/threads/model.ts
@@ -10,6 +10,14 @@ export type MessageThread = {
   totalMessages: number;
   pinned: boolean;
   workSpaceId: string;
+  /**
+   * Monotonic version of when this summary was emitted (epoch ms). Used by
+   * `applyThreadToCache` to reject stale writes — e.g. a SignalR summary
+   * landing after a fresher SSE thread frame because the server's DB write
+   * lagged Redis. Mappers derive this from `lastUpdatedAt`; client-side
+   * writers like `ensureDraftThread` use `Date.now()`.
+   */
+  summaryEmittedAt: number;
 };
 
 export type ThreadsResponse = {

--- a/packages/chat-ui/src/messages/MessageList.tsx
+++ b/packages/chat-ui/src/messages/MessageList.tsx
@@ -58,15 +58,6 @@ export function MessageList({
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const prevMessageCountRef = useRef<number>(0);
   const hasInitialScrollRef = useRef<boolean>(false);
-  // Per-thread high-water mark of "have we ever rendered messages?". Used to
-  // suppress the welcome / empty-state flash when the messages cache momentarily
-  // returns 0 entries during a transition (e.g. SSE/SignalR ordering at a
-  // flow's terminal frame). Reset on threadId change so a brand-new draft
-  // thread still gets the welcome screen on its first paint.
-  const everHadMessagesRef = useRef<{ threadId: string; had: boolean }>({
-    threadId: '',
-    had: false,
-  });
   const isMobile = useIsMobile();
 
   const { data: activeWorkspace } = useWorkspace(workspaceId);
@@ -167,20 +158,6 @@ export function MessageList({
 
   const safeMessages = messages ?? [];
 
-  // Track per-thread whether we've ever rendered ≥1 message. Reset when the
-  // threadId changes so a fresh draft can legitimately show the welcome
-  // screen on first paint. Used below to suppress loading / error / empty
-  // states once we know the thread has content — those transient states
-  // appear during cache races at flow completion (SSE terminal frame vs.
-  // SignalR vs. mutation invalidation) and would otherwise flash a wrong
-  // page over an in-progress chat.
-  if (everHadMessagesRef.current.threadId !== threadId) {
-    everHadMessagesRef.current = { threadId, had: safeMessages.length > 0 };
-  } else if (safeMessages.length > 0) {
-    everHadMessagesRef.current.had = true;
-  }
-  const hadMessagesBefore = everHadMessagesRef.current.had;
-
   // Avoid flicker: if we already have data, keep rendering it while refetching.
   // `isChoosingThread` is opt-in via prop — see MessageListProps for usage.
   const isLoading =
@@ -188,7 +165,7 @@ export function MessageList({
     ((threadPending || threadFetching) && !thread) ||
     ((messagesPending || messagesFetching) && messages === undefined);
 
-  if (isLoading && !hadMessagesBefore) {
+  if (isLoading) {
     return (
       <div
         className={`ss-chat__body flex-shrink-10 flex-1 overflow-y-auto ${hostBg}`}
@@ -208,7 +185,7 @@ export function MessageList({
       </div>
     );
   }
-  if ((threadError || messagesError) && !hadMessagesBefore) {
+  if (threadError || messagesError) {
     return (
       <div className="flex flex-1 items-center justify-center p-6">
         <div className="w-full max-w-md space-y-3">
@@ -232,19 +209,6 @@ export function MessageList({
   }
 
   if (safeMessages.length === 0) {
-    // If we've previously rendered messages on this thread, a transient empty
-    // cache is almost certainly a race (e.g. mutation cache reset between
-    // POST and SSE snapshot, or a stale write from SignalR after the terminal
-    // SSE frame). Render an empty body so the user doesn't see a "no messages"
-    // flash mid-conversation — the next cache write will repaint the list.
-    if (hadMessagesBefore) {
-      return (
-        <div
-          className={`ss-chat__body flex-shrink-10 flex-1 overflow-y-auto ${hostBg}`}
-          data-ss-layer="message-list"
-        />
-      );
-    }
     return (
       <div className="flex overflow-auto flex-shrink-10 flex-col p-8 text-center">
         <h3 className="text-lg font-medium mb-2">

--- a/packages/chat-ui/src/messages/MessageList.tsx
+++ b/packages/chat-ui/src/messages/MessageList.tsx
@@ -58,6 +58,20 @@ export function MessageList({
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const prevMessageCountRef = useRef<number>(0);
   const hasInitialScrollRef = useRef<boolean>(false);
+  // Per-thread high-water mark of "have we ever rendered messages?". Once
+  // true, the loading / error / empty fallback branches stop returning a
+  // different DOM tree — instead we fall through to the ScrollArea with
+  // whatever's currently in cache (possibly empty for a frame). This both
+  // hides the transient "Failed to load messages" flash that surfaces from
+  // SSE/SignalR/mutation cache races at flow completion, and preserves the
+  // viewport's scrollTop across those blips so the user doesn't get
+  // bounced back to the top of the conversation. Reset on threadId change
+  // so a brand-new draft thread still gets its welcome screen on first
+  // paint.
+  const everHadMessagesRef = useRef<{ threadId: string; had: boolean }>({
+    threadId: '',
+    had: false,
+  });
   const isMobile = useIsMobile();
 
   const { data: activeWorkspace } = useWorkspace(workspaceId);
@@ -158,6 +172,18 @@ export function MessageList({
 
   const safeMessages = messages ?? [];
 
+  // Track per-thread whether we've ever rendered ≥1 message. Once true, fall
+  // through to the ScrollArea below for the rest of the thread's lifetime so
+  // transient cache states (refetch error, momentarily empty cache from a
+  // stale write at flow completion) don't unmount the viewport and bounce
+  // the user back to the top.
+  if (everHadMessagesRef.current.threadId !== threadId) {
+    everHadMessagesRef.current = { threadId, had: safeMessages.length > 0 };
+  } else if (safeMessages.length > 0) {
+    everHadMessagesRef.current.had = true;
+  }
+  const hadMessagesBefore = everHadMessagesRef.current.had;
+
   // Avoid flicker: if we already have data, keep rendering it while refetching.
   // `isChoosingThread` is opt-in via prop — see MessageListProps for usage.
   const isLoading =
@@ -165,7 +191,7 @@ export function MessageList({
     ((threadPending || threadFetching) && !thread) ||
     ((messagesPending || messagesFetching) && messages === undefined);
 
-  if (isLoading) {
+  if (isLoading && !hadMessagesBefore) {
     return (
       <div
         className={`ss-chat__body flex-shrink-10 flex-1 overflow-y-auto ${hostBg}`}
@@ -185,7 +211,7 @@ export function MessageList({
       </div>
     );
   }
-  if (threadError || messagesError) {
+  if ((threadError || messagesError) && !hadMessagesBefore) {
     return (
       <div className="flex flex-1 items-center justify-center p-6">
         <div className="w-full max-w-md space-y-3">
@@ -208,7 +234,7 @@ export function MessageList({
     );
   }
 
-  if (safeMessages.length === 0) {
+  if (safeMessages.length === 0 && !hadMessagesBefore) {
     return (
       <div className="flex overflow-auto flex-shrink-10 flex-col p-8 text-center">
         <h3 className="text-lg font-medium mb-2">

--- a/packages/chat-ui/src/messages/MessageList.tsx
+++ b/packages/chat-ui/src/messages/MessageList.tsx
@@ -58,6 +58,15 @@ export function MessageList({
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const prevMessageCountRef = useRef<number>(0);
   const hasInitialScrollRef = useRef<boolean>(false);
+  // Per-thread high-water mark of "have we ever rendered messages?". Used to
+  // suppress the welcome / empty-state flash when the messages cache momentarily
+  // returns 0 entries during a transition (e.g. SSE/SignalR ordering at a
+  // flow's terminal frame). Reset on threadId change so a brand-new draft
+  // thread still gets the welcome screen on its first paint.
+  const everHadMessagesRef = useRef<{ threadId: string; had: boolean }>({
+    threadId: '',
+    had: false,
+  });
   const isMobile = useIsMobile();
 
   const { data: activeWorkspace } = useWorkspace(workspaceId);
@@ -156,6 +165,22 @@ export function MessageList({
     return () => ro.disconnect();
   }, [isAtBottom, scrollToBottom]);
 
+  const safeMessages = messages ?? [];
+
+  // Track per-thread whether we've ever rendered ≥1 message. Reset when the
+  // threadId changes so a fresh draft can legitimately show the welcome
+  // screen on first paint. Used below to suppress loading / error / empty
+  // states once we know the thread has content — those transient states
+  // appear during cache races at flow completion (SSE terminal frame vs.
+  // SignalR vs. mutation invalidation) and would otherwise flash a wrong
+  // page over an in-progress chat.
+  if (everHadMessagesRef.current.threadId !== threadId) {
+    everHadMessagesRef.current = { threadId, had: safeMessages.length > 0 };
+  } else if (safeMessages.length > 0) {
+    everHadMessagesRef.current.had = true;
+  }
+  const hadMessagesBefore = everHadMessagesRef.current.had;
+
   // Avoid flicker: if we already have data, keep rendering it while refetching.
   // `isChoosingThread` is opt-in via prop — see MessageListProps for usage.
   const isLoading =
@@ -163,7 +188,7 @@ export function MessageList({
     ((threadPending || threadFetching) && !thread) ||
     ((messagesPending || messagesFetching) && messages === undefined);
 
-  if (isLoading) {
+  if (isLoading && !hadMessagesBefore) {
     return (
       <div
         className={`ss-chat__body flex-shrink-10 flex-1 overflow-y-auto ${hostBg}`}
@@ -183,7 +208,7 @@ export function MessageList({
       </div>
     );
   }
-  if (threadError || messagesError) {
+  if ((threadError || messagesError) && !hadMessagesBefore) {
     return (
       <div className="flex flex-1 items-center justify-center p-6">
         <div className="w-full max-w-md space-y-3">
@@ -206,9 +231,20 @@ export function MessageList({
     );
   }
 
-  const safeMessages = messages ?? [];
-
   if (safeMessages.length === 0) {
+    // If we've previously rendered messages on this thread, a transient empty
+    // cache is almost certainly a race (e.g. mutation cache reset between
+    // POST and SSE snapshot, or a stale write from SignalR after the terminal
+    // SSE frame). Render an empty body so the user doesn't see a "no messages"
+    // flash mid-conversation — the next cache write will repaint the list.
+    if (hadMessagesBefore) {
+      return (
+        <div
+          className={`ss-chat__body flex-shrink-10 flex-1 overflow-y-auto ${hostBg}`}
+          data-ss-layer="message-list"
+        />
+      );
+    }
     return (
       <div className="flex overflow-auto flex-shrink-10 flex-col p-8 text-center">
         <h3 className="text-lg font-medium mb-2">

--- a/src/domains/messages/__tests__/mutations.spec.tsx
+++ b/src/domains/messages/__tests__/mutations.spec.tsx
@@ -1,0 +1,138 @@
+import { act } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { renderHookWithChat } from '@/test/chatProviderHarness';
+import {
+  type Message,
+  MessageValueType,
+  messagesKeys,
+  useSendMessage,
+} from '@smartspace/chat-ui';
+
+const baseMessage = (over: Partial<Message> = {}): Message => ({
+  id: 'm-base',
+  values: [
+    {
+      id: 'v-base',
+      type: MessageValueType.INPUT,
+      name: 'prompt',
+      value: 'baseline',
+      channels: {},
+      createdAt: new Date('2024-01-01T00:00:00Z'),
+      createdBy: 'Server',
+      createdByUserId: 'u1',
+    },
+  ],
+  createdAt: new Date('2024-01-01T00:00:00Z'),
+  createdBy: 'Server',
+  createdByUserId: 'u1',
+  ...over,
+});
+
+describe('useSendMessage merge-in-place reconciliation', () => {
+  it('drops the optimistic and appends realMessage when not already present', async () => {
+    const realMessage = baseMessage({ id: 'real-1' });
+    const sendMessage = vi.fn().mockResolvedValueOnce(realMessage);
+    const { result, queryClient } = renderHookWithChat(() => useSendMessage(), {
+      threadId: 't1',
+      service: {
+        sendMessage,
+      } as Parameters<typeof renderHookWithChat>[1] extends infer O
+        ? O extends { service?: infer S }
+          ? S
+          : never
+        : never,
+    });
+
+    // Seed historical messages so we can verify they're preserved.
+    const m1 = baseMessage({ id: 'm1' });
+    const m2 = baseMessage({ id: 'm2' });
+    queryClient.setQueryData<Message[]>(messagesKeys.list('t1'), [m1, m2]);
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        workspaceId: 'w1',
+        threadId: 't1',
+        contentList: [{ text: 'hi', image: undefined }],
+      });
+    });
+
+    const after =
+      queryClient.getQueryData<Message[]>(messagesKeys.list('t1')) ?? [];
+    expect(after.map((m) => m.id)).toEqual(['m1', 'm2', 'real-1']);
+    expect(after.some((m) => m.optimistic)).toBe(false);
+  });
+
+  it('keeps the existing entry when the SSE has already delivered realMessage', async () => {
+    // The SSE could open early (SignalR-triggered) and deliver `realMessage`
+    // with richer state — in-progress AI output, fresher fields — before this
+    // mutation's onSuccess runs. The default `keep-existing` strategy must
+    // not clobber that with the sparse POST response.
+    const richIncoming = baseMessage({
+      id: 'real-1',
+      values: [
+        ...baseMessage().values!,
+        {
+          id: 'ai-out-1',
+          type: MessageValueType.OUTPUT,
+          name: 'response',
+          value: 'AI streaming...',
+          channels: {},
+          createdAt: new Date('2024-01-01T00:00:01Z'),
+          createdBy: 'bot',
+          createdByUserId: 'bot',
+        },
+      ],
+    });
+    const sparseFromPost = baseMessage({ id: 'real-1' }); // inputs only
+    const sendMessage = vi.fn().mockResolvedValueOnce(sparseFromPost);
+    const { result, queryClient } = renderHookWithChat(() => useSendMessage(), {
+      threadId: 't1',
+      service: { sendMessage } as never,
+    });
+
+    queryClient.setQueryData<Message[]>(messagesKeys.list('t1'), [
+      richIncoming,
+    ]);
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        workspaceId: 'w1',
+        threadId: 't1',
+        contentList: [{ text: 'hi', image: undefined }],
+      });
+    });
+
+    const after =
+      queryClient.getQueryData<Message[]>(messagesKeys.list('t1')) ?? [];
+    expect(after).toHaveLength(1);
+    // The richer SSE-delivered version is preserved (still has 2 values).
+    expect(after[0].values?.length).toBe(2);
+  });
+
+  it('rolls back the optimistic when sendMessage rejects', async () => {
+    const sendMessage = vi.fn().mockRejectedValueOnce(new Error('boom'));
+    const { result, queryClient } = renderHookWithChat(() => useSendMessage(), {
+      threadId: 't1',
+      service: { sendMessage } as never,
+    });
+
+    const m1 = baseMessage({ id: 'm1' });
+    queryClient.setQueryData<Message[]>(messagesKeys.list('t1'), [m1]);
+
+    await act(async () => {
+      await expect(
+        result.current.mutateAsync({
+          workspaceId: 'w1',
+          threadId: 't1',
+          contentList: [{ text: 'hi', image: undefined }],
+        })
+      ).rejects.toThrow('boom');
+    });
+
+    const after =
+      queryClient.getQueryData<Message[]>(messagesKeys.list('t1')) ?? [];
+    expect(after.map((m) => m.id)).toEqual(['m1']);
+    expect(after.some((m) => m.optimistic)).toBe(false);
+  });
+});

--- a/src/domains/messages/__tests__/service.spec.ts
+++ b/src/domains/messages/__tests__/service.spec.ts
@@ -144,6 +144,34 @@ describe('messages service', () => {
     ).rejects.toThrow(/status 500/);
   });
 
+  it('postMessage throws on a 4xx response with the status in the message', async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ message: 'bad request' }), {
+          status: 422,
+        })
+    ) as typeof fetch;
+    await expect(
+      postMessage({ workSpaceId: 'w', threadId: 't1' })
+    ).rejects.toThrow(/status 422/);
+  });
+
+  it('postMessage throws a clear error when the body isnt JSON', async () => {
+    // 200 with non-JSON body — e.g. a proxy injecting an HTML error page.
+    // `response.json()` throws; we should surface a meaningful error rather
+    // than the opaque SyntaxError that `JSON.parse` produces.
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response('<html>oops</html>', {
+          status: 200,
+          headers: { 'Content-Type': 'text/html' },
+        })
+    ) as typeof fetch;
+    await expect(
+      postMessage({ workSpaceId: 'w', threadId: 't1' })
+    ).rejects.toThrow(/non-JSON body/);
+  });
+
   it('addInputToMessage throws when no valid message received', async () => {
     globalThis.fetch = vi.fn(
       async () => new Response(bodyFromChunks([]), { status: 200 })

--- a/src/domains/messages/__tests__/service.spec.ts
+++ b/src/domains/messages/__tests__/service.spec.ts
@@ -97,7 +97,7 @@ describe('messages service', () => {
     expect(res[0].id).toBe('m1');
   });
 
-  it('postMessage POSTs JSON and returns the parsed Message body', async () => {
+  it('postMessage POSTs to /Messages/start and returns the parsed Message body', async () => {
     const real = {
       id: 'real-7',
       createdAt: '2024-01-01T00:00:00Z',
@@ -108,7 +108,14 @@ describe('messages service', () => {
       errors: [],
       values: [],
     };
-    mockPostMessage.mockResolvedValueOnce({ data: real });
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify(real), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    ) as unknown as typeof fetch;
+    globalThis.fetch = fetchMock;
 
     const result = await postMessage({
       workSpaceId: 'w',
@@ -118,18 +125,23 @@ describe('messages service', () => {
 
     expect(result.id).toBe('real-7');
 
-    expect(mockPostMessage).toHaveBeenCalledOnce();
-    const [body] = mockPostMessage.mock.calls[0];
+    const [rawUrl, init] = (fetchMock as unknown as ReturnType<typeof vi.fn>)
+      .mock.calls[0] as [string, RequestInit];
+    expect(rawUrl).toBe('https://api.test/Messages/start');
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body as string);
     expect(body.messageThreadId).toBe('t1');
     expect(body.workSpaceId).toBe('w');
     expect(body.inputs[0].name).toBe('prompt');
   });
 
   it('postMessage propagates errors from the request', async () => {
-    mockPostMessage.mockRejectedValueOnce(new Error('boom'));
+    globalThis.fetch = vi.fn(
+      async () => new Response('err', { status: 500 })
+    ) as typeof fetch;
     await expect(
       postMessage({ workSpaceId: 'w', threadId: 't1' })
-    ).rejects.toThrow('boom');
+    ).rejects.toThrow(/status 500/);
   });
 
   it('addInputToMessage throws when no valid message received', async () => {

--- a/src/domains/messages/service.ts
+++ b/src/domains/messages/service.ts
@@ -1,12 +1,6 @@
-import {
-  AXIOS_INSTANCE,
-  ChatApi,
-  ChatZod,
-  SignalR,
-} from '@smartspace/api-client';
+import { ChatApi, ChatZod, SignalR } from '@smartspace/api-client';
 
-import { getAuthAdapter } from '@/platform/auth';
-import { getApiScopes } from '@/platform/auth/scopes';
+import { fetchAuthed } from '@/platform/api/fetchAuthed';
 import { parseOrThrow } from '@/platform/validation';
 
 import { parseSseStream } from '@/shared/utils/sseStream';
@@ -76,16 +70,9 @@ export async function addInputToMessage({
   value: unknown;
   channels: Record<string, number> | null;
 }): Promise<Message> {
-  const baseUrl = (AXIOS_INSTANCE.defaults.baseURL ?? '').replace(/\/$/, '');
-  const token = await getAuthAdapter().getAccessToken({
-    silentOnly: true,
-    scopes: getApiScopes(),
-  });
-
-  const response = await fetch(`${baseUrl}/messages/${messageId}/values`, {
+  const response = await fetchAuthed(`/messages/${messageId}/values`, {
     method: 'POST',
     headers: {
-      Authorization: `Bearer ${token}`,
       Accept: 'text/event-stream',
       'Content-Type': 'application/json',
     },
@@ -165,16 +152,9 @@ export async function postMessage({
     });
   }
 
-  const baseUrl = (AXIOS_INSTANCE.defaults.baseURL ?? '').replace(/\/$/, '');
-  const token = await getAuthAdapter().getAccessToken({
-    silentOnly: true,
-    scopes: getApiScopes(),
-  });
-
-  const response = await fetch(`${baseUrl}/Messages/start`, {
+  const response = await fetchAuthed(`/Messages/start`, {
     method: 'POST',
     headers: {
-      Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
       Accept: 'application/json',
     },
@@ -192,7 +172,19 @@ export async function postMessage({
     );
   }
 
-  const raw = (await response.json()) as Record<string, unknown> | null;
+  // Wrap JSON parse so a non-JSON 200 body (e.g. an HTML error page from a
+  // proxy or sidecar) surfaces as a clear error instead of an opaque
+  // `SyntaxError: Unexpected token < in JSON`.
+  let raw: Record<string, unknown> | null;
+  try {
+    raw = (await response.json()) as Record<string, unknown> | null;
+  } catch (err) {
+    throw new Error(
+      `POST /Messages/start returned a non-JSON body: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+  }
   if (!raw) throw new Error('POST /Messages/start returned no body');
   coerceMessageDto(raw);
   return mapMessageDtoToModel(
@@ -259,18 +251,11 @@ export async function streamThreadMessages({
   threadId: string;
   signal: AbortSignal;
 } & ThreadStreamHandlers): Promise<StreamThreadMessagesResult> {
-  const baseUrl = (AXIOS_INSTANCE.defaults.baseURL ?? '').replace(/\/$/, '');
-  const token = await getAuthAdapter().getAccessToken({
-    silentOnly: true,
-    scopes: getApiScopes(),
-  });
-
-  const response = await fetch(
-    `${baseUrl}/MessageThreads/${threadId}/messages/stream`,
+  const response = await fetchAuthed(
+    `/MessageThreads/${threadId}/messages/stream`,
     {
       method: 'GET',
       headers: {
-        Authorization: `Bearer ${token}`,
         Accept: 'text/event-stream',
       },
       signal,

--- a/src/domains/messages/service.ts
+++ b/src/domains/messages/service.ts
@@ -125,6 +125,13 @@ export async function addInputToMessage({
 // with inputs populated and id assigned. The flow continues running in the
 // background; output deltas arrive on the thread SSE keyed by the returned id.
 // Callers should reconcile their optimistic temp-id entry with this Message.
+//
+// Hits `POST /Messages/start` so the call resolves the moment the flow has
+// been queued, instead of `POST /Messages` which (with default `Accept: json`)
+// blocks until the AI flow completes — that blocking variant produced an
+// end-of-flow flicker because the mutation's authoritative cache write landed
+// at the same moment the SSE terminal frame did. Uses raw `fetch` because the
+// installed SDK doesn't expose the `/start` endpoint yet.
 export async function postMessage({
   workSpaceId,
   threadId,
@@ -158,15 +165,35 @@ export async function postMessage({
     });
   }
 
-  const response = await chatApi.messagesThreadMessages({
-    inputs,
-    messageThreadId: threadId,
-    workSpaceId,
-    variables,
+  const baseUrl = (AXIOS_INSTANCE.defaults.baseURL ?? '').replace(/\/$/, '');
+  const token = await getAuthAdapter().getAccessToken({
+    silentOnly: true,
+    scopes: getApiScopes(),
   });
 
-  const raw = response.data as unknown as Record<string, unknown>;
-  if (!raw) throw new Error('POST /messages returned no body');
+  const response = await fetch(`${baseUrl}/Messages/start`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify({
+      inputs,
+      messageThreadId: threadId,
+      workSpaceId,
+      variables,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `POST /Messages/start failed with status ${response.status}`
+    );
+  }
+
+  const raw = (await response.json()) as Record<string, unknown> | null;
+  if (!raw) throw new Error('POST /Messages/start returned no body');
   coerceMessageDto(raw);
   return mapMessageDtoToModel(
     messagesResponseSchema.shape.data.element.parse(raw)

--- a/src/domains/threads/__tests__/cache.spec.ts
+++ b/src/domains/threads/__tests__/cache.spec.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import {
   applyThreadToCache,
   type MessageThread,
+  type ThreadsResponse,
   threadsKeys,
 } from '@smartspace/chat-ui';
 
@@ -106,5 +107,63 @@ describe('applyThreadToCache stale-summary guard', () => {
       threadsKeys.detail(legacy.workSpaceId, legacy.id)
     );
     expect(after?.isFlowRunning).toBe(false);
+  });
+
+  it('rejects a stale false→true write inside a finite list page', () => {
+    const qc = new QueryClient();
+    const fresh = thread({ summaryEmittedAt: 2000, isFlowRunning: false });
+    qc.setQueryData<ThreadsResponse>(threadsKeys.list(fresh.workSpaceId), {
+      data: [fresh],
+      total: 1,
+    });
+
+    const stale = thread({ summaryEmittedAt: 1000, isFlowRunning: true });
+    const applied = applyThreadToCache(qc, stale);
+
+    // foundInList tracks list visits, not detail; the guard rejected the
+    // page-level write so foundInList stays false even though the entry exists.
+    expect(applied).toBe(false);
+    const after = qc.getQueryData<ThreadsResponse>(
+      threadsKeys.list(fresh.workSpaceId)
+    );
+    expect(after?.data[0].isFlowRunning).toBe(false);
+    expect(after?.data[0].summaryEmittedAt).toBe(2000);
+  });
+
+  it('rejects a stale false→true write inside an infinite list page', () => {
+    const qc = new QueryClient();
+    const fresh = thread({ summaryEmittedAt: 2000, isFlowRunning: false });
+    qc.setQueryData(threadsKeys.list(fresh.workSpaceId), {
+      pages: [{ data: [fresh], total: 1 }] as ThreadsResponse[],
+      pageParams: [0],
+    });
+
+    const stale = thread({ summaryEmittedAt: 1000, isFlowRunning: true });
+    applyThreadToCache(qc, stale);
+
+    const after = qc.getQueryData<{
+      pages: ThreadsResponse[];
+      pageParams: unknown[];
+    }>(threadsKeys.list(fresh.workSpaceId));
+    expect(after?.pages[0].data[0].isFlowRunning).toBe(false);
+    expect(after?.pages[0].data[0].summaryEmittedAt).toBe(2000);
+  });
+
+  it('accepts a true→false terminal frame inside a list page even when older', () => {
+    const qc = new QueryClient();
+    const midFlow = thread({ summaryEmittedAt: 2000, isFlowRunning: true });
+    qc.setQueryData<ThreadsResponse>(threadsKeys.list(midFlow.workSpaceId), {
+      data: [midFlow],
+      total: 1,
+    });
+
+    const terminal = thread({ summaryEmittedAt: 1000, isFlowRunning: false });
+    applyThreadToCache(qc, terminal);
+
+    const after = qc.getQueryData<ThreadsResponse>(
+      threadsKeys.list(midFlow.workSpaceId)
+    );
+    // Older timestamp but the running-direction is safe — write goes through.
+    expect(after?.data[0].isFlowRunning).toBe(false);
   });
 });

--- a/src/domains/threads/__tests__/cache.spec.ts
+++ b/src/domains/threads/__tests__/cache.spec.ts
@@ -1,0 +1,110 @@
+import { QueryClient } from '@tanstack/react-query';
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyThreadToCache,
+  type MessageThread,
+  threadsKeys,
+} from '@smartspace/chat-ui';
+
+const thread = (over: Partial<MessageThread> = {}): MessageThread => ({
+  id: 't1',
+  workSpaceId: 'w1',
+  name: 'Thread',
+  createdAt: new Date('2024-01-01T00:00:00Z'),
+  createdBy: 'me',
+  createdByUserId: 'u1',
+  isFlowRunning: false,
+  lastUpdatedAt: new Date('2024-01-01T00:00:00Z'),
+  lastUpdatedByUserId: 'u1',
+  totalMessages: 0,
+  pinned: false,
+  summaryEmittedAt: 1000,
+  ...over,
+});
+
+describe('applyThreadToCache stale-summary guard', () => {
+  it('rejects a stale write that would resurrect a settled false back to true', () => {
+    // Original race: SSE terminal already wrote { running: false } with a
+    // fresh timestamp, then a lagged SignalR `receiveThreadUpdate` with an
+    // older timestamp arrives carrying the now-obsolete `running: true`.
+    const qc = new QueryClient();
+    const fresh = thread({ summaryEmittedAt: 2000, isFlowRunning: false });
+    qc.setQueryData<MessageThread>(
+      threadsKeys.detail(fresh.workSpaceId, fresh.id),
+      fresh
+    );
+
+    const stale = thread({ summaryEmittedAt: 1000, isFlowRunning: true });
+    const applied = applyThreadToCache(qc, stale);
+
+    expect(applied).toBe(false);
+    const after = qc.getQueryData<MessageThread>(
+      threadsKeys.detail(fresh.workSpaceId, fresh.id)
+    );
+    // Detail cache still holds the fresher write — running indicator stays cleared.
+    expect(after?.isFlowRunning).toBe(false);
+    expect(after?.summaryEmittedAt).toBe(2000);
+  });
+
+  it('accepts an older-timestamp write that flips running to false (terminal frame after fresher mid-flow updates)', () => {
+    // Real-world case: SignalR mid-flow updates push summaryEmittedAt forward
+    // (each broadcast carries a fresh wall-clock timestamp), then the SSE
+    // terminal frame arrives carrying the original message-creation
+    // `lastUpdatedAt` (which is older). The terminal frame must still be
+    // applied — otherwise the running indicator never clears.
+    const qc = new QueryClient();
+    const midFlow = thread({ summaryEmittedAt: 2000, isFlowRunning: true });
+    qc.setQueryData<MessageThread>(
+      threadsKeys.detail(midFlow.workSpaceId, midFlow.id),
+      midFlow
+    );
+
+    const terminal = thread({ summaryEmittedAt: 1000, isFlowRunning: false });
+    applyThreadToCache(qc, terminal);
+
+    const after = qc.getQueryData<MessageThread>(
+      threadsKeys.detail(midFlow.workSpaceId, midFlow.id)
+    );
+    expect(after?.isFlowRunning).toBe(false);
+  });
+
+  it('accepts a write whose summaryEmittedAt is newer than the existing detail cache', () => {
+    const qc = new QueryClient();
+    const old = thread({ summaryEmittedAt: 1000, isFlowRunning: true });
+    qc.setQueryData<MessageThread>(
+      threadsKeys.detail(old.workSpaceId, old.id),
+      old
+    );
+
+    const fresh = thread({ summaryEmittedAt: 2000, isFlowRunning: false });
+    applyThreadToCache(qc, fresh);
+
+    const after = qc.getQueryData<MessageThread>(
+      threadsKeys.detail(old.workSpaceId, old.id)
+    );
+    expect(after?.isFlowRunning).toBe(false);
+    expect(after?.summaryEmittedAt).toBe(2000);
+  });
+
+  it('accepts a write when the existing cache entry has no summaryEmittedAt (legacy)', () => {
+    const qc = new QueryClient();
+    const legacy = thread({
+      isFlowRunning: true,
+      // simulate a legacy cached value without the version field
+      summaryEmittedAt: undefined as unknown as number,
+    });
+    qc.setQueryData<MessageThread>(
+      threadsKeys.detail(legacy.workSpaceId, legacy.id),
+      legacy
+    );
+
+    const incoming = thread({ summaryEmittedAt: 1000, isFlowRunning: false });
+    applyThreadToCache(qc, incoming);
+
+    const after = qc.getQueryData<MessageThread>(
+      threadsKeys.detail(legacy.workSpaceId, legacy.id)
+    );
+    expect(after?.isFlowRunning).toBe(false);
+  });
+});

--- a/src/domains/threads/__tests__/draftThread.spec.ts
+++ b/src/domains/threads/__tests__/draftThread.spec.ts
@@ -1,0 +1,30 @@
+import { QueryClient } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ensureDraftThread } from '@/domains/threads/draftThread';
+
+import { type MessageThread, threadsKeys } from '@smartspace/chat-ui';
+
+describe('ensureDraftThread', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-01T12:00:00Z'));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('stamps the new draft with summaryEmittedAt = Date.now() so applyThreadToCache treats it as fresh', () => {
+    const qc = new QueryClient();
+    const { draftId, isExisting } = ensureDraftThread('w1', qc);
+
+    expect(isExisting).toBe(false);
+    const cached = qc.getQueryData<MessageThread>(
+      threadsKeys.detail('w1', draftId)
+    );
+    expect(cached?.summaryEmittedAt).toBe(
+      new Date('2024-06-01T12:00:00Z').getTime()
+    );
+    expect(cached?.summaryEmittedAt).toBe(cached?.lastUpdatedAt.getTime());
+  });
+});

--- a/src/domains/threads/__tests__/mapper.spec.ts
+++ b/src/domains/threads/__tests__/mapper.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  mapSignalRThreadSummaryToModel,
+  mapThreadDtoToModel,
+} from '@smartspace/chat-ui';
+
+describe('thread mappers', () => {
+  it('mapThreadDtoToModel sets summaryEmittedAt from lastUpdatedAt epoch ms', () => {
+    const result = mapThreadDtoToModel({
+      id: 't1',
+      workSpaceId: 'w1',
+      name: 'Thread',
+      createdAt: '2024-01-01T00:00:00Z',
+      createdBy: 'me',
+      createdByUserId: 'u1',
+      isFlowRunning: true,
+      lastUpdatedAt: '2024-02-15T12:30:45Z',
+      lastUpdatedByUserId: 'u1',
+      totalMessages: 3,
+      favorited: false,
+    } as Parameters<typeof mapThreadDtoToModel>[0]);
+
+    expect(result.summaryEmittedAt).toBe(
+      new Date('2024-02-15T12:30:45Z').getTime()
+    );
+    expect(result.summaryEmittedAt).toBe(result.lastUpdatedAt.getTime());
+  });
+
+  it('mapSignalRThreadSummaryToModel sets summaryEmittedAt from lastUpdatedAt epoch ms', () => {
+    const result = mapSignalRThreadSummaryToModel({
+      id: 't2',
+      workSpaceId: 'w1',
+      name: 'Thread 2',
+      createdAt: '2024-01-01T00:00:00Z',
+      createdBy: 'me',
+      createdByUserId: 'u1',
+      isFlowRunning: false,
+      lastUpdatedAt: '2024-03-20T09:15:30Z',
+      lastUpdatedByUserId: 'u1',
+      totalMessages: 5,
+      favorited: true,
+    } as Parameters<typeof mapSignalRThreadSummaryToModel>[0]);
+
+    expect(result.summaryEmittedAt).toBe(
+      new Date('2024-03-20T09:15:30Z').getTime()
+    );
+    expect(result.summaryEmittedAt).toBe(result.lastUpdatedAt.getTime());
+  });
+});

--- a/src/domains/threads/draftThread.ts
+++ b/src/domains/threads/draftThread.ts
@@ -148,6 +148,7 @@ export function ensureDraftThread(
     totalMessages: 0,
     pinned: false,
     workSpaceId: workspaceId,
+    summaryEmittedAt: now.getTime(),
   };
 
   queryClient.setQueryData(

--- a/src/platform/api/fetchAuthed.ts
+++ b/src/platform/api/fetchAuthed.ts
@@ -1,0 +1,41 @@
+// Authenticated fetch against the chat API. Centralizes the baseUrl
+// normalisation + bearer-token retrieval + Authorization-header wiring that
+// every raw-fetch caller in this codebase used to repeat. Used by the
+// streaming endpoints the SDK doesn't expose (`/Messages/start`,
+// `/Messages/{id}/values`, `/MessageThreads/{id}/messages/stream`); SDK
+// methods stay the preferred path for non-streaming endpoints.
+//
+// Returns the raw `Response` — callers choose how to consume the body
+// (`.json()` for plain endpoints, `.body` for SSE) and own their non-2xx
+// error message wording. The helper deliberately doesn't throw on bad
+// status because `streamThreadMessages` treats 404 as a return value, not
+// an error.
+import { AXIOS_INSTANCE } from '@smartspace/api-client';
+
+import { getAuthAdapter } from '@/platform/auth';
+import { getApiScopes } from '@/platform/auth/scopes';
+
+export type FetchAuthedInit = Omit<RequestInit, 'headers'> & {
+  headers?: Record<string, string>;
+};
+
+export async function fetchAuthed(
+  endpoint: string,
+  init: FetchAuthedInit = {}
+): Promise<Response> {
+  const baseUrl = (AXIOS_INSTANCE.defaults.baseURL ?? '').replace(/\/$/, '');
+  const token = await getAuthAdapter().getAccessToken({
+    silentOnly: true,
+    scopes: getApiScopes(),
+  });
+  const url = `${baseUrl}${
+    endpoint.startsWith('/') ? endpoint : `/${endpoint}`
+  }`;
+  return fetch(url, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...init.headers,
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Four interlocking bugs in the message-send + thread-running pipeline, each triggering the same family of "flash mid-conversation" symptoms. They build on each other so easiest to land together.

- **Stale SignalR can resurrect a cleared running indicator.** SignalR's `receiveThreadUpdate` is broadcast independently of the SSE; a lagged summary with `isFlowRunning: true` could land after the SSE terminal frame already wrote `false`, leaving typing dots / composer spinner / sidebar dot stuck on. Stamp summaries with `summaryEmittedAt` (epoch ms from `lastUpdatedAt`; client writers use `Date.now()`) and reject stale writes that would flip a settled `false` back to `true`. Guard is intentionally narrow — `running: true → false` writes always go through even when older, because the SSE terminal frame can carry an older `lastUpdatedAt` than mid-flow SignalR broadcasts.
- **`POST /Messages` blocks until the AI flow completes.** Default `Accept: application/json` makes the controller `await response.LastAsync()`, so the mutation's authoritative cache write landed at the same instant as the SSE terminal frame and end-of-flow flicker was inevitable. Switch to `POST /Messages/start` (which the backend exposes specifically for SSE consumers); resolves in ~50ms with an inputs-only Message. Uses raw `fetch` because the installed SDK doesn't expose the method yet.
- **Mutation nuked the messages cache on POST resolve.** `setQueryData(messagesKeys.list, [realMessage])` dropped m1, m2, m3, … until the SSE snapshot restored them. Even with `/Messages/start` resolving fast, the gap before the snapshot lands is enough to flash the whole list. Reconcile in place instead: drop the optimistic, append `realMessage` if not already there, dedupe-guard for the rare case the SSE delivered it first.
- **MessageList flashed welcome / loading / error pages on transient cache states.** Per-thread high-water-mark ref — once we've rendered ≥1 message, the three non-list branches render an empty body div instead. Resets on `threadId` change so a fresh draft still shows the welcome screen. Defensive only; doesn't change the data flow.

## Test plan

- [ ] **Multi-message thread, plain send.** Old messages stay visible the whole time; the optimistic resolves into the realMessage in place; AI response streams in progressively (not all at end); typing dots clear within ~1s of the response finishing.
- [ ] **Brand-new draft thread.** Workspace home → first send. Welcome screen still shows on first paint of the empty thread; first message + AI response complete cleanly; running indicator clears.
- [ ] **Several sends back-to-back.** Each one transitions cleanly without disturbing the previous AI response, no duplicate AI bubble at the bottom, no whole-list flash.
- [ ] **Multi-tab.** Tab A sends, Tab B is viewing the same thread. Both tabs see the running indicator turn on/off together; B doesn't double-render the user message; no flicker on either side.
- [ ] **Switching threads mid-run.** Start a flow on thread X, switch to thread Y, switch back. Running state on X is correct (still running if not done; cleared if done while away).
- [ ] **Thread with stale SignalR.** Hard one to manually trigger — closest is to send a fast prompt and watch `isFlowRunning` in React Query Devtools at the moment the response finishes. Should never bounce back from `false` → `true`. The new test in `cache.spec.ts` covers the unit-level behavior.
- [ ] **Network tab on send.** Request goes to `…/Messages/start` (not `…/Messages`) and returns ~50–150ms later with the initial Message; output deltas come over `…/messages/stream`.
- [ ] **Lint / typecheck / tests** all green (verified locally).

## Notes

- `addInputToMessage` (used for embedded form-input flows in messages) still reads to the last frame — a follow-up could mirror the `/start` contract there too, but it's not on the standard send path so no flicker symptoms.
- The MessageList ref guard is a band-aid. If the underlying cache races resurface, it'll mask them. Worth revisiting after a few weeks of usage.