### PR TITLE
chore(chat-ui): drop dead isPromptAndResponseLoggingEnabled workspace field

### DIFF
--- a/packages/chat-ui/src/domains/workspaces/mapper.ts
+++ b/packages/chat-ui/src/domains/workspaces/mapper.ts
@@ -82,10 +82,6 @@ export function mapWorkspaceDtoToModel(dto: WorkspaceDto): Workspace {
     outputSchema: dto.outputSchema ?? undefined,
     inputs: dto.inputs ?? undefined,
 
-    isPromptAndResponseLoggingEnabled: truthy(
-      dto.isPromptAndResponseLoggingEnabled
-    ),
-
     variables,
 
     sandBoxThreadId: dto.sandBoxThreadId ?? undefined,

--- a/packages/chat-ui/src/domains/workspaces/model.ts
+++ b/packages/chat-ui/src/domains/workspaces/model.ts
@@ -36,8 +36,6 @@ export type Workspace = {
   outputSchema?: unknown;
   inputs?: unknown;
 
-  isPromptAndResponseLoggingEnabled: boolean; // normalized default false
-
   variables: Variables; // normalized default {}
 
   // Sandbox thread is genuinely optional — many workspaces don't have one.


### PR DESCRIPTION
## Summary

- Removes the `isPromptAndResponseLoggingEnabled` field from the chat-ui `Workspace` model and its mapper.
- Aligns the boundary layer with [Smartspace-app-api#783](https://github.com/Smartspace-ai/Smartspace-app-api/pull/783), which deleted the `IsPromptAndResponseLoggingEnabled` column, service method, and `PUT /workspaces/{id}/promptresponse` endpoint as verified-dead surface.
- Pre-emptive: the next `@smartspace/api-client` dev publish (auto-built from app-api `develop`) will drop the field from `WorkspaceDto`, which would have made `mapper.ts:85-87` a typecheck error.

No UI in this repo reads the field — grep confirms only the model declaration and the mapper assignment referenced it.

## Test plan

- [x] `npx tsc --noEmit` in `packages/chat-ui` clean
- [ ] CI green
- [ ] After app-api `develop` SDK auto-publishes, lockfile bump PR cleanly applies