### PR TITLE
fix(ci): grant id-token: write to chat-ui publish workflows (unblock OIDC publish)

### DIFF
--- a/.github/workflows/chat-ui-publish-develop.yml
+++ b/.github/workflows/chat-ui-publish-develop.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write  # OIDC trusted publishing for @smartspace/chat-ui (shared-chat-ui-publish.yml)
 
 concurrency:
   group: chat-ui-publish-develop

--- a/.github/workflows/chat-ui-publish-main.yml
+++ b/.github/workflows/chat-ui-publish-main.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write  # OIDC trusted publishing for @smartspace/chat-ui (shared-chat-ui-publish.yml)
 
 concurrency:
   group: chat-ui-publish-main

--- a/.github/workflows/chat-ui-publish-pr.yml
+++ b/.github/workflows/chat-ui-publish-pr.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write  # OIDC trusted publishing for @smartspace/chat-ui (shared-chat-ui-publish.yml)
   pull-requests: write
 
 concurrency:

--- a/.github/workflows/chat-ui-publish-release.yml
+++ b/.github/workflows/chat-ui-publish-release.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write  # OIDC trusted publishing for @smartspace/chat-ui (shared-chat-ui-publish.yml)
 
 concurrency:
   group: chat-ui-publish-release-${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Problem

All four `chat-ui-publish-*.yml` callers (`develop`, `main`, `pr`, `release`) were refactored to call the reusable workflow `Smartspace-ai/ci-workflows/.github/workflows/shared-chat-ui-publish.yml@main`, which declares:

```yaml
permissions:
  contents: read
  id-token: write   # OIDC trusted publishing for @smartspace/chat-ui
```

But each **caller** grants only `permissions: contents: read`. A reusable workflow's permissions **cannot exceed the caller's**, so GitHub rejects the run at **compile time** — the symptom is a failed run with **zero jobs** and "This run likely failed because of a workflow file issue."

## Impact

`@smartspace/chat-ui` has not published on **any** channel since the OIDC migration (~2026-05-28):
- `develop`/`pr`/`release` fail on every trigger
- `main` failed on the first `main` push after a release — surfaced when release PR #285 merged

Downstream **Smartspace-app** (consumes `@smartspace/chat-ui`) has therefore received no updates for ~a week.

## Fix

Add `id-token: write` to the top-level `permissions:` of all four callers (keeping `contents: read`, and `pull-requests: write` on the PR one). 4-line change, no logic touched.

## Validation note

This unblocks the **compile** failure (the run will now start jobs). If npm's trusted-publisher scoping needs adjustment, a *runtime* error could surface at the actual `pnpm publish --provenance` step — we'll see that on the first real run and address separately if so. `id-token: write` is correct and required regardless.

## Rollout

Takes effect per-channel as it merges: `develop`/`pr` immediately on merge to `develop`; `main`/`release` once carried to `main` by the next release.
