### PR TITLE
fix(internal-bump-sdk): add --workspace-root to pnpm add (backport to main)

### DIFF
--- a/.github/workflows/internal-bump-sdk.yml
+++ b/.github/workflows/internal-bump-sdk.yml
@@ -62,7 +62,9 @@ jobs:
           # Pin the exact resolved version. This forces pnpm to refresh the
           # lockfile entry — the literal "dev"/"main" tag spec doesn't trigger
           # re-resolution on its own once a version is locked.
-          pnpm add --save-exact "@smartspace/api-client@${NEW_VERSION}"
+          # --workspace-root: this repo is a pnpm workspace; pnpm refuses to
+          # add deps to the root without it.
+          pnpm add --workspace-root --save-exact "@smartspace/api-client@${NEW_VERSION}"
 
           # Revert the package.json spec back to the channel literal so the
           # existing check-package-json-channel.yml swap workflow keeps working.


### PR DESCRIPTION
## Summary

Backport of the develop fix in #265. Since `repository_dispatch` triggers workflows from the default branch (`main`), the fix has to land here for the next bump dispatch to actually succeed.

Cherry-picked from #265.

## Test plan

- [ ] Merge to main
- [ ] Re-trigger a `sdk-published` dispatch and confirm bump completes through to push (lands on `develop` per payload)