### PR TITLE
fix: post-248 phase 1 — optimistic UUIDs, workspace query gate, subscription lifetime

### DIFF
--- a/packages/chat-ui/src/domains/messages/mutations.ts
+++ b/packages/chat-ui/src/domains/messages/mutations.ts
@@ -238,7 +238,7 @@ export function useAddInputToMessage() {
                 values: [
                   ...(m.values ?? []),
                   {
-                    id: `temp-${Date.now()}-add`,
+                    id: `temp-${crypto.randomUUID()}-add`,
                     type: MessageValueType.INPUT,
                     name,
                     value,


### PR DESCRIPTION
## What & why
- Replace `Date.now()` optimistic ID with `crypto.randomUUID()` in `useAddInputToMessage` — avoids collisions under fast concurrent form-input mutations (the other temp-id sites in `useSendMessage` and `useAddComment` were already using `randomUUID`)
- `useWorkspace` enable gate (`enabled: !!workspaceId`) was already present on this branch — no change needed
- `useWorkspaceSubscriptions` was already moved to `_protected.tsx` on this branch — no change needed

## What changed and where
- `packages/chat-ui/src/domains/messages/mutations.ts` line 241: `temp-${Date.now()}-add` → `temp-${crypto.randomUUID()}-add`

## Test plan
- [x] typecheck, lint, tests green (confirmed locally — pre-existing typecheck error in `src/domains/comments/mapper.ts:66` exists on base branch, not introduced here)
- [x] Send a form input on a message and verify no duplicate/flickering in message list
- [x] Switch workspaces and verify subscriptions reconnect cleanly

## Risk & rollback
Isolated, single-line change. Rollback: revert this commit.