### PR TITLE
fix(ci): pin release branch to the main-channel candidate SDK, not @latest (unblock #338)

### DIFF
--- a/.github/workflows/update-release-next.yml
+++ b/.github/workflows/update-release-next.yml
@@ -4,18 +4,19 @@
 # On every push to `develop`:
 #   1. Hard-resets `release/next` to develop's HEAD
 #   2. Merges `main` in (auto-resolves dependency-pin conflicts in favor of develop)
-#   3. Pins @smartspace/api-client to the released `latest` version — the SDK that
-#      matches the deployed production API — across every workspace manifest
+#   3. Pins @smartspace/api-client to the exact `main`-channel version — the
+#      candidate SDK (app-api `main`) — across every workspace manifest
 #   4. Force-pushes `release/next`
 #   5. Opens the standing PR if it doesn't already exist
 #
 # Releasing develop → main becomes "click Merge on the standing PR".
 # No human ever creates or checks out `release/next`.
 #
-# NOTE: production pins the released `latest` SDK, not develop's `dev` SDK. So the
-# standing PR's `quality` check goes RED whenever develop's code uses API surface
-# not yet in the released SDK — i.e. "you can't ship UI for an unreleased API".
-# That red is the production-safety gate: release the API first.
+# NOTE: the release branch pins the exact `main`-channel (candidate) SDK, not
+# develop's `dev` SDK. So the standing PR's `quality` check goes RED whenever
+# develop's code uses API surface not yet on app-api `main` — fix by landing it
+# on app-api `main` (its develop→main). The `latest` (public) promotion is a
+# separate, later step.
 
 name: Update standing release PR
 
@@ -95,7 +96,7 @@ jobs:
           fi
 
           # Keep develop's side of any dependency-pin conflict; the next step
-          # re-pins @smartspace/api-client to the released `latest` regardless.
+          # re-pins @smartspace/api-client to the `main`-channel SDK regardless.
           git checkout --ours -- package.json pnpm-lock.yaml
 
           # Reconcile the lockfile to package.json after taking 'ours'.
@@ -104,22 +105,23 @@ jobs:
           git add package.json pnpm-lock.yaml
           git commit --no-edit
 
-      - name: Pin @smartspace/api-client to released `latest`
+      - name: Pin @smartspace/api-client to the `main`-channel (candidate) SDK
         run: |
-          # Production pins the EXACT released SDK (npm dist-tag `latest`) — the
-          # build that matches the deployed production API — not develop's `dev`
-          # SDK and not app-api's main-HEAD. Resolve `latest` to its exact version
-          # and pin it across every workspace manifest. This replaces the old
-          # dev->main channel swap (check-package-json-channel.yml, now removed).
-          LATEST=$(npm view @smartspace/api-client@latest version)
-          if [ -z "$LATEST" ]; then
-            echo "::error::Could not resolve @smartspace/api-client@latest from npm."
+          # The release branch pins the EXACT `main`-channel SDK — the candidate
+          # corresponding to app-api `main` (deployed to the test client) — not
+          # develop's `dev` SDK. Resolve the `main` tag to its exact version and
+          # pin it across every workspace manifest. This replaces the old dev->main
+          # channel swap (check-package-json-channel.yml, now removed). The
+          # `latest` (public) promotion is a separate, later step.
+          MAIN=$(npm view @smartspace/api-client@main version)
+          if [ -z "$MAIN" ]; then
+            echo "::error::Could not resolve @smartspace/api-client@main from npm."
             exit 1
           fi
-          echo "Pinning @smartspace/api-client to released latest: $LATEST"
-          LATEST="$LATEST" node -e "
+          echo "Pinning @smartspace/api-client to main-channel: $MAIN"
+          MAIN="$MAIN" node -e "
             const fs = require('fs');
-            const v = process.env.LATEST;
+            const v = process.env.MAIN;
             for (const f of ['package.json', 'packages/chat-ui/package.json']) {
               const p = JSON.parse(fs.readFileSync(f, 'utf8'));
               for (const k of ['dependencies', 'devDependencies']) {
@@ -131,13 +133,13 @@ jobs:
           "
           # --ignore-scripts: don't run chat-ui's `prepare` build here. We only
           # need to resolve the lockfile; if chat-ui is incompatible with the
-          # released SDK, the standing PR's `quality` check surfaces it as a red
-          # check (the "develop is ahead of the released API" signal) — it must
+          # main-channel SDK, the standing PR's `quality` check surfaces it as a
+          # red check (the "develop is ahead of app-api main" signal) — it must
           # NOT break this release-sync workflow.
           pnpm install --no-frozen-lockfile --ignore-scripts
           git add package.json packages/chat-ui/package.json pnpm-lock.yaml
-          git commit -m "release: pin @smartspace/api-client to released latest ($LATEST)" \
-            || echo "Already at released latest — nothing to pin."
+          git commit -m "release: pin @smartspace/api-client to main-channel ($MAIN)" \
+            || echo "Already at the main-channel SDK — nothing to pin."
 
       # Force-push: release/next is fully derived from develop + main each run.
       # Local commits to release/next are intentionally lost.
@@ -170,10 +172,10 @@ jobs:
 
           1. Resets `release/next` to develop's HEAD
           2. Merges `main` in
-          3. Pins `@smartspace/api-client` to the released `latest` SDK (the build that matches the deployed production API)
+          3. Pins `@smartspace/api-client` to the exact `main`-channel SDK (the candidate matching app-api `main`)
           4. Force-pushes `release/next`
 
-          **A red `quality` check means develop's code uses API surface not yet in the released SDK — release the API first, then this goes green.**
+          **A red `quality` check means develop's code uses API surface not yet on app-api `main` — land it there first, then this goes green.**
 
           ## Don't commit to `release/next`
 


### PR DESCRIPTION
## Why

#5 over-corrected: it pinned the release branch to the released **`@latest`** SDK, which forces a formal SDK release before `main` can even build. The correct model (ADR `2026-06-05`): the release branch pins app-api's **`main`-channel candidate** — the SDK deployed to the test client — and `latest` is a *later promotion*, not a precondition.

## Change

`update-release-next`'s pin step now resolves **`@main`** (not `@latest`) to its exact version and pins both manifests to it. One-channel re-target; everything else (delete-swap, frozen-lockfile, `--ignore-scripts`) stays as-is.

## Effect — unblocks #338

`@main` currently resolves to **`0.1.0-main.2ba677e`** (the #871 merge — app-api `main` post your develop→main), which **has** the endpoints develop uses (`messageThreadsThreadMessagesIdMessagesResponse`). So once this merges and the standing PR re-syncs, it pins that and **`quality` goes green** — no formal `latest` release needed.

## Red-semantics, corrected

A red standing PR now means *"develop uses API not yet on app-api `main`"* → fix by landing it on app-api `main` (its develop→main). Looser and more correct than "not in released `latest`".

## Scope

This is **P4a** in the plan — the interim re-target that unblocks shipping today. **P4b** (pin the lockstep `rc` candidate) and the app-api **build-once/promote** work (P2) follow per [the plan doc](work/architecture/planning/sdk-publish-pipeline-remediation.md). Workflow YAML validated locally with `js-yaml`.
