### PR TITLE
fix(ci): swap SDK channel across all workspace manifests (kill split-brain pin)

### DIFF
--- a/.github/workflows/check-package-json-channel.yml
+++ b/.github/workflows/check-package-json-channel.yml
@@ -6,6 +6,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - package.json
+      - packages/*/package.json
       - pnpm-lock.yaml
 
 permissions:
@@ -35,11 +36,16 @@ jobs:
       - name: Detect 'dev' SDK pins
         id: detect
         run: |
-          if grep -qE '"@smartspace/[^"]+"\s*:\s*"dev"' package.json; then
+          # Cover every workspace manifest (root + packages/*), not just the
+          # root. chat-ui carries its own '@smartspace/api-client: "dev"' pin;
+          # swapping only the root left release/next resolving a split
+          # dev/main dependency graph (two api-client versions at once).
+          manifests=$(git ls-files 'package.json' 'packages/*/package.json')
+          if grep -lE '"@smartspace/[^"]+"\s*:\s*"dev"' $manifests; then
             echo "needs-swap=true" >> "$GITHUB_OUTPUT"
           else
             echo "needs-swap=false" >> "$GITHUB_OUTPUT"
-            echo "OK: no develop-channel SDK pins in package.json — nothing to do."
+            echo "OK: no develop-channel SDK pins in any workspace manifest — nothing to do."
           fi
 
       - name: Generate CI_DISPATCH_APP token
@@ -76,7 +82,9 @@ jobs:
       - name: Swap pins and refresh lockfile
         if: steps.detect.outputs.needs-swap == 'true'
         run: |
-          sed -i -E 's|("@smartspace/[^"]+"\s*:\s*)"dev"|\1"main"|g' package.json
+          manifests=$(git ls-files 'package.json' 'packages/*/package.json')
+          echo "Swapping dev→main in: $manifests"
+          sed -i -E 's|("@smartspace/[^"]+"\s*:\s*)"dev"|\1"main"|g' $manifests
           pnpm install --no-frozen-lockfile
 
       - name: Commit and push
@@ -84,6 +92,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json pnpm-lock.yaml
+          git add $(git ls-files 'package.json' 'packages/*/package.json') pnpm-lock.yaml
           git commit -m "auto: swap @smartspace/* SDK pins from 'dev' to 'main' for main-targeted PR"
           git push


### PR DESCRIPTION
## What

The `dev→main` channel swap (`check-package-json-channel.yml`) only rewrote the **root** `package.json`. But `packages/chat-ui/package.json` carries its own `"@smartspace/api-client": "dev"` pin, which the swap never touched.

So on `release/next` the workspace resolved **two api-client channels at once** — root app on `main`, chat-ui sub-package on `dev` — a split dependency graph that produces cross-package type-identity mismatches and means a "main" release never cleanly ships on the main channel.

## Change

Make the detect, swap, and commit steps operate over **every tracked workspace manifest** (`root + packages/*`) instead of just the root, via `git ls-files 'package.json' 'packages/*/package.json'`. Also adds `packages/*/package.json` to the workflow's `paths:` trigger.

Validated by dry-run on the current `develop` tree: both `package.json:60` and `packages/chat-ui/package.json:72` flip `dev → main` (previously only the root did).

## Why now

Immediate-relief bridge (rank-2 "split-brain" finding) from the 2026-06-04 CI/CD audit. The longer-term fix replaces channel-swapping entirely with exact-version pinning + bump-PRs — see **ADR 2026-06-04: Pin the generated SDK by exact version + bump-PRs, not floating dist-tags**. This PR is safe to ship independently and keeps working under the new scheme until the swap is removed.

## Risk

Low — workflow-only change; logic dry-run-validated. No app code touched.
