### PR TITLE
chore(ci): publish under @sentuar npm scope (temp until @smartspace account restored)

### DIFF
--- a/.github/workflows/chat-ui-publish-develop.yml
+++ b/.github/workflows/chat-ui-publish-develop.yml
@@ -52,6 +52,11 @@ jobs:
           jq --arg v "${{ steps.ver.outputs.version }}" '.version = $v' package.json > p.json
           mv p.json package.json
 
+      - name: Rename package to personal npm scope (temporary — remove when @smartspace npm account is restored)
+        run: |
+          cd packages/chat-ui
+          jq '.name = "@sentuar/chat-ui"' package.json > p.json && mv p.json package.json
+
       - run: pnpm --filter @smartspace/chat-ui build
 
       - name: Publish dev to npmjs.com (tag=dev)
@@ -77,10 +82,11 @@ jobs:
             -f event_type=chat-ui-published \
             -f "client_payload[tag]=dev" \
             -f "client_payload[version]=${{ steps.ver.outputs.version }}" \
-            -f "client_payload[target_branch]=develop"
+            -f "client_payload[target_branch]=develop" \
+            -f "client_payload[package_name]=@sentuar/chat-ui"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Summary
         run: |
-          echo "Published \`@smartspace/chat-ui@${{ steps.ver.outputs.version }}\` (dist-tag \`dev\`)" >> "$GITHUB_STEP_SUMMARY"
+          echo "Published \`@sentuar/chat-ui@${{ steps.ver.outputs.version }}\` (dist-tag \`dev\`) — install as \`@smartspace/chat-ui@npm:@sentuar/chat-ui@${{ steps.ver.outputs.version }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/chat-ui-publish-pr.yml
+++ b/.github/workflows/chat-ui-publish-pr.yml
@@ -53,6 +53,11 @@ jobs:
           jq --arg v "${{ steps.ver.outputs.version }}" '.version = $v' package.json > p.json
           mv p.json package.json
 
+      - name: Rename package to personal npm scope (temporary — remove when @smartspace npm account is restored)
+        run: |
+          cd packages/chat-ui
+          jq '.name = "@sentuar/chat-ui"' package.json > p.json && mv p.json package.json
+
       - run: pnpm --filter @smartspace/chat-ui build
 
       - name: Publish pre-release to npmjs.com (tag=pr)
@@ -73,7 +78,7 @@ jobs:
               `## chat-ui pre-release published`,
               ``,
               '```bash',
-              `pnpm add @smartspace/chat-ui@${version}`,
+              `pnpm add @smartspace/chat-ui@npm:@sentuar/chat-ui@${version}`,
               '```',
               ``,
               `Version: \`${version}\` (dist-tag \`pr\`)`,

--- a/.github/workflows/internal-bump-sdk.yml
+++ b/.github/workflows/internal-bump-sdk.yml
@@ -58,26 +58,37 @@ jobs:
         env:
           NEW_VERSION: ${{ github.event.client_payload.version }}
           CHANNEL: ${{ github.event.client_payload.tag }}
+          PKG_NAME: ${{ github.event.client_payload.package_name }}
         run: |
-          # Pin the exact resolved version. This forces pnpm to refresh the
-          # lockfile entry — the literal "dev"/"main" tag spec doesn't trigger
-          # re-resolution on its own once a version is locked.
-          # --workspace-root: this repo is a pnpm workspace; pnpm refuses to
-          # add deps to the root without it.
-          pnpm add --workspace-root --save-exact "@smartspace/api-client@${NEW_VERSION}"
+          # Determine whether we're installing from the temp personal scope or
+          # the real @smartspace scope. When package_name is set (e.g.
+          # @sentuar/api-client) use an npm alias so imports stay @smartspace/*.
+          if [ -n "$PKG_NAME" ] && [ "$PKG_NAME" != "@smartspace/api-client" ]; then
+            pnpm add --workspace-root --save-exact "@smartspace/api-client@npm:${PKG_NAME}@${NEW_VERSION}"
+            # Do NOT restore the channel literal — @sentuar/* doesn't have a
+            # dev/main dist-tag, so the alias spec must remain in package.json.
+            pnpm install --no-frozen-lockfile
+          else
+            # Pin the exact resolved version. This forces pnpm to refresh the
+            # lockfile entry — the literal "dev"/"main" tag spec doesn't trigger
+            # re-resolution on its own once a version is locked.
+            # --workspace-root: this repo is a pnpm workspace; pnpm refuses to
+            # add deps to the root without it.
+            pnpm add --workspace-root --save-exact "@smartspace/api-client@${NEW_VERSION}"
 
-          # Revert the package.json spec back to the channel literal so the
-          # existing check-package-json-channel.yml swap workflow keeps working.
-          node -e "
-            const fs = require('fs');
-            const p = JSON.parse(fs.readFileSync('package.json','utf8'));
-            p.dependencies['@smartspace/api-client'] = process.env.CHANNEL;
-            fs.writeFileSync('package.json', JSON.stringify(p, null, 2) + '\n');
-          "
+            # Revert the package.json spec back to the channel literal so the
+            # existing check-package-json-channel.yml swap workflow keeps working.
+            node -e "
+              const fs = require('fs');
+              const p = JSON.parse(fs.readFileSync('package.json','utf8'));
+              p.dependencies['@smartspace/api-client'] = process.env.CHANNEL;
+              fs.writeFileSync('package.json', JSON.stringify(p, null, 2) + '\n');
+            "
 
-          # Resync the lockfile spec field to the literal tag. Resolved version
-          # is unchanged, so this is fast.
-          pnpm install --no-frozen-lockfile
+            # Resync the lockfile spec field to the literal tag. Resolved version
+            # is unchanged, so this is fast.
+            pnpm install --no-frozen-lockfile
+          fi
 
       - name: Detect changes and validate scope
         id: diff


### PR DESCRIPTION
## Summary

- Renames `@smartspace/chat-ui` → `@sentuar/chat-ui` before publishing in both the PR pre-release and dev-channel workflows
- Updates `internal-bump-sdk.yml` to install via npm alias (`@smartspace/api-client@npm:@sentuar/api-client@VERSION`) when `package_name` is set in the dispatch payload — source imports stay unchanged
- Adds `package_name=@sentuar/chat-ui` to the `Notify Smartspace-app` dispatch

Temporary — revert all three files once the `@smartspace` npm account is unlocked.

## Test plan

- [ ] Merge to `develop` and push a chat-ui change — confirm `@sentuar/chat-ui` is published with `dev` dist-tag
- [ ] Confirm auto-bump fires in Smartspace-app using the alias install