### PR TITLE
chore(diagnostics): trace route loaders + on-screen log panel

### DIFF
--- a/src/pages/teams_loader.tsx
+++ b/src/pages/teams_loader.tsx
@@ -1,3 +1,7 @@
+import { useEffect, useState } from 'react';
+
+import { isSsDebugEnabled } from '@/platform/log';
+
 import { getBrandConfig } from '@/theme/branding';
 
 import { Logo } from '@/assets/logo';
@@ -5,6 +9,138 @@ import { Logo } from '@/assets/logo';
 type TeamsLoaderProps = {
   message?: string;
 };
+
+type SsLogEntry = {
+  t: string;
+  level: string;
+  scope: string;
+  msg: string;
+  data: unknown;
+};
+
+/**
+ * Debug panel is shown when the standard ss_debug flag is on OR when the URL
+ * carries ?ssdebug=1. The URL form lets us surface logs inside Teams Desktop,
+ * where there's no DevTools/console to read window.__ssLogs from.
+ */
+function isDebugPanelEnabled(): boolean {
+  try {
+    if (new URLSearchParams(window.location.search).get('ssdebug') === '1') {
+      return true;
+    }
+  } catch {
+    /* ignore */
+  }
+  return isSsDebugEnabled();
+}
+
+function safeData(d: unknown): string {
+  if (d == null || d === '') return '';
+  try {
+    return typeof d === 'string' ? d : JSON.stringify(d);
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * On-screen tail of window.__ssLogs. Polls every second so it keeps updating
+ * while the route loader is still pending — i.e. it stays useful precisely when
+ * the app is "stuck", which is when you need it most.
+ */
+function DebugLogPanel() {
+  const [logs, setLogs] = useState<SsLogEntry[]>([]);
+  const [elapsed, setElapsed] = useState(0);
+
+  useEffect(() => {
+    const start = Date.now();
+    const id = setInterval(() => {
+      try {
+        const w = window as unknown as { __ssLogs?: SsLogEntry[] };
+        setLogs((w.__ssLogs ?? []).slice(-40));
+      } catch {
+        /* ignore */
+      }
+      setElapsed(Math.round((Date.now() - start) / 1000));
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const copyAll = async () => {
+    try {
+      const w = window as unknown as { __ssLogs?: unknown };
+      await navigator.clipboard.writeText(
+        JSON.stringify(w.__ssLogs ?? [], null, 2)
+      );
+    } catch {
+      /* clipboard may be blocked; the on-screen text is still readable */
+    }
+  };
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        left: 0,
+        right: 0,
+        bottom: 0,
+        maxHeight: '45vh',
+        overflow: 'auto',
+        background: 'rgba(0,0,0,0.88)',
+        color: '#d6f5d6',
+        fontFamily: 'monospace',
+        fontSize: 11,
+        lineHeight: 1.4,
+        padding: 8,
+        zIndex: 2147483647,
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          marginBottom: 6,
+        }}
+      >
+        <span>
+          ss debug · stuck {elapsed}s · {logs.length} recent log lines
+        </span>
+        <button
+          onClick={copyAll}
+          style={{
+            background: '#2dd36f',
+            color: '#000',
+            border: 0,
+            borderRadius: 4,
+            padding: '2px 10px',
+            cursor: 'pointer',
+          }}
+        >
+          Copy all logs
+        </button>
+      </div>
+      {logs.map((l, i) => (
+        <div
+          key={i}
+          style={{
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+            color:
+              l.level === 'error'
+                ? '#ffd166'
+                : l.level === 'warn'
+                ? '#ffe08a'
+                : '#d6f5d6',
+          }}
+        >
+          {`${(l.t || '').slice(11, 23)} [${l.scope}] ${l.msg}${
+            l.data ? ' ' + safeData(l.data) : ''
+          }`}
+        </div>
+      ))}
+    </div>
+  );
+}
 
 export function TeamsLoader({ message = 'Loading…' }: TeamsLoaderProps) {
   const brand = getBrandConfig();
@@ -39,6 +175,7 @@ export function TeamsLoader({ message = 'Loading…' }: TeamsLoaderProps) {
           </div>
         </div>
       </div>
+      {isDebugPanelEnabled() && <DebugLogPanel />}
     </div>
   );
 }

--- a/src/routes/_protected/workspace/$workspaceId/__layout.tsx
+++ b/src/routes/_protected/workspace/$workspaceId/__layout.tsx
@@ -2,6 +2,7 @@
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { Suspense, useEffect, useMemo } from 'react';
 
+import { ssError, ssInfoAlways } from '@/platform/log';
 import {
   RouteIdsProvider,
   useRouteIds,
@@ -52,10 +53,31 @@ function WorkspaceBodyBackground() {
 export const Route = createFileRoute(
   '/_protected/workspace/$workspaceId/__layout'
 )({
-  loader: ({ params, context }) =>
-    context.queryClient.ensureQueryData(
-      workspaceDetailOptions(params.workspaceId)
-    ),
+  loader: async ({ params, context }) => {
+    const t0 = Date.now();
+    ssInfoAlways(
+      'route:workspace-detail',
+      'loader: fetching workspace detail…',
+      {
+        workspaceId: params.workspaceId,
+      }
+    );
+    try {
+      const ws = await context.queryClient.ensureQueryData(
+        workspaceDetailOptions(params.workspaceId)
+      );
+      ssInfoAlways('route:workspace-detail', 'workspace detail resolved', {
+        ms: Date.now() - t0,
+      });
+      return ws;
+    } catch (e) {
+      ssError('route:workspace-detail', 'workspace detail FAILED', {
+        ms: Date.now() - t0,
+        error: e instanceof Error ? e.message : String(e),
+      });
+      throw e;
+    }
+  },
   component: () => (
     <RouteIdsProvider>
       <PendingThreadsProvider>

--- a/src/routes/_protected/workspace/$workspaceId/index.tsx
+++ b/src/routes/_protected/workspace/$workspaceId/index.tsx
@@ -1,5 +1,7 @@
 import { createFileRoute, redirect } from '@tanstack/react-router';
 
+import { ssError, ssInfoAlways } from '@/platform/log';
+
 import { threadsListOptions } from '@/domains/threads/queries';
 
 import ChatBotPage from '@/pages/WorkspaceThreadPage/chat';
@@ -9,9 +11,26 @@ export const Route = createFileRoute('/_protected/workspace/$workspaceId/')({
   pendingMs: 0,
   pendingComponent: WorkspaceIndexRouteComponent,
   loader: async ({ params, context }) => {
-    const list = await context.queryClient.ensureQueryData(
-      threadsListOptions(params.workspaceId, { take: 1, skip: 0 })
-    );
+    const t0 = Date.now();
+    ssInfoAlways('route:threads', 'loader: fetching threads list…', {
+      workspaceId: params.workspaceId,
+    });
+    let list;
+    try {
+      list = await context.queryClient.ensureQueryData(
+        threadsListOptions(params.workspaceId, { take: 1, skip: 0 })
+      );
+    } catch (e) {
+      ssError('route:threads', 'threads list FAILED', {
+        ms: Date.now() - t0,
+        error: e instanceof Error ? e.message : String(e),
+      });
+      throw e;
+    }
+    ssInfoAlways('route:threads', 'threads list resolved', {
+      count: list?.data?.length ?? 0,
+      ms: Date.now() - t0,
+    });
     const first = list.data[0];
     if (first?.id) {
       throw redirect({

--- a/src/routes/_protected/workspace/$workspaceId/thread/$threadId.tsx
+++ b/src/routes/_protected/workspace/$workspaceId/thread/$threadId.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react';
 import { z } from 'zod';
 
 import { isNotFoundError } from '@/platform/envelopes';
+import { ssError, ssInfoAlways } from '@/platform/log';
 
 import {
   threadDetailOptions,
@@ -33,17 +34,37 @@ export const Route = createFileRoute(
     threadRouteSearchSchema.parse(search),
   pendingMs: 0,
   loader: async ({ params, context }) => {
+    const t0 = Date.now();
+    ssInfoAlways('route:thread-detail', 'loader: fetching thread detail…', {
+      workspaceId: params.workspaceId,
+      threadId: params.threadId,
+    });
     try {
-      return await context.queryClient.ensureQueryData(
+      const detail = await context.queryClient.ensureQueryData(
         threadDetailOptions({
           workspaceId: params.workspaceId,
           threadId: params.threadId,
         })
       );
+      ssInfoAlways('route:thread-detail', 'thread detail resolved', {
+        ms: Date.now() - t0,
+      });
+      return detail;
     } catch (e: unknown) {
       // If user deep-links to a random GUID that doesn't exist, redirect to the first thread
       // (same behavior as /workspace/$workspaceId/ without a threadId).
-      if (!isNotFoundError(e)) throw e;
+      if (!isNotFoundError(e)) {
+        ssError('route:thread-detail', 'thread detail FAILED', {
+          ms: Date.now() - t0,
+          error: e instanceof Error ? e.message : String(e),
+        });
+        throw e;
+      }
+      ssInfoAlways(
+        'route:thread-detail',
+        'thread not found → redirecting to first thread',
+        { ms: Date.now() - t0 }
+      );
 
       const list = await context.queryClient.ensureQueryData(
         threadsListOptions(params.workspaceId, { take: 1, skip: 0 })

--- a/src/routes/_protected/workspace/index.tsx
+++ b/src/routes/_protected/workspace/index.tsx
@@ -1,6 +1,8 @@
 // src/routes/_protected/workspace/index.tsx
 import { createFileRoute, redirect } from '@tanstack/react-router';
 
+import { ssError, ssInfoAlways } from '@/platform/log';
+
 import { workspacesListOptions } from '@/domains/workspaces/queries';
 
 import TeamsLoaderPage from '@/pages/teams_loader';
@@ -9,9 +11,22 @@ export const Route = createFileRoute('/_protected/workspace/')({
   pendingMs: 0,
   pendingComponent: () => <TeamsLoaderPage message="Loading workspaces…" />,
   loader: async ({ context }) => {
-    const list = await context.queryClient.ensureQueryData(
-      workspacesListOptions()
-    );
+    const t0 = Date.now();
+    ssInfoAlways('route:workspaces', 'loader: fetching workspaces list…');
+    let list;
+    try {
+      list = await context.queryClient.ensureQueryData(workspacesListOptions());
+    } catch (e) {
+      ssError('route:workspaces', 'workspaces list FAILED', {
+        ms: Date.now() - t0,
+        error: e instanceof Error ? e.message : String(e),
+      });
+      throw e;
+    }
+    ssInfoAlways('route:workspaces', 'workspaces list resolved', {
+      count: list?.length ?? 0,
+      ms: Date.now() - t0,
+    });
     if (list?.length) {
       throw redirect({
         to: '/workspace/$workspaceId',


### PR DESCRIPTION
## What
Diagnostics to find why the app hangs on **"Preparing your workspace"** inside Teams (where there's no DevTools to read the network/console).

1. **Route-loader tracing** — `ssInfoAlways`/`ssError` with timings around each protected-route `ensureQueryData`:
   - workspaces list → workspace detail → threads list → **thread detail**
   - A loader that logs "fetching…" with no matching "resolved" pinpoints exactly which fetch never returns.
2. **On-screen log panel** in `TeamsLoader` — surfaces `window.__ssLogs` as a fixed overlay with a **Copy all logs** button and a "stuck Ns" timer. Shown when `ss_debug` is set **or** `?ssdebug=1` is in the URL, so it's readable **in Teams Desktop**.

## How to use
Deploy this to `dev-delta`, then open the app with **`?ssdebug=1`** (or set `ss_debug=1`). When it hangs on "Preparing your workspace," the panel shows the loader trace live — the last `route:*` line with no "resolved" is the culprit.

## Note
Pure diagnostics — no behaviour change to the app. Intended to be reverted once the hang is root-caused.