### PR TITLE
ci(deploy): pass VITE_TENANT_ID into the build env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,7 @@ jobs:
             echo "VITE_CLIENT_SCOPES=${{ vars.VITE_CLIENT_SCOPES }}"
             echo "VITE_CHAT_API_URI=${{ vars.VITE_CHAT_API_URI }}"
             echo "VITE_TEAMS_USE_MSAL=${{ vars.VITE_TEAMS_USE_MSAL }}"
+            echo "VITE_TENANT_ID=${{ vars.VITE_TENANT_ID }}"
           } > .env
 
       - name: Validate .env


### PR DESCRIPTION
## What
Adds `VITE_TENANT_ID` to the `.env` generated by the deploy workflow, sourced from the GitHub environment.

## Why
The Teams **NAA** auth adapter requires an explicit tenant id (`Client_Id` + `Tenant_Id`) — it falls back to `VITE_TENANT_ID`, which the deploy never emitted. Without it, the NAA path fails with *"Missing auth configuration for NAA (Client_Id/Tenant_Id)"* and Teams auto-login dies. This wires the value through so NAA can be enabled per environment.

## Optional by design
`VITE_TENANT_ID` is **not** added to `REQUIRED_ENV_VARS` in the Dagger `check-env` step, so it stays optional:
- Environments using the default **MSAL** Teams flow (`VITE_TEAMS_USE_MSAL=true`, which uses `VITE_CLIENT_AUTHORITY`) deploy unchanged when it's unset.
- Environments that set `VITE_TENANT_ID` can use the silent NAA SSO path.

## To use
Set `VITE_TENANT_ID` as a Variable on the relevant GitHub environment, then re-deploy. Leaving it unset is safe.

## Note
This does not by itself switch any environment to NAA — the adapter is still chosen by `VITE_TEAMS_USE_MSAL`. NAA also needs the app registration configured for nested-app brokering; this PR only removes the missing-config blocker.