### PR TITLE
revert(ci): restore NPM_TOKEN chat-ui publish (unblock — OIDC migration is broken)

### DIFF
--- a/.github/workflows/chat-ui-publish-develop.yml
+++ b/.github/workflows/chat-ui-publish-develop.yml
@@ -10,39 +10,57 @@ on:
 
 permissions:
   contents: read
-  id-token: write  # OIDC trusted publishing for @smartspace/chat-ui (shared-chat-ui-publish.yml)
 
 concurrency:
   group: chat-ui-publish-develop
   cancel-in-progress: false
 
 jobs:
-  compute-version:
+  publish:
+    if: github.repository == 'Smartspace-ai/Smartspace-app-public'
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.ver.outputs.version }}
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 0   # need tag history for git describe
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: pnpm install --frozen-lockfile
+
       - name: Compute dev version
         id: ver
         run: |
+          # Base = most recent v* tag, stripped of the leading 'v'.
+          # Falls back to 0.0.0 if no platform tags exist yet (first
+          # release pre-cut situation).
           BASE_TAG=$(git describe --tags --match='v*' --abbrev=0 2>/dev/null || echo 'v0.0.0')
           BASE="${BASE_TAG#v}"
-          echo "version=${BASE}-dev.${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+          VERSION="${BASE}-dev.${GITHUB_SHA:0:7}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-  publish:
-    needs: compute-version
-    uses: Smartspace-ai/ci-workflows/.github/workflows/shared-chat-ui-publish.yml@main
-    with:
-      version: ${{ needs.compute-version.outputs.version }}
-      tag: dev
+      - name: Stamp version into package.json
+        run: |
+          cd packages/chat-ui
+          jq --arg v "${{ steps.ver.outputs.version }}" '.version = $v' package.json > p.json
+          mv p.json package.json
 
-  notify:
-    needs: [compute-version, publish]
-    runs-on: ubuntu-latest
-    steps:
+      - run: pnpm --filter @smartspace/chat-ui build
+
+      - name: Publish dev to npmjs.com (tag=dev)
+        run: |
+          cd packages/chat-ui
+          pnpm publish --tag dev --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Generate CI_DISPATCH_APP token
         id: app-token
         uses: actions/create-github-app-token@v1
@@ -58,11 +76,11 @@ jobs:
             --method POST \
             -f event_type=chat-ui-published \
             -f "client_payload[tag]=dev" \
-            -f "client_payload[version]=${{ needs.compute-version.outputs.version }}" \
+            -f "client_payload[version]=${{ steps.ver.outputs.version }}" \
             -f "client_payload[target_branch]=develop"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Summary
         run: |
-          echo "Published \`@smartspace/chat-ui@${{ needs.compute-version.outputs.version }}\` (dist-tag \`dev\`)" >> "$GITHUB_STEP_SUMMARY"
+          echo "Published \`@smartspace/chat-ui@${{ steps.ver.outputs.version }}\` (dist-tag \`dev\`)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/chat-ui-publish-main.yml
+++ b/.github/workflows/chat-ui-publish-main.yml
@@ -10,39 +10,54 @@ on:
 
 permissions:
   contents: read
-  id-token: write  # OIDC trusted publishing for @smartspace/chat-ui (shared-chat-ui-publish.yml)
 
 concurrency:
   group: chat-ui-publish-main
   cancel-in-progress: false
 
 jobs:
-  compute-version:
+  publish:
+    if: github.repository == 'Smartspace-ai/Smartspace-app-public'
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.ver.outputs.version }}
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 0   # need tag history for git describe
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: pnpm install --frozen-lockfile
+
       - name: Compute main version
         id: ver
         run: |
           BASE_TAG=$(git describe --tags --match='v*' --abbrev=0 2>/dev/null || echo 'v0.0.0')
           BASE="${BASE_TAG#v}"
-          echo "version=${BASE}-main.${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+          VERSION="${BASE}-main.${GITHUB_SHA:0:7}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-  publish:
-    needs: compute-version
-    uses: Smartspace-ai/ci-workflows/.github/workflows/shared-chat-ui-publish.yml@main
-    with:
-      version: ${{ needs.compute-version.outputs.version }}
-      tag: main
+      - name: Stamp version into package.json
+        run: |
+          cd packages/chat-ui
+          jq --arg v "${{ steps.ver.outputs.version }}" '.version = $v' package.json > p.json
+          mv p.json package.json
 
-  notify:
-    needs: [compute-version, publish]
-    runs-on: ubuntu-latest
-    steps:
+      - run: pnpm --filter @smartspace/chat-ui build
+
+      - name: Publish main to npmjs.com (tag=main)
+        run: |
+          cd packages/chat-ui
+          pnpm publish --tag main --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Generate CI_DISPATCH_APP token
         id: app-token
         uses: actions/create-github-app-token@v1
@@ -58,11 +73,11 @@ jobs:
             --method POST \
             -f event_type=chat-ui-published \
             -f "client_payload[tag]=main" \
-            -f "client_payload[version]=${{ needs.compute-version.outputs.version }}" \
+            -f "client_payload[version]=${{ steps.ver.outputs.version }}" \
             -f "client_payload[target_branch]=main"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Summary
         run: |
-          echo "Published \`@smartspace/chat-ui@${{ needs.compute-version.outputs.version }}\` (dist-tag \`main\`)" >> "$GITHUB_STEP_SUMMARY"
+          echo "Published \`@smartspace/chat-ui@${{ steps.ver.outputs.version }}\` (dist-tag \`main\`)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/chat-ui-publish-pr.yml
+++ b/.github/workflows/chat-ui-publish-pr.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write  # OIDC trusted publishing for @smartspace/chat-ui (shared-chat-ui-publish.yml)
   pull-requests: write
 
 concurrency:
@@ -18,15 +17,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  compute-version:
+  publish:
+    # Customer forks can't reach our npm token; skip there.
     if: github.repository == 'Smartspace-ai/Smartspace-app-public'
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.ver.outputs.version }}
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 0   # need tag history for git describe
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: pnpm install --frozen-lockfile
+
       - name: Compute pre-release version
         id: ver
         run: |
@@ -34,23 +44,29 @@ jobs:
           BASE="${BASE_TAG#v}"
           SHORT_SHA="${{ github.event.pull_request.head.sha }}"
           SHORT_SHA="${SHORT_SHA:0:7}"
-          echo "version=${BASE}-pr.${{ github.event.pull_request.number }}.${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          VERSION="${BASE}-pr.${{ github.event.pull_request.number }}.${SHORT_SHA}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-  publish:
-    needs: compute-version
-    uses: Smartspace-ai/ci-workflows/.github/workflows/shared-chat-ui-publish.yml@main
-    with:
-      version: ${{ needs.compute-version.outputs.version }}
-      tag: pr
+      - name: Stamp version into package.json
+        run: |
+          cd packages/chat-ui
+          jq --arg v "${{ steps.ver.outputs.version }}" '.version = $v' package.json > p.json
+          mv p.json package.json
 
-  comment:
-    needs: [compute-version, publish]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/github-script@v7
+      - run: pnpm --filter @smartspace/chat-ui build
+
+      - name: Publish pre-release to npmjs.com (tag=pr)
+        run: |
+          cd packages/chat-ui
+          pnpm publish --tag pr --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Comment install command on PR
+        uses: actions/github-script@v7
         with:
           script: |
-            const version = '${{ needs.compute-version.outputs.version }}';
+            const version = '${{ steps.ver.outputs.version }}';
             const marker = '<!-- chat-ui-prerelease-comment -->';
             const body = [
               marker,

--- a/.github/workflows/chat-ui-publish-release.yml
+++ b/.github/workflows/chat-ui-publish-release.yml
@@ -10,22 +10,33 @@ on:
 
 permissions:
   contents: read
-  id-token: write  # OIDC trusted publishing for @smartspace/chat-ui (shared-chat-ui-publish.yml)
 
 concurrency:
   group: chat-ui-publish-release-${{ github.event.release.tag_name }}
   cancel-in-progress: false
 
 jobs:
-  compute-version:
+  publish:
     if: |
       github.repository == 'Smartspace-ai/Smartspace-app-public' &&
       startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.ver.outputs.version }}
-      tag: ${{ steps.tag.outputs.tag }}
+    timeout-minutes: 10
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: pnpm install --frozen-lockfile
+
       - name: Extract version from release tag
         id: ver
         run: |
@@ -47,17 +58,21 @@ jobs:
             echo "tag=latest" >> "$GITHUB_OUTPUT"
           fi
 
-  publish:
-    needs: compute-version
-    uses: Smartspace-ai/ci-workflows/.github/workflows/shared-chat-ui-publish.yml@main
-    with:
-      version: ${{ needs.compute-version.outputs.version }}
-      tag: ${{ needs.compute-version.outputs.tag }}
+      - name: Stamp version into package.json
+        run: |
+          cd packages/chat-ui
+          jq --arg v "${{ steps.ver.outputs.version }}" '.version = $v' package.json > p.json
+          mv p.json package.json
 
-  summary:
-    needs: [compute-version, publish]
-    runs-on: ubuntu-latest
-    steps:
+      - run: pnpm --filter @smartspace/chat-ui build
+
+      - name: Publish release to npmjs.com
+        run: |
+          cd packages/chat-ui
+          pnpm publish --tag ${{ steps.tag.outputs.tag }} --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Summary
         run: |
-          echo "Published \`@smartspace/chat-ui@${{ needs.compute-version.outputs.version }}\` (dist-tag \`${{ needs.compute-version.outputs.tag }}\`)" >> "$GITHUB_STEP_SUMMARY"
+          echo "Published \`@smartspace/chat-ui@${{ steps.ver.outputs.version }}\` (dist-tag \`${{ steps.tag.outputs.tag }}\`)" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Why

The OIDC migration of the chat-ui publishers (`129324c` → `1a91d03` → `b171587`) **broke `@smartspace/chat-ui` publishing on all four channels.** Every run fails to **compile** ("This run likely failed because of a workflow file issue", zero jobs) — a cause not exposed through the GitHub Actions API (no check-run/annotation on a zero-job run). The `id-token: write` fix (#329) was necessary but **not sufficient** — it still won't compile.

`@smartspace/chat-ui` has not published since **~05-28 (dev tag) / 05-18 (main tag)**, so **Smartspace-app** (which consumes it) has been getting nothing new for ~a week.

## What

Restore all four `chat-ui-publish-*.yml` to their last known-good state — `129324c^`, the self-contained `pnpm publish --tag <ch>` using `secrets.NPM_TOKEN`. This cleanly undoes the entire OIDC migration arc (including #329's now-moot `id-token` line). Earlier non-OIDC features (version derivation, the `chat-ui-published` dispatch to Smartspace-app) are preserved — they predate the migration.

## Confirmed before reverting

- ✅ **`NPM_TOKEN` is still available** to this repo as an **org secret** (`Smartspace-ai`), so the self-contained publish will authenticate.

## Trade-off

Gives up OIDC trusted publishing + provenance (the migration's goal). That's an acceptable, deliberate step back to a *working* publish — the OIDC migration should be re-attempted later **with the actual compile error in hand** (needs the run's UI banner or org-admin Actions-policy access).

## Rollout & built-in test

- `develop` + `pr` publishers take effect **immediately on merge to `develop`** — and because this PR changes `chat-ui-publish-develop.yml` (in that workflow's own `paths:` filter), **merging it triggers a real develop-channel publish**, which is an immediate end-to-end test that chat-ui publishes again.
- `main` + `release` take effect once carried to `main` by the next release.
