### PR TITLE
fix(ci): gate release/next sync on content diff (stop phantom PRs)

### DIFF
--- a/.github/workflows/update-release-next.yml
+++ b/.github/workflows/update-release-next.yml
@@ -141,12 +141,28 @@ jobs:
           git commit -m "release: pin @smartspace/api-client to main-channel ($MAIN)" \
             || echo "Already at the main-channel SDK — nothing to pin."
 
+      - name: Check release/next differs from main (skip empty phantom PRs)
+        id: changed
+        run: |
+          # Squash-merging the standing PR gives main release/next's content but
+          # not its history, so without this check the workflow would force-push
+          # and reopen an empty "phantom" PR after every release. A tree diff is
+          # empty exactly when there's nothing real to release.
+          if git diff --quiet origin/main HEAD; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "release/next is identical to main — nothing to release; skipping push + PR."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       # Force-push: release/next is fully derived from develop + main each run.
       # Local commits to release/next are intentionally lost.
       - name: Force-push release/next
+        if: steps.changed.outputs.changed == 'true'
         run: git push origin release/next --force
 
       - name: Ensure standing release PR exists
+        if: steps.changed.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |


### PR DESCRIPTION
Same phantom-PR fix as the other standing-PR workflows, adapted to the pinning variant: after rebuilding `release/next` (develop + main merge + the `@main` SDK pin), skip the force-push and PR creation when `release/next` is content-identical to `main` (`git diff --quiet origin/main HEAD`). Squash-merging otherwise reopens an empty phantom PR every push.