### PR TITLE
fix(ci): stop auto-bumping the 'main' SDK channel (deadlock + issue spam)

### DIFF
--- a/.github/workflows/internal-bump-sdk.yml
+++ b/.github/workflows/internal-bump-sdk.yml
@@ -4,8 +4,12 @@
 # same quality gate as a normal CI build before pushing — if quality fails the
 # branch is NOT updated and an issue is opened instead.
 #
-# Only acts on the `dev` and `main` channels. Stable `latest` / `rc` releases
-# are intentionally left to manual review.
+# Only acts on the `dev` channel. The `main` channel is deliberately ignored:
+# app-public's code tracks the `dev` SDK, so compiling it against a fresh `main`
+# build deadlocks the bump (and spams auto-bump-failed issues). The release/next
+# `main` pin is set by check-package-json-channel.yml at release time, not here.
+# Stable `latest` / `rc` releases are likewise left to manual review.
+# (Matches Smartspace-app's bump-sdk.yml, which also only acts on `dev`.)
 
 name: Bump @smartspace/api-client (auto, internal)
 
@@ -25,7 +29,7 @@ jobs:
   bump:
     if: |
       github.repository == 'Smartspace-ai/Smartspace-app-public' &&
-      (github.event.client_payload.tag == 'dev' || github.event.client_payload.tag == 'main')
+      github.event.client_payload.tag == 'dev'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
## What

`internal-bump-sdk.yml` reacts to `sdk-published` dispatches on **both** the `dev` and `main` channels. The `main` path is pathological:

- It targets the long-lived `main` branch and runs the quality gate *before* pushing.
- app-public's code on `main` has already adopted **dev-only** generated SDK types, so compiling it against a freshly-published `main` SDK **always fails**.
- Each failure → the bump is rejected (lockfile frozen stale) **and** an `auto-bump-failed` issue is opened (e.g. #311, #312).

## Change

One-line guard: act on `tag == 'dev'` only. Drop the `|| tag == 'main'`. (Plus a comment explaining why.)

The `release/next` → `main` channel pin is set by `check-package-json-channel.yml` at release time, **not** by this workflow, so nothing is lost. This matches **Smartspace-app**'s `bump-sdk.yml`, which already only acts on `dev`.

## Why now

Immediate-relief bridge (rank-4 "auto-bump deadlock" finding) from the 2026-06-04 CI/CD audit. Independent of #313. The longer-term fix reworks this workflow to write **exact versions** and open **bump-PRs** — see **ADR 2026-06-04**.

## Risk

Low — workflow-only `if`-condition change. Removes futile runs and issue noise; does not touch the release pin mechanism.

## Follow-up

Existing open `auto-bump-failed` issues (#311/#312 and any siblings) can be closed once this lands.
