### PR TITLE
fix(comments): mention crash, guest userId mismatch, API schema drift

### DIFF
--- a/packages/chat-ui/src/shared/markdown/extensions/mention.ts
+++ b/packages/chat-ui/src/shared/markdown/extensions/mention.ts
@@ -65,7 +65,7 @@ export const mention = $node('mention', () => ({
     match: (node) => node.type.name === 'mention',
     runner: (state, node) => {
       const { id, label } = node.attrs as { id: string; label: string };
-      state.addNode('mention', undefined, `${id}|${label}`);
+      state.addNode('text', undefined, label || `@${id}`);
     },
   } as NodeSerializerSpec,
 }));

--- a/src/domains/comments/mapper.ts
+++ b/src/domains/comments/mapper.ts
@@ -21,9 +21,11 @@ export function mapMentionUserDtoToModel(
   if (typeof dto === 'string') {
     return { id: dto, displayName: '', initials: null };
   }
+  // API may return {userId, name} or {id, name} depending on endpoint version
+  const obj = dto as unknown as Record<string, string | undefined>;
   return {
-    id: dto.id,
-    displayName: dto.name ?? '',
+    id: obj.id ?? obj.userId ?? '',
+    displayName: obj.displayName ?? obj.name ?? '',
     initials: null,
   };
 }

--- a/src/domains/comments/mutations.ts
+++ b/src/domains/comments/mutations.ts
@@ -71,10 +71,16 @@ export function useAddComment(threadId: string) {
           const realIdx = list.findIndex((c) => c.id === realComment.id);
 
           // The SignalR `receiveCommentsUpdate` push can land before the POST
-          // response. When it does, the real comment is already in the cache,
-          // and naively replacing the placeholder would leave two copies.
+          // response. When it does, the real comment is already in the cache.
+          // Replace the SignalR entry with the POST response — it is the
+          // authoritative source and may carry fields (e.g. createdBy for B2B
+          // guests) that the SignalR payload omits.
           if (realIdx !== -1) {
-            return tempIdx === -1 ? list : list.filter((c) => c.id !== tempId);
+            const without =
+              tempIdx === -1 ? list : list.filter((c) => c.id !== tempId);
+            return without.map((c) =>
+              c.id === realComment.id ? realComment : c
+            );
           }
           if (tempIdx === -1) return [...list, realComment];
           const next = list.slice();

--- a/src/domains/comments/service.ts
+++ b/src/domains/comments/service.ts
@@ -1,6 +1,5 @@
 import { ChatApi, ChatZod } from '@smartspace/api-client';
-
-import { parseOrThrow } from '@/platform/validation';
+import type { z } from 'zod';
 
 import { mapCommentDtoToModel, mapCommentsDtoToModels } from './mapper';
 import { Comment, MentionUser } from './model';
@@ -14,12 +13,12 @@ const chatApi = ChatApi.getSmartSpaceChatAPI();
 // Fetch all comments for a given thread
 export async function fetchComments(threadId: string): Promise<Comment[]> {
   const response = await chatApi.messageThreadsGetComments(threadId);
-  const parsed = parseOrThrow(
-    commentsResponseSchema,
-    response.data,
-    `GET /messageThreads/${threadId}/comments`
-  );
-  const models = mapCommentsDtoToModels(parsed.data);
+  // The API now returns mentionedUsers as {userId, name}[] objects rather than string[],
+  // so the generated schema rejects it. Cast and let the mapper normalise the shape.
+  const raw = response.data as unknown as z.infer<
+    typeof commentsResponseSchema
+  >;
+  const models = mapCommentsDtoToModels(raw.data);
   return models.sort(
     (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
   );
@@ -35,11 +34,11 @@ export async function addComment(
     content,
     mentionedUsers: mentionedUsers.map((u) => u.id),
   });
-  const parsed = parseOrThrow(
-    commentCreateResponseSchema,
-    response.data,
-    `POST /messageThreads/${threadId}/comments`
-  );
-  const model = mapCommentDtoToModel({ ...parsed, messageThreadId: threadId });
+  // The API now returns mentionedUsers as {userId, name}[] objects rather than string[],
+  // so the generated schema rejects it. Cast and let the mapper normalise the shape.
+  const raw = response.data as unknown as z.infer<
+    typeof commentCreateResponseSchema
+  >;
+  const model = mapCommentDtoToModel({ ...raw, messageThreadId: threadId });
   return model;
 }

--- a/src/platform/auth/providers/msalWeb.ts
+++ b/src/platform/auth/providers/msalWeb.ts
@@ -265,13 +265,22 @@ export function createMsalWebAdapter(): AuthAdapter {
         // downstream consumers (e.g. optimistic comment placeholders) hit when
         // displayName is undefined.
         return {
-          accountId: a.homeAccountId,
+          // localAccountId is the `oid` claim — the objectId in the current
+          // (resource) tenant. homeAccountId is "{oid}.{tenantId}" which diverges
+          // from the server's createdByUserId for B2B guest accounts.
+          accountId: a.localAccountId,
           displayName: a.name ?? a.username ?? undefined,
         };
       }
       // Fallback: popup token available but MSAL cache is partitioned (Teams Mobile).
       if (popupFallbackToken) {
-        return { accountId: popupFallbackToken.homeAccountId };
+        const fallbackAccount = msalInstance.getAccountByHomeId(
+          popupFallbackToken.homeAccountId
+        );
+        return {
+          accountId:
+            fallbackAccount?.localAccountId ?? popupFallbackToken.homeAccountId,
+        };
       }
       return null;
     },


### PR DESCRIPTION
## Summary

- **Milkdown crash on mention nodes** — `toMarkdown.runner` was emitting a custom `mention` MDAST node that `mdast-util-to-markdown` can't serialize, throwing on every keystroke. Now emits a `text` node with the display label instead.
- **Zod validation errors on GET/POST comments** — the API now returns `mentionedUsers` as `{userId, name}[]` objects but the generated API-client schemas still expect `string[]`. Both `fetchComments` and `addComment` now bypass the stale schema via a type cast and let the mapper normalise the shape.
- **Mapper handling both mention shapes** — `mapMentionUserDtoToModel` now handles both `{id, name}` and `{userId, name}` API response formats.
- **Guest AAD user shows ? avatar / blank name on optimistic comment** — `msalWeb.ts` was storing `homeAccountId` (`objectId.tenantId`) as the session `accountId`, but the server uses just the `objectId` (`localAccountId`). For B2B guests these diverge, so the photo URL was wrong and the optimistic `createdByUserId` didn't match the server's value. Switched to `a.localAccountId`; also fixed the Teams Mobile popup fallback path.
- **Name flicker after comment sent** — when SignalR delivers the comment before the POST response arrives, the `onSuccess` handler was leaving the SignalR cache entry as-is (which can have an empty `createdBy` for guests). Now replaces the SignalR entry with the authoritative POST response data.

## Test plan

- [ ] Post a comment as a regular AAD member — avatar, name, and content display correctly throughout (optimistic → settled)
- [ ] Post a comment as a B2B guest user — no `?` avatar, no blank name, no name flicker after posting
- [ ] Type `@` in the comment editor and select a mention — no console errors on every keystroke, mention serialises to display text on submit
- [ ] Load a thread with existing comments that have mentioned users — no Zod validation errors in console
- [ ] Verify `pnpm run typecheck` passes