### PR TITLE
Release: comments fixes (SignalR de-dupe, username fallback, ctrl+enter)

### DIFF
--- a/src/domains/comments/__tests__/mutations.spec.tsx
+++ b/src/domains/comments/__tests__/mutations.spec.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -20,18 +20,83 @@ describe('comments mutations', () => {
     );
 
     const real = {
-      id: 'c-real', content: 'hello', createdAt: new Date('2024-01-01'), createdBy: 'me-id', createdByUserId: 'me-id', mentionedUsers: [], messageThreadId: 't1',
+      id: 'c-real',
+      content: 'hello',
+      createdAt: new Date('2024-01-01'),
+      createdBy: 'me-id',
+      createdByUserId: 'me-id',
+      mentionedUsers: [],
+      messageThreadId: 't1',
     } as any;
     const spy = vi.spyOn(service, 'addComment').mockResolvedValueOnce(real);
 
     const { result } = renderHook(() => useAddComment('t1'), { wrapper });
-    await result.current.mutateAsync({ threadId: 't1', content: 'hello', mentionedUsers: [] });
+    await result.current.mutateAsync({
+      threadId: 't1',
+      content: 'hello',
+      mentionedUsers: [],
+    });
 
     const data = client.getQueryData<any[]>(commentsKeys.list('t1')) || [];
     expect(data.find((x) => x.id === 'c-real')).toBeTruthy();
     expect(data.find((x) => String(x.id).startsWith('temp-'))).toBeFalsy();
     spy.mockRestore();
   });
+
+  it('useAddComment does not duplicate when SignalR push lands before the POST resolves', async () => {
+    const client = new QueryClient();
+    const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+
+    const real = {
+      id: 'c-real',
+      content: 'hello',
+      createdAt: new Date('2024-01-01'),
+      createdBy: 'me-id',
+      createdByUserId: 'me-id',
+      mentionedUsers: [],
+      messageThreadId: 't1',
+    } as any;
+
+    // Simulate the race: SignalR pushes the real comment into the cache while
+    // the POST is still in flight. Resolve the mutation only after we have
+    // injected the real comment alongside the optimistic placeholder.
+    let resolvePost: (value: any) => void = () => undefined;
+    const postPromise = new Promise((r) => {
+      resolvePost = r;
+    });
+    const spy = vi
+      .spyOn(service, 'addComment')
+      .mockImplementationOnce(() => postPromise as any);
+
+    const { result } = renderHook(() => useAddComment('t1'), { wrapper });
+    const pending = result.current.mutateAsync({
+      threadId: 't1',
+      content: 'hello',
+      mentionedUsers: [],
+    });
+
+    // Wait for onMutate to settle (it awaits cancelQueries) and the optimistic placeholder to land.
+    await waitFor(() => {
+      const list = client.getQueryData<any[]>(commentsKeys.list('t1')) || [];
+      expect(list.length).toBe(1);
+      expect(String(list[0].id).startsWith('temp-')).toBe(true);
+    });
+
+    // SignalR appends the real comment alongside the placeholder.
+    client.setQueryData(commentsKeys.list('t1'), (old: any[] | undefined) => [
+      ...(old ?? []),
+      real,
+    ]);
+
+    // Now let the POST resolve.
+    resolvePost(real);
+    await pending;
+
+    const data = client.getQueryData<any[]>(commentsKeys.list('t1')) || [];
+    expect(data.filter((x) => x.id === 'c-real').length).toBe(1);
+    expect(data.find((x) => String(x.id).startsWith('temp-'))).toBeFalsy();
+    spy.mockRestore();
+  });
 });
-
-

--- a/src/domains/comments/mutations.ts
+++ b/src/domains/comments/mutations.ts
@@ -67,10 +67,18 @@ export function useAddComment(threadId: string) {
         commentsKeys.list(tid),
         (old: Comment[] | undefined) => {
           const list = old ?? [];
-          const idx = list.findIndex((c) => c.id === tempId);
-          if (idx === -1) return [...list, realComment];
+          const tempIdx = list.findIndex((c) => c.id === tempId);
+          const realIdx = list.findIndex((c) => c.id === realComment.id);
+
+          // The SignalR `receiveCommentsUpdate` push can land before the POST
+          // response. When it does, the real comment is already in the cache,
+          // and naively replacing the placeholder would leave two copies.
+          if (realIdx !== -1) {
+            return tempIdx === -1 ? list : list.filter((c) => c.id !== tempId);
+          }
+          if (tempIdx === -1) return [...list, realComment];
           const next = list.slice();
-          next[idx] = realComment;
+          next[tempIdx] = realComment;
           return next;
         }
       );

--- a/src/platform/auth/providers/msalWeb.ts
+++ b/src/platform/auth/providers/msalWeb.ts
@@ -259,7 +259,15 @@ export function createMsalWebAdapter(): AuthAdapter {
         hasFallback: !!popupFallbackToken,
       });
       if (a) {
-        return { accountId: a.homeAccountId, displayName: a.name ?? undefined };
+        // `a.name` is sourced from the ID token's `name` claim and is not
+        // guaranteed to be populated (some tenants strip it). `a.username` is
+        // the UPN/email and is always present — better than the 'You' fallback
+        // downstream consumers (e.g. optimistic comment placeholders) hit when
+        // displayName is undefined.
+        return {
+          accountId: a.homeAccountId,
+          displayName: a.name ?? a.username ?? undefined,
+        };
       }
       // Fallback: popup token available but MSAL cache is partitioned (Teams Mobile).
       if (popupFallbackToken) {

--- a/src/ui/comments_draw/sidebar-right.tsx
+++ b/src/ui/comments_draw/sidebar-right.tsx
@@ -111,8 +111,7 @@ export function SidebarRight() {
   });
   const isMobile = useIsMobile();
 
-  const handleAddComment = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
+  const submitComment = async () => {
     if (isAddingComment) return;
     if (isDraft) return;
     const content = editorRef.current?.getPlainText?.() ?? threadComment.plain;
@@ -130,6 +129,21 @@ export function SidebarRight() {
       editorRef.current?.clear?.();
     } catch {
       // Error handled in hook
+    }
+  };
+
+  const handleAddComment = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    await submitComment();
+  };
+
+  const handleEditorKeyDown = (e: React.KeyboardEvent) => {
+    // Ctrl/Cmd + Enter posts. Plain Enter inserts a newline (or selects a
+    // mention candidate when the mention popup is open — the editor
+    // intercepts that case before this handler runs).
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+      e.preventDefault();
+      void submitComment();
     }
   };
 
@@ -275,6 +289,7 @@ export function SidebarRight() {
                   className="md-editor--bare text-sm pr-12 pb-10"
                   minHeight={90}
                   placeholder="Type a comment..."
+                  onKeyDown={handleEditorKeyDown}
                 />
 
                 <UIButton
@@ -321,6 +336,7 @@ export function SidebarRight() {
                   className="md-editor--bare text-sm pr-28 pb-12"
                   minHeight={120}
                   placeholder="Type a comment..."
+                  onKeyDown={handleEditorKeyDown}
                 />
 
                 <UIButton


### PR DESCRIPTION
## Summary

Promote develop to main. Includes PR #269:

- **SignalR de-dupe**: `onSuccess` no-ops the placeholder swap when SignalR has already inserted the real comment, preventing duplicate IDs.
- **Username fallback**: MSAL session falls back to `account.username` when `account.name` is empty, so optimistic comments show the user's email instead of literal "You" on tenants that strip the name claim.
- **Ctrl+Enter / Cmd+Enter** in the comment editor submits the comment.

## Test plan

- [ ] Add a comment and verify only one entry appears (no SignalR duplicate)
- [ ] On a tenant where `account.name` is empty, confirm optimistic comment shows the email rather than "You"
- [ ] Press Ctrl+Enter (Win) / Cmd+Enter (Mac) in the comment editor and confirm submission
- [ ] Existing comment flows (edit, delete, reply) still work