### PR TITLE
fix(internal-bump-sdk): add --workspace-root to pnpm add

### DIFF
--- a/.github/workflows/internal-bump-sdk.yml
+++ b/.github/workflows/internal-bump-sdk.yml
@@ -62,7 +62,9 @@ jobs:
           # Pin the exact resolved version. This forces pnpm to refresh the
           # lockfile entry — the literal "dev"/"main" tag spec doesn't trigger
           # re-resolution on its own once a version is locked.
-          pnpm add --save-exact "@smartspace/api-client@${NEW_VERSION}"
+          # --workspace-root: this repo is a pnpm workspace; pnpm refuses to
+          # add deps to the root without it.
+          pnpm add --workspace-root --save-exact "@smartspace/api-client@${NEW_VERSION}"
 
           # Revert the package.json spec back to the channel literal so the
           # existing check-package-json-channel.yml swap workflow keeps working.


### PR DESCRIPTION
## Summary

The bump workflow's first real dispatch (run [25531096665](https://github.com/Smartspace-ai/Smartspace-app-public/actions/runs/25531096665)) failed at the lockfile-bump step:

```
ERR_PNPM_ADDING_TO_ROOT  Running this command will add the dependency to the workspace root...
```

This repo is a pnpm workspace (`packages/chat-ui` is a member), and pnpm refuses to add deps to the root without explicit `--workspace-root` opt-in. One-flag fix.

## Test plan

- [ ] Merge to develop
- [ ] Backport to main (separate PR — required for the workflow on main, which is what dispatches actually run from)
- [ ] Re-trigger a dispatch and confirm bump completes through to push