### PR TITLE
fix(chat-ui): hide UserInfo input and style number variables

### DIFF
--- a/packages/chat-ui/src/chat-variables/renders/index.ts
+++ b/packages/chat-ui/src/chat-variables/renders/index.ts
@@ -20,6 +20,7 @@ import {
   ModelIdRendererControl,
   modelIdRendererTester,
 } from './model-id-renderer';
+import { NumberRendererControl, numberRendererTester } from './number-renderer';
 import {
   TextareaRendererControl,
   textareaRendererTester,
@@ -35,6 +36,7 @@ export const renderers = [
   { tester: modelIdRendererTester, renderer: ModelIdRendererControl },
   { tester: booleanRendererTester, renderer: BooleanRendererControl },
   { tester: dropdownRendererTester, renderer: DropdownRendererControl },
+  { tester: numberRendererTester, renderer: NumberRendererControl },
   { tester: textareaRendererTester, renderer: TextareaRendererControl },
   ...vanillaRenderers,
   { tester: jsonEditorTester, renderer: JsonEditorRendererControl },

--- a/packages/chat-ui/src/chat-variables/renders/number-renderer.tsx
+++ b/packages/chat-ui/src/chat-variables/renders/number-renderer.tsx
@@ -1,0 +1,159 @@
+import type {
+  ControlElement,
+  ControlProps,
+  JsonSchema7,
+  RankedTester,
+} from '@jsonforms/core';
+import { rankWith } from '@jsonforms/core';
+import { withJsonFormsControlProps } from '@jsonforms/react';
+import React, { useCallback } from 'react';
+
+type AccessUiSchema = { access?: 'Read' | 'Write' };
+
+const NumberRenderer: React.FC<ControlProps> = ({
+  data,
+  handleChange,
+  path,
+  label,
+  description,
+  errors,
+  schema,
+  uischema,
+  visible,
+  enabled,
+  required,
+}) => {
+  const isInteger = (schema as JsonSchema7 | undefined)?.type === 'integer';
+
+  const handleInputChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const raw = event.target.value;
+      if (raw === '') {
+        handleChange(path, undefined);
+        return;
+      }
+      const parsed = isInteger ? parseInt(raw, 10) : parseFloat(raw);
+      if (Number.isNaN(parsed)) {
+        handleChange(path, undefined);
+        return;
+      }
+      handleChange(path, parsed);
+    },
+    [handleChange, path, isInteger]
+  );
+
+  if (!visible) return null;
+
+  const readOnly =
+    (uischema as unknown as AccessUiSchema | undefined)?.access === 'Read';
+  const isDisabled = !enabled || readOnly;
+  const hasError = !!errors && errors.length > 0;
+
+  const fieldSchema = schema as JsonSchema7 | undefined;
+  const min = fieldSchema?.minimum;
+  const max = fieldSchema?.maximum;
+  const step = isInteger ? 1 : fieldSchema?.multipleOf ?? 'any';
+
+  return (
+    <div className="ss-jsonforms-field ss-jsonforms-number compact-field">
+      {label && (
+        <label
+          htmlFor={`number-${path}`}
+          style={{
+            display: 'block',
+            color: hasError ? '#ef4444' : '#475569',
+            fontSize: '0.875rem',
+            fontWeight: 500,
+            marginBottom: '0.375rem',
+          }}
+        >
+          {label}
+          {required && (
+            <span style={{ color: '#ef4444', marginLeft: '0.25rem' }}>*</span>
+          )}
+        </label>
+      )}
+
+      {description && (
+        <div
+          style={{
+            color: '#6b7280',
+            fontSize: '0.75rem',
+            marginBottom: '0.5rem',
+          }}
+        >
+          {description}
+        </div>
+      )}
+
+      <input
+        id={`number-${path}`}
+        type="number"
+        value={data ?? ''}
+        onChange={handleInputChange}
+        disabled={isDisabled}
+        min={min}
+        max={max}
+        step={step}
+        style={{
+          width: '100%',
+          padding: '0.5rem 0.75rem',
+          border: hasError ? '2px solid #ef4444' : '1px solid #d1d5db',
+          borderRadius: '6px',
+          fontSize: '0.875rem',
+          lineHeight: '1.5',
+          fontFamily: 'inherit',
+          backgroundColor: isDisabled ? '#f9fafb' : '#ffffff',
+          color: isDisabled ? '#9ca3af' : '#111827',
+          outline: 'none',
+          boxSizing: 'border-box',
+          transition:
+            'border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out',
+          boxShadow: hasError ? '0 0 0 1px #ef4444' : 'none',
+        }}
+        onFocus={(e) => {
+          if (!hasError) {
+            e.target.style.borderColor = '#6366f1';
+            e.target.style.boxShadow = '0 0 0 1px #6366f1';
+          }
+        }}
+        onBlur={(e) => {
+          if (!hasError) {
+            e.target.style.borderColor = '#d1d5db';
+            e.target.style.boxShadow = 'none';
+          }
+        }}
+      />
+
+      {hasError && (
+        <div
+          style={{
+            color: '#ef4444',
+            fontSize: '0.75rem',
+            marginTop: '0.25rem',
+          }}
+        >
+          {errors}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const numberRendererTester: RankedTester = rankWith(
+  40,
+  (uischema, schema) => {
+    if (uischema.type !== 'Control') return false;
+    const propertyPath = (uischema as ControlElement).scope.replace(
+      '#/properties/',
+      ''
+    );
+    const fieldSchema = (schema as JsonSchema7 | undefined)?.properties?.[
+      propertyPath
+    ] as JsonSchema7 | undefined;
+    if (!fieldSchema) return false;
+    return fieldSchema.type === 'integer' || fieldSchema.type === 'number';
+  }
+);
+
+export const NumberRendererControl = withJsonFormsControlProps(NumberRenderer);

--- a/packages/chat-ui/src/chat-variables/renders/number-renderer.tsx
+++ b/packages/chat-ui/src/chat-variables/renders/number-renderer.tsx
@@ -55,16 +55,25 @@ const NumberRenderer: React.FC<ControlProps> = ({
   const step = isInteger ? 1 : fieldSchema?.multipleOf ?? 'any';
 
   return (
-    <div className="ss-jsonforms-field ss-jsonforms-number compact-field">
+    <div
+      className="ss-jsonforms-field ss-jsonforms-number"
+      style={{
+        display: 'inline-flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 8,
+        minHeight: '40px',
+      }}
+    >
       {label && (
         <label
           htmlFor={`number-${path}`}
           style={{
-            display: 'block',
             color: hasError ? '#ef4444' : '#475569',
             fontSize: '0.875rem',
             fontWeight: 500,
-            marginBottom: '0.375rem',
+            whiteSpace: 'nowrap',
+            lineHeight: '24px',
           }}
         >
           {label}
@@ -72,18 +81,6 @@ const NumberRenderer: React.FC<ControlProps> = ({
             <span style={{ color: '#ef4444', marginLeft: '0.25rem' }}>*</span>
           )}
         </label>
-      )}
-
-      {description && (
-        <div
-          style={{
-            color: '#6b7280',
-            fontSize: '0.75rem',
-            marginBottom: '0.5rem',
-          }}
-        >
-          {description}
-        </div>
       )}
 
       <input
@@ -96,32 +93,18 @@ const NumberRenderer: React.FC<ControlProps> = ({
         max={max}
         step={step}
         style={{
-          width: '100%',
-          padding: '0.5rem 0.75rem',
+          width: '80px',
+          height: '24px',
+          padding: '0 0.5rem',
           border: hasError ? '2px solid #ef4444' : '1px solid #d1d5db',
           borderRadius: '6px',
           fontSize: '0.875rem',
-          lineHeight: '1.5',
+          lineHeight: '24px',
           fontFamily: 'inherit',
           backgroundColor: isDisabled ? '#f9fafb' : '#ffffff',
           color: isDisabled ? '#9ca3af' : '#111827',
           outline: 'none',
           boxSizing: 'border-box',
-          transition:
-            'border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out',
-          boxShadow: hasError ? '0 0 0 1px #ef4444' : 'none',
-        }}
-        onFocus={(e) => {
-          if (!hasError) {
-            e.target.style.borderColor = '#6366f1';
-            e.target.style.boxShadow = '0 0 0 1px #6366f1';
-          }
-        }}
-        onBlur={(e) => {
-          if (!hasError) {
-            e.target.style.borderColor = '#d1d5db';
-            e.target.style.boxShadow = 'none';
-          }
         }}
       />
 
@@ -130,7 +113,6 @@ const NumberRenderer: React.FC<ControlProps> = ({
           style={{
             color: '#ef4444',
             fontSize: '0.75rem',
-            marginTop: '0.25rem',
           }}
         >
           {errors}

--- a/packages/chat-ui/src/messages/MessageItem.tsx
+++ b/packages/chat-ui/src/messages/MessageItem.tsx
@@ -190,8 +190,9 @@ export const MessageItem: FC<MessageItemProps> = ({
     const name = v.name.toLowerCase();
 
     switch (name) {
-      case 'variables': {
-        // Do not display message variables payloads
+      case 'variables':
+      case 'userinfo': {
+        // Internal system inputs — never render
         continue;
       }
       case 'status': {


### PR DESCRIPTION
## Summary

Two small chat-ui rendering fixes spotted in production data.

### 1. `UserInfo` input rendered as a JSON bubble
Messages that include a system-injected `UserInfo` input value (e.g. `{ Id, Name, EmailAddress, MobilePhone, IsAdmin }`) were falling through the `default` branch of the value-name switch in `MessageItem` and being `JSON.stringify`'d into a content bubble. Treat `userinfo` the same as `variables` — never render.

### 2. Integer/number variables rendered as unstyled inline text (`Batch Size10`)
Numeric chat variables had no dedicated renderer, so they fell to the JSONForms vanilla renderer which produces an unstyled inline label + raw `<input>` with no width — landing the label and value glued together inside the grid cell.

Added a dedicated number renderer that matches the look of the existing textarea/boolean/dropdown renderers:
- Block label above input
- Padded, bordered input with focus ring and error states
- Honours `minimum` / `maximum` / `multipleOf` from the schema
- Coerces value to `integer` or `number` on change; respects `access: 'Read'`

Registered at rank 40, alongside the other custom renderers.

## Test plan

- [x] Open a thread where a message has a `UserInfo` Input value — confirm no JSON bubble appears (only the prompt and response render)
- [x] Open a workspace with an integer variable (e.g. Batch Size) — confirm the field shows label-above-input with proper width/padding, not "Batch Size10" inline
- [x] Same for a `number` variable (decimals allowed)
- [x] Edit a numeric variable — value is sent to the backend as a number, not a string
- [x] Numeric variable with `access: 'Read'` is disabled
- [x] Other variable types (boolean toggle, dropdown, textarea, model-id) still render unchanged