### PR TITLE
fix(comments): de-dupe SignalR race, populate username, add ctrl+enter

### DIFF
--- a/src/domains/comments/__tests__/mutations.spec.tsx
+++ b/src/domains/comments/__tests__/mutations.spec.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -20,18 +20,83 @@ describe('comments mutations', () => {
     );
 
     const real = {
-      id: 'c-real', content: 'hello', createdAt: new Date('2024-01-01'), createdBy: 'me-id', createdByUserId: 'me-id', mentionedUsers: [], messageThreadId: 't1',
+      id: 'c-real',
+      content: 'hello',
+      createdAt: new Date('2024-01-01'),
+      createdBy: 'me-id',
+      createdByUserId: 'me-id',
+      mentionedUsers: [],
+      messageThreadId: 't1',
     } as any;
     const spy = vi.spyOn(service, 'addComment').mockResolvedValueOnce(real);
 
     const { result } = renderHook(() => useAddComment('t1'), { wrapper });
-    await result.current.mutateAsync({ threadId: 't1', content: 'hello', mentionedUsers: [] });
+    await result.current.mutateAsync({
+      threadId: 't1',
+      content: 'hello',
+      mentionedUsers: [],
+    });
 
     const data = client.getQueryData<any[]>(commentsKeys.list('t1')) || [];
     expect(data.find((x) => x.id === 'c-real')).toBeTruthy();
     expect(data.find((x) => String(x.id).startsWith('temp-'))).toBeFalsy();
     spy.mockRestore();
   });
+
+  it('useAddComment does not duplicate when SignalR push lands before the POST resolves', async () => {
+    const client = new QueryClient();
+    const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+
+    const real = {
+      id: 'c-real',
+      content: 'hello',
+      createdAt: new Date('2024-01-01'),
+      createdBy: 'me-id',
+      createdByUserId: 'me-id',
+      mentionedUsers: [],
+      messageThreadId: 't1',
+    } as any;
+
+    // Simulate the race: SignalR pushes the real comment into the cache while
+    // the POST is still in flight. Resolve the mutation only after we have
+    // injected the real comment alongside the optimistic placeholder.
+    let resolvePost: (value: any) => void = () => undefined;
+    const postPromise = new Promise((r) => {
+      resolvePost = r;
+    });
+    const spy = vi
+      .spyOn(service, 'addComment')
+      .mockImplementationOnce(() => postPromise as any);
+
+    const { result } = renderHook(() => useAddComment('t1'), { wrapper });
+    const pending = result.current.mutateAsync({
+      threadId: 't1',
+      content: 'hello',
+      mentionedUsers: [],
+    });
+
+    // Wait for onMutate to settle (it awaits cancelQueries) and the optimistic placeholder to land.
+    await waitFor(() => {
+      const list = client.getQueryData<any[]>(commentsKeys.list('t1')) || [];
+      expect(list.length).toBe(1);
+      expect(String(list[0].id).startsWith('temp-')).toBe(true);
+    });
+
+    // SignalR appends the real comment alongside the placeholder.
+    client.setQueryData(commentsKeys.list('t1'), (old: any[] | undefined) => [
+      ...(old ?? []),
+      real,
+    ]);
+
+    // Now let the POST resolve.
+    resolvePost(real);
+    await pending;
+
+    const data = client.getQueryData<any[]>(commentsKeys.list('t1')) || [];
+    expect(data.filter((x) => x.id === 'c-real').length).toBe(1);
+    expect(data.find((x) => String(x.id).startsWith('temp-'))).toBeFalsy();
+    spy.mockRestore();
+  });
 });
-
-

--- a/src/domains/comments/mutations.ts
+++ b/src/domains/comments/mutations.ts
@@ -67,10 +67,18 @@ export function useAddComment(threadId: string) {
         commentsKeys.list(tid),
         (old: Comment[] | undefined) => {
           const list = old ?? [];
-          const idx = list.findIndex((c) => c.id === tempId);
-          if (idx === -1) return [...list, realComment];
+          const tempIdx = list.findIndex((c) => c.id === tempId);
+          const realIdx = list.findIndex((c) => c.id === realComment.id);
+
+          // The SignalR `receiveCommentsUpdate` push can land before the POST
+          // response. When it does, the real comment is already in the cache,
+          // and naively replacing the placeholder would leave two copies.
+          if (realIdx !== -1) {
+            return tempIdx === -1 ? list : list.filter((c) => c.id !== tempId);
+          }
+          if (tempIdx === -1) return [...list, realComment];
           const next = list.slice();
-          next[idx] = realComment;
+          next[tempIdx] = realComment;
           return next;
         }
       );

--- a/src/platform/auth/providers/msalWeb.ts
+++ b/src/platform/auth/providers/msalWeb.ts
@@ -259,7 +259,15 @@ export function createMsalWebAdapter(): AuthAdapter {
         hasFallback: !!popupFallbackToken,
       });
       if (a) {
-        return { accountId: a.homeAccountId, displayName: a.name ?? undefined };
+        // `a.name` is sourced from the ID token's `name` claim and is not
+        // guaranteed to be populated (some tenants strip it). `a.username` is
+        // the UPN/email and is always present — better than the 'You' fallback
+        // downstream consumers (e.g. optimistic comment placeholders) hit when
+        // displayName is undefined.
+        return {
+          accountId: a.homeAccountId,
+          displayName: a.name ?? a.username ?? undefined,
+        };
       }
       // Fallback: popup token available but MSAL cache is partitioned (Teams Mobile).
       if (popupFallbackToken) {

--- a/src/ui/comments_draw/sidebar-right.tsx
+++ b/src/ui/comments_draw/sidebar-right.tsx
@@ -111,8 +111,7 @@ export function SidebarRight() {
   });
   const isMobile = useIsMobile();
 
-  const handleAddComment = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
+  const submitComment = async () => {
     if (isAddingComment) return;
     if (isDraft) return;
     const content = editorRef.current?.getPlainText?.() ?? threadComment.plain;
@@ -130,6 +129,21 @@ export function SidebarRight() {
       editorRef.current?.clear?.();
     } catch {
       // Error handled in hook
+    }
+  };
+
+  const handleAddComment = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    await submitComment();
+  };
+
+  const handleEditorKeyDown = (e: React.KeyboardEvent) => {
+    // Ctrl/Cmd + Enter posts. Plain Enter inserts a newline (or selects a
+    // mention candidate when the mention popup is open — the editor
+    // intercepts that case before this handler runs).
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+      e.preventDefault();
+      void submitComment();
     }
   };
 
@@ -275,6 +289,7 @@ export function SidebarRight() {
                   className="md-editor--bare text-sm pr-12 pb-10"
                   minHeight={90}
                   placeholder="Type a comment..."
+                  onKeyDown={handleEditorKeyDown}
                 />
 
                 <UIButton
@@ -321,6 +336,7 @@ export function SidebarRight() {
                   className="md-editor--bare text-sm pr-28 pb-12"
                   minHeight={120}
                   placeholder="Type a comment..."
+                  onKeyDown={handleEditorKeyDown}
                 />
 
                 <UIButton


### PR DESCRIPTION
## Summary

Three small fixes around the add-comment flow:

- **Stop the duplicate when SignalR races the POST.** The server emits `receiveCommentsUpdate` right after persisting, so the real comment can land in the cache before the POST response returns. The old `onSuccess` blindly replaced the optimistic placeholder by tempId — which, with the real comment already inserted by SignalR, left two copies of the same id. `onSuccess` now checks for the real id first: if it's there, the placeholder is dropped; otherwise the swap proceeds as before. Regression test added.
- **Optimistic comment now shows a real name instead of 'You'.** `useUserDisplayName()` returns `'You'` when `session.displayName` is undefined; that happens whenever MSAL's `account.name` is empty (some Entra tenants strip the `name` claim, B2B/guests, missing `profile` consent). The MSAL adapter's `getSession()` now falls back through `a.name → a.username → undefined`, so consumers see the user's UPN/email instead of the literal 'You'.
- **Ctrl/Cmd + Enter posts the comment.** Editor `onKeyDown` wired in `sidebar-right.tsx` — works in both mobile and desktop layouts. Plain Enter still inserts a newline.

### Known minor

When the `@`-mention popup is open, the SDK's `MarkdownEditor` intercepts Enter to pick a candidate before forwarding the event, and that intercept doesn't check `ctrlKey`. So Ctrl+Enter while the popup is open inserts a mention rather than submitting. Fixing it cleanly requires a `chat-ui` change; out of scope here.

## Test plan

- [ ] **Username**: open a thread, post a comment. The optimistic bubble shows your name (or email fallback) — not 'You'. After the POST resolves the bubble keeps the same identity.
- [ ] **Fresh sign-in**: sign out, sign back in, immediately post — placeholder still shows your name/email.
- [ ] **Duplicate guard (the original bug)**: post a comment from another browser tab/session into the same thread while you have it open, then post one of your own simultaneously. Neither should appear twice.
- [ ] **Ctrl+Enter posts (Windows)**: focus the editor, type, Ctrl+Enter — comment posts, editor clears.
- [ ] **Cmd+Enter posts (Mac)**: same with Cmd+Enter.
- [ ] **Plain Enter**: still inserts a newline, doesn't submit.
- [ ] **Disabled-state shortcut**: while a comment is posting (`isAddingComment`) or thread is a draft, Ctrl+Enter is ignored.
- [ ] **Empty / over-length guards**: empty editor → Ctrl+Enter no-ops; >350 chars → toast appears, no post.
- [ ] **Mention popup edge case (known)**: type `@`, then Ctrl+Enter — picks a mention; press Ctrl+Enter again to submit.