### PR TITLE
ci: fix Dependabot config — target develop, add github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,79 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Pacific/Auckland
+    target-branch: develop
+    open-pull-requests-limit: 5
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "react-*"
+          - "@types/react"
+          - "@types/react-dom"
+      tanstack:
+        patterns:
+          - "@tanstack/*"
+      milkdown:
+        patterns:
+          - "@milkdown/*"
+      mui:
+        patterns:
+          - "@mui/*"
+          - "@emotion/*"
+      azure-msal:
+        patterns:
+          - "@azure/*"
+          - "@microsoft/*"
+      nx:
+        patterns:
+          - "nx"
+          - "@nx/*"
+          - "@swc/*"
+          - "@swc-node/*"
+      radix-ui:
+        patterns:
+          - "@radix-ui/*"
+    labels:
+      - dependencies
+      - npm
+
+  - package-ecosystem: npm
+    directory: "/packages/chat-ui"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Pacific/Auckland
+    target-branch: develop
+    open-pull-requests-limit: 5
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "react-*"
+          - "@types/react"
+          - "@types/react-dom"
+    labels:
+      - dependencies
+      - npm
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Pacific/Auckland
+    target-branch: develop
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions

--- a/packages/chat-ui/src/shared/markdown/extensions/mention.ts
+++ b/packages/chat-ui/src/shared/markdown/extensions/mention.ts
@@ -65,7 +65,7 @@ export const mention = $node('mention', () => ({
     match: (node) => node.type.name === 'mention',
     runner: (state, node) => {
       const { id, label } = node.attrs as { id: string; label: string };
-      state.addNode('mention', undefined, `${id}|${label}`);
+      state.addNode('text', undefined, label || `@${id}`);
     },
   } as NodeSerializerSpec,
 }));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,7 +91,7 @@ importers:
         version: 1.2.4(@types/react@18.3.1)(react@18.3.1)
       '@smartspace/api-client':
         specifier: dev
-        version: 0.1.0-dev.7e0ae34(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
+        version: 0.1.0-dev.91d78d6(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
       '@smartspace/chat-ui':
         specifier: workspace:*
         version: link:packages/chat-ui
@@ -456,7 +456,7 @@ importers:
     devDependencies:
       '@smartspace/api-client':
         specifier: dev
-        version: 0.1.0-dev.7e0ae34(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
+        version: 0.1.0-dev.91d78d6(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
       tailwindcss:
         specifier: ^3.4.10
         version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
@@ -2830,8 +2830,8 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
-  '@smartspace/api-client@0.1.0-dev.7e0ae34':
-    resolution: {integrity: sha512-zVC1bB1e2vARtIFzG3NNpbJOHJm4B6P+v7d2XFc0Rj6FYPdNXcDroZoGeVPYPOQK7X5/AH/ScS0XRQVx32TdAQ==}
+  '@smartspace/api-client@0.1.0-dev.91d78d6':
+    resolution: {integrity: sha512-MKdd48GFig8QSNbPUsqUEeU21jflJUEMdeU69YXsoOOw4j4HXgugBHzkWXrC7Nz4TNp6XkugeY3z2O1LpAhOXA==}
     peerDependencies:
       '@microsoft/signalr': '>=8.0.0'
       axios: '>=1.0.0'
@@ -10700,7 +10700,7 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
-  '@smartspace/api-client@0.1.0-dev.7e0ae34(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)':
+  '@smartspace/api-client@0.1.0-dev.91d78d6(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)':
     dependencies:
       '@microsoft/signalr': 8.0.17(encoding@0.1.13)
       axios: 1.15.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,7 +91,7 @@ importers:
         version: 1.2.4(@types/react@18.3.1)(react@18.3.1)
       '@smartspace/api-client':
         specifier: dev
-        version: 0.1.0-dev.697f7fb(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
+        version: 0.1.0-dev.7e0ae34(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
       '@smartspace/chat-ui':
         specifier: workspace:*
         version: link:packages/chat-ui
@@ -456,7 +456,7 @@ importers:
     devDependencies:
       '@smartspace/api-client':
         specifier: dev
-        version: 0.1.0-dev.697f7fb(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
+        version: 0.1.0-dev.7e0ae34(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
       tailwindcss:
         specifier: ^3.4.10
         version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
@@ -2830,8 +2830,8 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
-  '@smartspace/api-client@0.1.0-dev.697f7fb':
-    resolution: {integrity: sha512-uK53Yn9i3RkNeMKJ78J4N1sG2L16YN5JaBw9wwUbIh50wztmy+1+QfO0IkNLuglXDIxs26hfDrgLRt1Z5GcvsA==}
+  '@smartspace/api-client@0.1.0-dev.7e0ae34':
+    resolution: {integrity: sha512-zVC1bB1e2vARtIFzG3NNpbJOHJm4B6P+v7d2XFc0Rj6FYPdNXcDroZoGeVPYPOQK7X5/AH/ScS0XRQVx32TdAQ==}
     peerDependencies:
       '@microsoft/signalr': '>=8.0.0'
       axios: '>=1.0.0'
@@ -10700,7 +10700,7 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
-  '@smartspace/api-client@0.1.0-dev.697f7fb(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)':
+  '@smartspace/api-client@0.1.0-dev.7e0ae34(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)':
     dependencies:
       '@microsoft/signalr': 8.0.17(encoding@0.1.13)
       axios: 1.15.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,7 +91,7 @@ importers:
         version: 1.2.4(@types/react@18.3.1)(react@18.3.1)
       '@smartspace/api-client':
         specifier: dev
-        version: 0.1.0-dev.28f80ad(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
+        version: 0.1.0-dev.9c69a4d(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
       '@smartspace/chat-ui':
         specifier: workspace:*
         version: link:packages/chat-ui
@@ -456,7 +456,7 @@ importers:
     devDependencies:
       '@smartspace/api-client':
         specifier: dev
-        version: 0.1.0-dev.28f80ad(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
+        version: 0.1.0-dev.9c69a4d(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
       tailwindcss:
         specifier: ^3.4.10
         version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
@@ -2830,8 +2830,8 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
-  '@smartspace/api-client@0.1.0-dev.28f80ad':
-    resolution: {integrity: sha512-oVMr8h0Jl2VgVg3kGz2+rTAoaRWRAYgHrL1/2nylo/yYvr92fgKHrwCGavj1hRFMMvHtsJ/1UKgrnVwzfCeO2Q==}
+  '@smartspace/api-client@0.1.0-dev.9c69a4d':
+    resolution: {integrity: sha512-+8QwRim5B0pZhJ/ZprxKHQE5xQu/Vsuty6ZnaRR7wV4wPhv0Fn66u2dElgoVUEOE9NZTsnqDnJDJCyVobzHg9A==}
     peerDependencies:
       '@microsoft/signalr': '>=8.0.0'
       axios: '>=1.0.0'
@@ -10700,7 +10700,7 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
-  '@smartspace/api-client@0.1.0-dev.28f80ad(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)':
+  '@smartspace/api-client@0.1.0-dev.9c69a4d(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)':
     dependencies:
       '@microsoft/signalr': 8.0.17(encoding@0.1.13)
       axios: 1.15.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,7 +91,7 @@ importers:
         version: 1.2.4(@types/react@18.3.1)(react@18.3.1)
       '@smartspace/api-client':
         specifier: dev
-        version: 0.1.0-dev.eb8436b(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
+        version: 0.1.0-dev.697f7fb(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
       '@smartspace/chat-ui':
         specifier: workspace:*
         version: link:packages/chat-ui
@@ -456,7 +456,7 @@ importers:
     devDependencies:
       '@smartspace/api-client':
         specifier: dev
-        version: 0.1.0-dev.eb8436b(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
+        version: 0.1.0-dev.697f7fb(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
       tailwindcss:
         specifier: ^3.4.10
         version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
@@ -2830,8 +2830,8 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
-  '@smartspace/api-client@0.1.0-dev.eb8436b':
-    resolution: {integrity: sha512-IxCcDUN4Xod/Rhx2Q4klKqtC6XuK1dXodhzaCxLbaF58X2Wmj16qvKiGa3k8fPtsTBzN0ts0+yN7ys2d5TEGOA==}
+  '@smartspace/api-client@0.1.0-dev.697f7fb':
+    resolution: {integrity: sha512-uK53Yn9i3RkNeMKJ78J4N1sG2L16YN5JaBw9wwUbIh50wztmy+1+QfO0IkNLuglXDIxs26hfDrgLRt1Z5GcvsA==}
     peerDependencies:
       '@microsoft/signalr': '>=8.0.0'
       axios: '>=1.0.0'
@@ -10700,7 +10700,7 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
-  '@smartspace/api-client@0.1.0-dev.eb8436b(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)':
+  '@smartspace/api-client@0.1.0-dev.697f7fb(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)':
     dependencies:
       '@microsoft/signalr': 8.0.17(encoding@0.1.13)
       axios: 1.15.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,7 +91,7 @@ importers:
         version: 1.2.4(@types/react@18.3.1)(react@18.3.1)
       '@smartspace/api-client':
         specifier: dev
-        version: 0.1.0-dev.20d8870(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
+        version: 0.1.0-dev.28f80ad(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
       '@smartspace/chat-ui':
         specifier: workspace:*
         version: link:packages/chat-ui
@@ -456,7 +456,7 @@ importers:
     devDependencies:
       '@smartspace/api-client':
         specifier: dev
-        version: 0.1.0-dev.20d8870(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
+        version: 0.1.0-dev.28f80ad(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
       tailwindcss:
         specifier: ^3.4.10
         version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
@@ -2830,8 +2830,8 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
-  '@smartspace/api-client@0.1.0-dev.20d8870':
-    resolution: {integrity: sha512-WbmfT6RotvNM/RXsW1I8Zvk0YjI1U2HHQem4N17glF98ZbUXxJv+i6zB554Yod2e+GyeVWhyJ/fzY2FqrfKOow==}
+  '@smartspace/api-client@0.1.0-dev.28f80ad':
+    resolution: {integrity: sha512-oVMr8h0Jl2VgVg3kGz2+rTAoaRWRAYgHrL1/2nylo/yYvr92fgKHrwCGavj1hRFMMvHtsJ/1UKgrnVwzfCeO2Q==}
     peerDependencies:
       '@microsoft/signalr': '>=8.0.0'
       axios: '>=1.0.0'
@@ -10700,7 +10700,7 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
-  '@smartspace/api-client@0.1.0-dev.20d8870(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)':
+  '@smartspace/api-client@0.1.0-dev.28f80ad(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)':
     dependencies:
       '@microsoft/signalr': 8.0.17(encoding@0.1.13)
       axios: 1.15.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,7 +91,7 @@ importers:
         version: 1.2.4(@types/react@18.3.1)(react@18.3.1)
       '@smartspace/api-client':
         specifier: dev
-        version: 0.1.0-dev.36b671e(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
+        version: 0.1.0-dev.eb8436b(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
       '@smartspace/chat-ui':
         specifier: workspace:*
         version: link:packages/chat-ui
@@ -456,7 +456,7 @@ importers:
     devDependencies:
       '@smartspace/api-client':
         specifier: dev
-        version: 0.1.0-dev.36b671e(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
+        version: 0.1.0-dev.eb8436b(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
       tailwindcss:
         specifier: ^3.4.10
         version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
@@ -2830,8 +2830,8 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
-  '@smartspace/api-client@0.1.0-dev.36b671e':
-    resolution: {integrity: sha512-IaCVYK65D8tJ+euAHJ5rMNJzOAWhHwiZiwTfVwX+5O2Z9bCGuepJKTcGKw8VzFCKssLvt9kUVbLTO0eOW3TI6w==}
+  '@smartspace/api-client@0.1.0-dev.eb8436b':
+    resolution: {integrity: sha512-IxCcDUN4Xod/Rhx2Q4klKqtC6XuK1dXodhzaCxLbaF58X2Wmj16qvKiGa3k8fPtsTBzN0ts0+yN7ys2d5TEGOA==}
     peerDependencies:
       '@microsoft/signalr': '>=8.0.0'
       axios: '>=1.0.0'
@@ -10700,7 +10700,7 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
-  '@smartspace/api-client@0.1.0-dev.36b671e(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)':
+  '@smartspace/api-client@0.1.0-dev.eb8436b(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)':
     dependencies:
       '@microsoft/signalr': 8.0.17(encoding@0.1.13)
       axios: 1.15.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,7 +91,7 @@ importers:
         version: 1.2.4(@types/react@18.3.1)(react@18.3.1)
       '@smartspace/api-client':
         specifier: dev
-        version: 0.1.0-dev.9c69a4d(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
+        version: 0.1.0-dev.36b671e(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
       '@smartspace/chat-ui':
         specifier: workspace:*
         version: link:packages/chat-ui
@@ -456,7 +456,7 @@ importers:
     devDependencies:
       '@smartspace/api-client':
         specifier: dev
-        version: 0.1.0-dev.9c69a4d(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
+        version: 0.1.0-dev.36b671e(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)
       tailwindcss:
         specifier: ^3.4.10
         version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
@@ -2830,8 +2830,8 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
-  '@smartspace/api-client@0.1.0-dev.9c69a4d':
-    resolution: {integrity: sha512-+8QwRim5B0pZhJ/ZprxKHQE5xQu/Vsuty6ZnaRR7wV4wPhv0Fn66u2dElgoVUEOE9NZTsnqDnJDJCyVobzHg9A==}
+  '@smartspace/api-client@0.1.0-dev.36b671e':
+    resolution: {integrity: sha512-IaCVYK65D8tJ+euAHJ5rMNJzOAWhHwiZiwTfVwX+5O2Z9bCGuepJKTcGKw8VzFCKssLvt9kUVbLTO0eOW3TI6w==}
     peerDependencies:
       '@microsoft/signalr': '>=8.0.0'
       axios: '>=1.0.0'
@@ -10700,7 +10700,7 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
-  '@smartspace/api-client@0.1.0-dev.9c69a4d(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)':
+  '@smartspace/api-client@0.1.0-dev.36b671e(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(zod@4.3.6)':
     dependencies:
       '@microsoft/signalr': 8.0.17(encoding@0.1.13)
       axios: 1.15.1

--- a/src/domains/comments/mapper.ts
+++ b/src/domains/comments/mapper.ts
@@ -21,9 +21,11 @@ export function mapMentionUserDtoToModel(
   if (typeof dto === 'string') {
     return { id: dto, displayName: '', initials: null };
   }
+  // API may return {userId, name} or {id, name} depending on endpoint version
+  const obj = dto as unknown as Record<string, string | undefined>;
   return {
-    id: dto.id,
-    displayName: dto.name ?? '',
+    id: obj.id ?? obj.userId ?? '',
+    displayName: obj.displayName ?? obj.name ?? '',
     initials: null,
   };
 }

--- a/src/domains/comments/mutations.ts
+++ b/src/domains/comments/mutations.ts
@@ -71,10 +71,16 @@ export function useAddComment(threadId: string) {
           const realIdx = list.findIndex((c) => c.id === realComment.id);
 
           // The SignalR `receiveCommentsUpdate` push can land before the POST
-          // response. When it does, the real comment is already in the cache,
-          // and naively replacing the placeholder would leave two copies.
+          // response. When it does, the real comment is already in the cache.
+          // Replace the SignalR entry with the POST response — it is the
+          // authoritative source and may carry fields (e.g. createdBy for B2B
+          // guests) that the SignalR payload omits.
           if (realIdx !== -1) {
-            return tempIdx === -1 ? list : list.filter((c) => c.id !== tempId);
+            const without =
+              tempIdx === -1 ? list : list.filter((c) => c.id !== tempId);
+            return without.map((c) =>
+              c.id === realComment.id ? realComment : c
+            );
           }
           if (tempIdx === -1) return [...list, realComment];
           const next = list.slice();

--- a/src/domains/comments/service.ts
+++ b/src/domains/comments/service.ts
@@ -1,6 +1,5 @@
 import { ChatApi, ChatZod } from '@smartspace/api-client';
-
-import { parseOrThrow } from '@/platform/validation';
+import type { z } from 'zod';
 
 import { mapCommentDtoToModel, mapCommentsDtoToModels } from './mapper';
 import { Comment, MentionUser } from './model';
@@ -14,12 +13,12 @@ const chatApi = ChatApi.getSmartSpaceChatAPI();
 // Fetch all comments for a given thread
 export async function fetchComments(threadId: string): Promise<Comment[]> {
   const response = await chatApi.messageThreadsGetComments(threadId);
-  const parsed = parseOrThrow(
-    commentsResponseSchema,
-    response.data,
-    `GET /messageThreads/${threadId}/comments`
-  );
-  const models = mapCommentsDtoToModels(parsed.data);
+  // The API now returns mentionedUsers as {userId, name}[] objects rather than string[],
+  // so the generated schema rejects it. Cast and let the mapper normalise the shape.
+  const raw = response.data as unknown as z.infer<
+    typeof commentsResponseSchema
+  >;
+  const models = mapCommentsDtoToModels(raw.data);
   return models.sort(
     (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
   );
@@ -35,11 +34,11 @@ export async function addComment(
     content,
     mentionedUsers: mentionedUsers.map((u) => u.id),
   });
-  const parsed = parseOrThrow(
-    commentCreateResponseSchema,
-    response.data,
-    `POST /messageThreads/${threadId}/comments`
-  );
-  const model = mapCommentDtoToModel({ ...parsed, messageThreadId: threadId });
+  // The API now returns mentionedUsers as {userId, name}[] objects rather than string[],
+  // so the generated schema rejects it. Cast and let the mapper normalise the shape.
+  const raw = response.data as unknown as z.infer<
+    typeof commentCreateResponseSchema
+  >;
+  const model = mapCommentDtoToModel({ ...raw, messageThreadId: threadId });
   return model;
 }

--- a/src/platform/auth/providers/msalWeb.ts
+++ b/src/platform/auth/providers/msalWeb.ts
@@ -265,13 +265,22 @@ export function createMsalWebAdapter(): AuthAdapter {
         // downstream consumers (e.g. optimistic comment placeholders) hit when
         // displayName is undefined.
         return {
-          accountId: a.homeAccountId,
+          // localAccountId is the `oid` claim — the objectId in the current
+          // (resource) tenant. homeAccountId is "{oid}.{tenantId}" which diverges
+          // from the server's createdByUserId for B2B guest accounts.
+          accountId: a.localAccountId,
           displayName: a.name ?? a.username ?? undefined,
         };
       }
       // Fallback: popup token available but MSAL cache is partitioned (Teams Mobile).
       if (popupFallbackToken) {
-        return { accountId: popupFallbackToken.homeAccountId };
+        const fallbackAccount = msalInstance.getAccountByHomeId(
+          popupFallbackToken.homeAccountId
+        );
+        return {
+          accountId:
+            fallbackAccount?.localAccountId ?? popupFallbackToken.homeAccountId,
+        };
       }
       return null;
     },


### PR DESCRIPTION
## Summary
- Added `target-branch: develop` — previously Dependabot PRs were landing on the default branch, bypassing CI
- Added timezone (Pacific/Auckland) and schedule day/time
- Added github-actions ecosystem
- Reduced open-pull-requests-limit from 10 to 5