### PR TITLE
ci(teams): on-demand Teams package build workflow

### DIFF
--- a/.github/workflows/build-teams-package.yml
+++ b/.github/workflows/build-teams-package.yml
@@ -1,0 +1,67 @@
+name: Build Teams package
+
+# Builds the Microsoft Teams app package (manifest.json + smartspace.zip) on
+# demand and uploads it as a downloadable artifact. The Teams manifest rarely
+# changes, so this is a manual workflow rather than part of every deploy.
+#
+# The Teams app id, base URL, name and client id are read from the selected
+# GitHub environment so they stay in lockstep with the web deploy. Bump the
+# version input whenever you re-upload to Teams (Teams requires an increasing
+# version for an update to apply).
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: GitHub environment to read Teams config from
+        type: choice
+        options:
+          - develop
+          - production
+        default: develop
+      version:
+        description: Manifest version (increment when re-uploading to Teams)
+        type: string
+        default: 1.0.0
+
+permissions:
+  contents: read
+
+jobs:
+  build-teams-package:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: ${{ inputs.environment }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable pnpm
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Teams package
+        run: pnpm run build:teams
+        env:
+          VITE_CLIENT_ID: ${{ vars.VITE_CLIENT_ID }}
+          TEAMS_APP_ID: ${{ vars.TEAMS_APP_ID }}
+          TEAMS_BASE_URL: ${{ vars.TEAMS_BASE_URL }}
+          TEAMS_APP_NAME: ${{ vars.TEAMS_APP_NAME }}
+          TEAMS_VERSION: ${{ inputs.version }}
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: teams-package-${{ inputs.environment }}-${{ inputs.version }}
+          path: |
+            teams/manifest.json
+            teams/smartspace.zip
+          if-no-files-found: error

--- a/teams/build-manifest.ts
+++ b/teams/build-manifest.ts
@@ -1,14 +1,17 @@
-// To use this script, run: pnpm add archiver dotenv
-// If using TypeScript, you may also want: pnpm add -D @types/archiver
+// Generates teams/manifest.json + teams/smartspace.zip.
+// Values come from env vars (CI) and fall back to teams/config.json (local).
 const fs = require('fs');
 const path = require('path');
 
 const archiver = require('archiver');
-const dotenv = require('dotenv');
 
-// Load .env
-const envPath = path.join(__dirname, '..', '.env');
-dotenv.config({ path: envPath });
+// Load a local .env if present, as a convenience for local builds. In CI the
+// values are supplied directly via process.env, so dotenv is optional here.
+try {
+  require('dotenv').config({ path: path.join(__dirname, '..', '.env') });
+} catch {
+  // dotenv not installed / no .env file — fall back to process.env.
+}
 
 const teamsDir = __dirname;
 const configPath = path.join(teamsDir, 'config.json');
@@ -16,14 +19,22 @@ const manifestPath = path.join(teamsDir, 'manifest.json');
 const zipPath = path.join(teamsDir, 'smartspace.zip');
 
 const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-const baseUrl = config.baseUrl;
-const appName = config.appName;
-const appId = config.appId;
-const version = config.version;
+
+// Env overrides (CI) take precedence; config.json is the local-dev fallback.
+const appId = process.env.TEAMS_APP_ID || config.appId;
+const appName = process.env.TEAMS_APP_NAME || config.appName;
+const version = process.env.TEAMS_VERSION || config.version;
+// Normalise the base URL once: strip trailing slashes so every derived URL and
+// validDomain is built cleanly (avoids '//privacy' and a trailing-slash domain).
+const baseUrl = String(process.env.TEAMS_BASE_URL || config.baseUrl).replace(
+  /\/+$/,
+  ''
+);
+const host = baseUrl.replace(/^https?:\/\//, '');
 
 const clientId = process.env.VITE_CLIENT_ID;
 if (!clientId) {
-  throw new Error('VITE_CLIENT_ID is not set in .env');
+  throw new Error('VITE_CLIENT_ID is not set (env var or .env)');
 }
 
 const manifest = {
@@ -59,23 +70,16 @@ const manifest = {
     {
       entityId: 'smartspace-tab',
       name: appName,
-      contentUrl: baseUrl + '?inTeams=true',
+      contentUrl: baseUrl + '/?inTeams=true',
       websiteUrl: baseUrl,
       scopes: ['personal', 'team'],
     },
   ],
   permissions: ['identity', 'messageTeamMembers'],
-  validDomains: [
-    baseUrl.replace(/^https?:\/\//, ''),
-    'login.microsoftonline.com',
-  ],
+  validDomains: [host, 'login.microsoftonline.com'],
   webApplicationInfo: {
     id: clientId,
-    resource:
-      'api://' +
-      baseUrl.replace(/^https?:\/\//, '').replace(/\/+$/, '') +
-      '/' +
-      clientId,
+    resource: 'api://' + host + '/' + clientId,
   },
 };
 


### PR DESCRIPTION
## What

Adds a manual workflow that builds the Microsoft Teams app package and uploads it as a downloadable artifact, instead of building it locally with `pnpm run build:teams`.

## Why on-demand (not on every deploy)

The Teams manifest only changes when the app id / base URL / name / client id / version change — which is rare. Building on every push would produce identical artifacts and (with auto-versioning) noisy "updates" that obscure real ones. So it's a `workflow_dispatch` you run when you actually need a package to upload.

## How it works

- **`.github/workflows/build-teams-package.yml`** — `workflow_dispatch` with two inputs: `environment` (`develop`/`production`) and `version`. Runs under the selected GitHub environment, builds the package, uploads `manifest.json` + `smartspace.zip` as an artifact (`teams-package-<env>-<version>`).
- **`teams/build-manifest.ts`** — now reads `TEAMS_APP_ID` / `TEAMS_BASE_URL` / `TEAMS_APP_NAME` / `TEAMS_VERSION` / `VITE_CLIENT_ID` from env, falling back to `teams/config.json`. Local `pnpm run build:teams` is unchanged. Pulling the client id from the same environment as the web deploy keeps them in lockstep.
- Made the `dotenv` load optional (it isn't a declared dep; in CI values come from `process.env`).
- Fixed a base-URL trailing-slash bug: a `baseUrl` ending in `/` previously produced `//privacy`, `//terms`, and a `validDomains` entry with a trailing slash. The URL is now normalised once.

## Required setup before first run

Add these as **Variables** on the `develop` (and later `production`) GitHub environment:

| Variable | Value |
|---|---|
| `TEAMS_APP_ID` | Stable Teams app GUID for this environment (do **not** regenerate per build — a new id creates a new app instead of updating) |
| `TEAMS_BASE_URL` | The deployed storage site URL for this environment |
| `TEAMS_APP_NAME` | Customer-facing app name |

`VITE_CLIENT_ID` is already present from the web deploy.

## Not included

Auto-publishing to Teams. The artifact is still uploaded manually to the Teams Admin Center — full auto-publish needs Graph `AppCatalog.ReadWrite.All` + admin consent, a separate, larger change.

## Test

Ran `build:teams` locally with a trailing-slash `TEAMS_BASE_URL`; confirmed env overrides apply and the manifest comes out clean (`/privacy`, no trailing-slash `validDomains`, `/?inTeams=true`).