### PR TITLE
ci(deploy): manual dev deploy of an arbitrary ref

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -3,6 +3,13 @@ name: Deploy to dev
 on:
   push:
     branches: [develop]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Ref (tag/branch/SHA) to build & deploy to dev. Defaults to develop.
+        required: false
+        type: string
+        default: develop
 
 concurrency:
   group: deploy-dev
@@ -13,4 +20,7 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     with:
       environment: develop
+      # On push, inputs.ref is empty, so deploy.yml checks out the pushed commit
+      # (unchanged behaviour). On manual runs, build the requested ref instead.
+      ref: ${{ inputs.ref }}
     secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,11 @@ on:
         required: true
         type: string
         description: GitHub environment name (dev or production)
+      ref:
+        required: false
+        type: string
+        default: ""
+        description: Git ref (tag/branch/SHA) to build. Empty = the triggering ref.
 
 permissions:
   contents: read
@@ -20,6 +25,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Generate .env from environment
         run: |


### PR DESCRIPTION
## What
Adds a `workflow_dispatch` trigger to **Deploy to dev** with a `ref` input, and threads an optional `ref` through the reusable `deploy.yml`. Lets you build & deploy any tag/branch/SHA to the **dev** environment on demand.

## Why
To reproduce a customer issue on an older release (e.g. `v1.14.0`) without disturbing the `develop` branch. The dev storage account temporarily serves the chosen ref; restore by re-running with `ref=develop`.

## How it respects the environment protection
The `develop` environment only allows the `develop` / `deployments/develop` branches to deploy. You run this **from the `develop` branch** (allowed), and it **checks out** the requested ref inside the job. The protection checks the run's branch, not the checked-out ref — so an arbitrary tag deploys without loosening any policy.

## Push behaviour unchanged
On `push` events `inputs.ref` is empty, so `deploy.yml` checks out the pushed commit exactly as before. The input only applies to manual runs.

## Usage
Actions → **Deploy to dev** → **Run workflow** → branch `develop`, `ref` = `v1.14.0` → Run.
Restore: same, with `ref` = `develop`.

## Note
`v1.14.0` (2026-05-08) already contains the `ci/` Dagger module and matching deploy workflows, so the current pipeline builds it cleanly.