### PR TITLE
fix(ci): --ignore-scripts on lockfile-reconcile installs (unbreak release sync)

### DIFF
--- a/.github/workflows/internal-bump-sdk.yml
+++ b/.github/workflows/internal-bump-sdk.yml
@@ -91,7 +91,10 @@ jobs:
 
           # Resync the lockfile spec field to the literal tag. Resolved version
           # is unchanged, so this is fast.
-          pnpm install --no-frozen-lockfile
+          # --ignore-scripts: lockfile-only. If a new dev SDK is incompatible with
+          # chat-ui, let the bump-PR's `quality` check show it as a red check
+          # rather than failing this workflow before the PR is even opened.
+          pnpm install --no-frozen-lockfile --ignore-scripts
 
       - name: Detect changes and validate scope
         id: diff

--- a/.github/workflows/update-release-next.yml
+++ b/.github/workflows/update-release-next.yml
@@ -99,7 +99,8 @@ jobs:
           git checkout --ours -- package.json pnpm-lock.yaml
 
           # Reconcile the lockfile to package.json after taking 'ours'.
-          pnpm install --no-frozen-lockfile
+          # --ignore-scripts: lockfile-only; don't run package build scripts here.
+          pnpm install --no-frozen-lockfile --ignore-scripts
           git add package.json pnpm-lock.yaml
           git commit --no-edit
 
@@ -128,7 +129,12 @@ jobs:
               fs.writeFileSync(f, JSON.stringify(p, null, 2) + '\n');
             }
           "
-          pnpm install --no-frozen-lockfile
+          # --ignore-scripts: don't run chat-ui's `prepare` build here. We only
+          # need to resolve the lockfile; if chat-ui is incompatible with the
+          # released SDK, the standing PR's `quality` check surfaces it as a red
+          # check (the "develop is ahead of the released API" signal) — it must
+          # NOT break this release-sync workflow.
+          pnpm install --no-frozen-lockfile --ignore-scripts
           git add package.json packages/chat-ui/package.json pnpm-lock.yaml
           git commit -m "release: pin @smartspace/api-client to released latest ($LATEST)" \
             || echo "Already at released latest — nothing to pin."


### PR DESCRIPTION
## Problem (caught by #5's first live run)

Merging #335 ran the new `update-release-next` pin step, which failed:

```
packages/chat-ui prepare: src/domains/messages/mapper.ts(10,3): error TS2339:
  Property 'messageThreadsThreadMessagesIdMessagesResponse' does not exist on
  type '...@smartspace+api-client@0.1.0.../zod'
```

`pnpm install` runs chat-ui's **`prepare`** build. When the pin step pinned `release/next` to the released `latest` (`0.1.0`), chat-ui's code used API surface **not in `0.1.0`** → the build failed → the **whole release-sync workflow failed** (release/next never updated, [#336](https://github.com/Smartspace-ai/Smartspace-app-public/issues/336) opened).

This is the *correct* "develop is ahead of the released API" condition — but it surfaced in the **wrong place** (breaking the sync workflow instead of producing a red standing PR).

## Fix

Add `--ignore-scripts` to the **three lockfile-reconcile installs**:
- `update-release-next.yml` — pin step + merge-reconcile
- `internal-bump-sdk.yml` — bump step

These only resolve the lockfile; they don't need to build anything. The build/typecheck stays in the **`quality`** check (which keeps scripts), where SDK incompatibility correctly shows as a **red standing PR** — not a broken workflow or a `release-sync-failed` issue.

## After this merges

- `update-release-next` will succeed → `release/next` updates and pins `@smartspace/api-client` to `latest` (`0.1.0`)
- **The standing release PR's `quality` check will be RED** — because develop genuinely uses API not in released `0.1.0`. **That's correct** (#5's production-safety gate): to make it green, app-api must release the API with those endpoints (then `latest` advances), or develop must not use unreleased surface.
- [#336](https://github.com/Smartspace-ai/Smartspace-app-public/issues/336) can be closed once the next sync runs green.

Workflow YAML validated locally with `js-yaml`.
