### PR TITLE
feat(auth): reactive re-auth on session expiry (REST + SignalR)

### DIFF
--- a/src/app/AppProviders.tsx
+++ b/src/app/AppProviders.tsx
@@ -9,6 +9,8 @@ import { sessionQueryOptions } from '@/platform/auth/sessionQuery';
 import { queryClient } from '@/platform/reactQueryClient';
 import { RealtimeProvider } from '@/platform/realtime/RealtimeProvider';
 
+import { SessionExpiryPrompt } from '@/app/ui/SessionExpiryPrompt';
+
 import { muiTheme } from '@/shared/ui/mui-bridge/theme';
 import { SidebarProvider } from '@/shared/ui/mui-compat/sidebar';
 
@@ -33,6 +35,7 @@ export default function AppProviders({ children }: { children: ReactNode }) {
     <TeamsProvider>
       <QueryClientProvider client={queryClient}>
         <AuthProvider>
+          <SessionExpiryPrompt />
           <RealtimeBridge>
             <StyledEngineProvider injectFirst>
               <ThemeProvider theme={muiTheme}>

--- a/src/app/ui/SessionExpiryPrompt.tsx
+++ b/src/app/ui/SessionExpiryPrompt.tsx
@@ -1,0 +1,93 @@
+// Root-level re-auth prompt for Teams (and any context where interactive
+// sign-in needs a user gesture). On pure web, handleSessionExpired() redirects
+// automatically and this never shows. In Teams, opening the auth popup requires
+// a click, so we surface a blocking prompt whose button drives signIn().
+//
+// Styles are intentionally inline raw values, not theme tokens: this overlay is
+// the last-resort UI when the session (and often the rest of the app's data) is
+// broken, so it must not depend on theme context being healthy.
+/* eslint-disable no-restricted-syntax -- intentional theme-independent styles */
+import { useState } from 'react';
+
+import { useAuth, useAuthRuntime } from '@/platform/auth/session';
+import { resetSessionExpiry } from '@/platform/auth/sessionExpiry';
+import { SESSION_QUERY_KEY } from '@/platform/auth/sessionQuery';
+import { ssWarn } from '@/platform/log';
+import { queryClient } from '@/platform/reactQueryClient';
+
+const overlay: React.CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  zIndex: 2147483647,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  background: 'rgba(0, 0, 0, 0.45)',
+};
+
+const card: React.CSSProperties = {
+  background: '#fff',
+  color: '#1a1a1a',
+  borderRadius: 12,
+  padding: '24px 28px',
+  maxWidth: 360,
+  textAlign: 'center',
+  boxShadow: '0 10px 40px rgba(0, 0, 0, 0.25)',
+  fontFamily: 'inherit',
+};
+
+const button: React.CSSProperties = {
+  marginTop: 16,
+  padding: '10px 20px',
+  borderRadius: 8,
+  border: 'none',
+  background: '#5b5bd6',
+  color: '#fff',
+  fontSize: 15,
+  fontWeight: 600,
+  cursor: 'pointer',
+};
+
+export function SessionExpiryPrompt() {
+  const adapter = useAuth();
+  const { sessionExpired } = useAuthRuntime();
+  const [signingIn, setSigningIn] = useState(false);
+
+  if (!sessionExpired) return null;
+
+  const onSignIn = async () => {
+    setSigningIn(true);
+    try {
+      await adapter.signIn();
+      resetSessionExpiry();
+      queryClient.invalidateQueries({ queryKey: SESSION_QUERY_KEY });
+    } catch (e) {
+      ssWarn('auth', 'sign-in from session-expiry prompt failed', e);
+      setSigningIn(false);
+    }
+  };
+
+  return (
+    <div
+      role="alertdialog"
+      aria-modal="true"
+      aria-label="Session expired"
+      style={overlay}
+    >
+      <div style={card}>
+        <h2 style={{ margin: '0 0 8px', fontSize: 18 }}>Session expired</h2>
+        <p style={{ margin: 0, fontSize: 14, lineHeight: 1.5 }}>
+          Your session timed out. Sign in again to keep working.
+        </p>
+        <button
+          type="button"
+          onClick={() => void onSignIn()}
+          disabled={signingIn}
+          style={{ ...button, opacity: signingIn ? 0.6 : 1 }}
+        >
+          {signingIn ? 'Signing in…' : 'Sign in'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/ui/SessionExpiryPrompt.tsx
+++ b/src/app/ui/SessionExpiryPrompt.tsx
@@ -50,16 +50,20 @@ const button: React.CSSProperties = {
 
 export function SessionExpiryPrompt() {
   const adapter = useAuth();
-  const { sessionExpired } = useAuthRuntime();
+  const { sessionExpired, authStuck } = useAuthRuntime();
   const [signingIn, setSigningIn] = useState(false);
 
-  if (!sessionExpired) return null;
+  // authStuck (re-auth looped without resolving) is terminal and takes
+  // precedence over the ordinary Teams gesture prompt.
+  if (!sessionExpired && !authStuck) return null;
 
   const onSignIn = async () => {
     setSigningIn(true);
+    // Clear flags + attempt budget before retrying so the redirect starts
+    // fresh (signIn() navigates away on web, so post-call cleanup won't run).
+    resetSessionExpiry();
     try {
       await adapter.signIn();
-      resetSessionExpiry();
       queryClient.invalidateQueries({ queryKey: SESSION_QUERY_KEY });
     } catch (e) {
       ssWarn('auth', 'sign-in from session-expiry prompt failed', e);
@@ -71,13 +75,17 @@ export function SessionExpiryPrompt() {
     <div
       role="alertdialog"
       aria-modal="true"
-      aria-label="Session expired"
+      aria-label={authStuck ? 'Unable to sign in' : 'Session expired'}
       style={overlay}
     >
       <div style={card}>
-        <h2 style={{ margin: '0 0 8px', fontSize: 18 }}>Session expired</h2>
+        <h2 style={{ margin: '0 0 8px', fontSize: 18 }}>
+          {authStuck ? "We couldn't sign you in" : 'Session expired'}
+        </h2>
         <p style={{ margin: 0, fontSize: 14, lineHeight: 1.5 }}>
-          Your session timed out. Sign in again to keep working.
+          {authStuck
+            ? 'Signing in didn’t resolve the problem. Try again, or contact your administrator if it keeps happening.'
+            : 'Your session timed out. Sign in again to keep working.'}
         </p>
         <button
           type="button"
@@ -85,7 +93,7 @@ export function SessionExpiryPrompt() {
           disabled={signingIn}
           style={{ ...button, opacity: signingIn ? 0.6 : 1 }}
         >
-          {signingIn ? 'Signing in…' : 'Sign in'}
+          {signingIn ? 'Signing in…' : 'Try again'}
         </button>
       </div>
     </div>

--- a/src/domains/messages/__tests__/service.spec.ts
+++ b/src/domains/messages/__tests__/service.spec.ts
@@ -55,6 +55,15 @@ vi.mock('@/platform/auth/scopes', () => ({
   getApiScopes: () => ['scope.read'],
 }));
 
+// fetchAuthed imports sessionExpiry, which (via msalConfig) would otherwise
+// pull the real auth/scopes chain past the barrel mock above.
+vi.mock('@/platform/auth/sessionExpiry', () => ({
+  handleSessionExpired: vi.fn(),
+  resetSessionExpiry: vi.fn(),
+  isReauthRequired: () => false,
+  isUnauthorizedError: () => false,
+}));
+
 import {
   addInputToMessage,
   fetchMessages,

--- a/src/domains/messages/__tests__/streamThreadMessages.spec.ts
+++ b/src/domains/messages/__tests__/streamThreadMessages.spec.ts
@@ -55,6 +55,15 @@ vi.mock('@/platform/auth/scopes', () => ({
   getApiScopes: () => ['scope.read'],
 }));
 
+// fetchAuthed imports sessionExpiry, which (via msalConfig) would otherwise
+// pull the real auth/scopes chain past the barrel mock above.
+vi.mock('@/platform/auth/sessionExpiry', () => ({
+  handleSessionExpired: vi.fn(),
+  resetSessionExpiry: vi.fn(),
+  isReauthRequired: () => false,
+  isUnauthorizedError: () => false,
+}));
+
 import { streamThreadMessages } from '@/domains/messages/service';
 
 function bodyFromChunks(chunks: string[]): ReadableStream<Uint8Array> {

--- a/src/platform/api/__tests__/configureApiClient.spec.ts
+++ b/src/platform/api/__tests__/configureApiClient.spec.ts
@@ -8,6 +8,9 @@ const { mockAxiosInstance, mockGetAuthAdapter, mockSetRuntimeAuthError } =
         request: {
           use: vi.fn(),
         },
+        response: {
+          use: vi.fn(),
+        },
       },
     },
     mockGetAuthAdapter: vi.fn(),
@@ -37,8 +40,13 @@ vi.mock('@/platform/auth/msalConfig', () => ({
 }));
 
 vi.mock('@/platform/auth/runtime', () => ({
-  getAuthRuntimeState: () => ({ isInTeams: null, lastError: null }),
+  getAuthRuntimeState: () => ({
+    isInTeams: null,
+    lastError: null,
+    sessionExpired: false,
+  }),
   setRuntimeAuthError: mockSetRuntimeAuthError,
+  setSessionExpired: vi.fn(),
 }));
 
 vi.mock('@/platform/auth/scopes', () => ({
@@ -52,6 +60,7 @@ vi.mock('@/platform/auth/sessionQuery', () => ({
 vi.mock('@/platform/log', () => ({
   ssInfo: vi.fn(),
   ssWarn: vi.fn(),
+  ssInfoAlways: vi.fn(),
 }));
 
 vi.mock('@/platform/reactQueryClient', () => ({
@@ -64,6 +73,7 @@ describe('configureApiClient', () => {
   beforeEach(() => {
     mockAxiosInstance.defaults = { baseURL: '' };
     mockAxiosInstance.interceptors.request.use.mockReset();
+    mockAxiosInstance.interceptors.response.use.mockReset();
     mockGetAuthAdapter.mockReset();
     mockSetRuntimeAuthError.mockReset();
   });

--- a/src/platform/api/__tests__/configureApiClient.spec.ts
+++ b/src/platform/api/__tests__/configureApiClient.spec.ts
@@ -1,21 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockAxiosInstance, mockGetAuthAdapter, mockSetRuntimeAuthError } =
-  vi.hoisted(() => ({
-    mockAxiosInstance: {
-      defaults: { baseURL: '' } as Record<string, unknown>,
-      interceptors: {
-        request: {
-          use: vi.fn(),
-        },
-        response: {
-          use: vi.fn(),
-        },
+const {
+  mockAxiosInstance,
+  mockGetAuthAdapter,
+  mockSetRuntimeAuthError,
+  mockHandleSessionExpired,
+  mockIsReauthRequired,
+} = vi.hoisted(() => ({
+  mockAxiosInstance: {
+    defaults: { baseURL: '' } as Record<string, unknown>,
+    interceptors: {
+      request: {
+        use: vi.fn(),
+      },
+      response: {
+        use: vi.fn(),
       },
     },
-    mockGetAuthAdapter: vi.fn(),
-    mockSetRuntimeAuthError: vi.fn(),
-  }));
+  },
+  mockGetAuthAdapter: vi.fn(),
+  mockSetRuntimeAuthError: vi.fn(),
+  mockHandleSessionExpired: vi.fn(),
+  mockIsReauthRequired: vi.fn(),
+}));
 
 vi.mock('@smartspace/api-client', () => ({
   AXIOS_INSTANCE: mockAxiosInstance,
@@ -51,6 +58,11 @@ vi.mock('@/platform/auth/runtime', () => ({
 
 vi.mock('@/platform/auth/scopes', () => ({
   getApiScopes: () => ['api://scope'],
+}));
+
+vi.mock('@/platform/auth/sessionExpiry', () => ({
+  handleSessionExpired: mockHandleSessionExpired,
+  isReauthRequired: mockIsReauthRequired,
 }));
 
 vi.mock('@/platform/auth/sessionQuery', () => ({
@@ -175,6 +187,50 @@ describe('configureApiClient', () => {
         writable: true,
         configurable: true,
       });
+    });
+  });
+
+  describe('response interceptor (re-auth on marked 401)', () => {
+    let onRejected: (error: unknown) => Promise<unknown>;
+
+    beforeEach(() => {
+      mockHandleSessionExpired.mockReset();
+      mockIsReauthRequired.mockReset();
+      configureApiClient();
+      onRejected = mockAxiosInstance.interceptors.response.use.mock.calls[0][1];
+    });
+
+    it('escalates on a 401 marked X-Reauth-Required and re-rejects', async () => {
+      mockIsReauthRequired.mockReturnValue(true);
+      const err = {
+        isAxiosError: true,
+        response: { status: 401, headers: {} },
+      };
+
+      await expect(onRejected(err)).rejects.toBe(err);
+      expect(mockHandleSessionExpired).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores a domain 401 without the header', async () => {
+      mockIsReauthRequired.mockReturnValue(false);
+      const err = {
+        isAxiosError: true,
+        response: { status: 401, headers: {} },
+      };
+
+      await expect(onRejected(err)).rejects.toBe(err);
+      expect(mockHandleSessionExpired).not.toHaveBeenCalled();
+    });
+
+    it('ignores non-401 errors', async () => {
+      mockIsReauthRequired.mockReturnValue(true);
+      const err = {
+        isAxiosError: true,
+        response: { status: 500, headers: {} },
+      };
+
+      await expect(onRejected(err)).rejects.toBe(err);
+      expect(mockHandleSessionExpired).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/platform/api/configureApiClient.ts
+++ b/src/platform/api/configureApiClient.ts
@@ -1,5 +1,5 @@
 import { AXIOS_INSTANCE } from '@smartspace/api-client';
-import { AxiosHeaders } from 'axios';
+import axios, { AxiosHeaders } from 'axios';
 
 import { AuthRequiredError } from '@/platform/auth/errors';
 import { getAuthAdapter } from '@/platform/auth/index';
@@ -9,6 +9,10 @@ import {
   setRuntimeAuthError,
 } from '@/platform/auth/runtime';
 import { getApiScopes } from '@/platform/auth/scopes';
+import {
+  handleSessionExpired,
+  isReauthRequired,
+} from '@/platform/auth/sessionExpiry';
 import { SESSION_QUERY_KEY } from '@/platform/auth/sessionQuery';
 import { ssInfo, ssWarn } from '@/platform/log';
 import { queryClient } from '@/platform/reactQueryClient';
@@ -102,10 +106,32 @@ export function configureApiClient() {
       // Invalidate session query so UI reacts to auth failure
       queryClient.invalidateQueries({ queryKey: SESSION_QUERY_KEY });
 
+      // Reactively escalate to interactive re-auth (redirect on web, prompt in
+      // Teams). De-duped inside handleSessionExpired — fire-and-forget.
+      void handleSessionExpired();
+
       ssWarn('api', 'silent token attach failed (blocking request)', e);
       throw e instanceof AuthRequiredError ? e : new AuthRequiredError();
     }
 
     return config;
   });
+
+  // Response interceptor — a live 401 the server marks with X-Reauth-Required is
+  // an auth-middleware rejection (expired/invalid token), not a domain 401. Most
+  // app-public expiries are caught request-side above (silent acquisition throws
+  // before the request is sent); this covers token-present-but-server-rejects.
+  AXIOS_INSTANCE.interceptors.response.use(
+    (response) => response,
+    (error: unknown) => {
+      if (
+        axios.isAxiosError(error) &&
+        error.response?.status === 401 &&
+        isReauthRequired(error.response.headers)
+      ) {
+        void handleSessionExpired();
+      }
+      return Promise.reject(error);
+    }
+  );
 }

--- a/src/platform/api/fetchAuthed.ts
+++ b/src/platform/api/fetchAuthed.ts
@@ -14,6 +14,10 @@ import { AXIOS_INSTANCE } from '@smartspace/api-client';
 
 import { getAuthAdapter } from '@/platform/auth';
 import { getApiScopes } from '@/platform/auth/scopes';
+import {
+  handleSessionExpired,
+  isReauthRequired,
+} from '@/platform/auth/sessionExpiry';
 
 export type FetchAuthedInit = Omit<RequestInit, 'headers'> & {
   headers?: Record<string, string>;
@@ -31,11 +35,17 @@ export async function fetchAuthed(
   const url = `${baseUrl}${
     endpoint.startsWith('/') ? endpoint : `/${endpoint}`
   }`;
-  return fetch(url, {
+  const res = await fetch(url, {
     ...init,
     headers: {
       Authorization: `Bearer ${token}`,
       ...init.headers,
     },
   });
+  // Raw fetch bypasses the axios response interceptor — funnel an
+  // auth-middleware 401 into the same de-duped re-auth escalation.
+  if (res.status === 401 && isReauthRequired(res.headers)) {
+    void handleSessionExpired();
+  }
+  return res;
 }

--- a/src/platform/auth/__tests__/sessionExpiry.spec.ts
+++ b/src/platform/auth/__tests__/sessionExpiry.spec.ts
@@ -1,0 +1,84 @@
+import { AxiosHeaders } from 'axios';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockSignIn, mockSetSessionExpired, state } = vi.hoisted(() => ({
+  mockSignIn: vi.fn().mockResolvedValue(undefined),
+  mockSetSessionExpired: vi.fn(),
+  state: { inTeams: false },
+}));
+
+vi.mock('@/platform/auth/index', () => ({
+  getAuthAdapter: () => ({ signIn: mockSignIn }),
+}));
+
+vi.mock('@/platform/auth/msalConfig', () => ({
+  isInTeams: () => state.inTeams,
+}));
+
+vi.mock('@/platform/auth/runtime', () => ({
+  getAuthRuntimeState: () => ({ isInTeams: null }),
+  setSessionExpired: mockSetSessionExpired,
+}));
+
+vi.mock('@/platform/log', () => ({
+  ssInfoAlways: vi.fn(),
+  ssWarn: vi.fn(),
+}));
+
+import {
+  handleSessionExpired,
+  isReauthRequired,
+  resetSessionExpiry,
+} from '@/platform/auth/sessionExpiry';
+
+describe('isReauthRequired', () => {
+  it('is true for the header on a fetch Headers object (case-insensitive)', () => {
+    const h = new Headers();
+    h.set('X-Reauth-Required', 'true');
+    expect(isReauthRequired(h)).toBe(true);
+  });
+
+  it('is true for AxiosHeaders', () => {
+    const h = AxiosHeaders.from({ 'x-reauth-required': 'true' });
+    expect(isReauthRequired(h)).toBe(true);
+  });
+
+  it('is true for a plain record', () => {
+    expect(isReauthRequired({ 'x-reauth-required': 'true' })).toBe(true);
+  });
+
+  it('is false when absent (domain 401) or malformed', () => {
+    expect(isReauthRequired(new Headers())).toBe(false);
+    expect(
+      isReauthRequired({ 'content-type': 'application/problem+json' })
+    ).toBe(false);
+    expect(isReauthRequired(null)).toBe(false);
+    expect(isReauthRequired(undefined)).toBe(false);
+  });
+});
+
+describe('handleSessionExpired', () => {
+  beforeEach(() => {
+    state.inTeams = false;
+    resetSessionExpiry();
+    mockSignIn.mockClear();
+    mockSetSessionExpired.mockClear();
+  });
+
+  it('web: redirects via signIn() exactly once for concurrent failures', async () => {
+    await Promise.all([
+      handleSessionExpired(),
+      handleSessionExpired(),
+      handleSessionExpired(),
+    ]);
+    expect(mockSignIn).toHaveBeenCalledTimes(1);
+    expect(mockSetSessionExpired).not.toHaveBeenCalled();
+  });
+
+  it('teams: flags the prompt instead of auto signing in', async () => {
+    state.inTeams = true;
+    await handleSessionExpired();
+    expect(mockSetSessionExpired).toHaveBeenCalledWith(true);
+    expect(mockSignIn).not.toHaveBeenCalled();
+  });
+});

--- a/src/platform/auth/__tests__/sessionExpiry.spec.ts
+++ b/src/platform/auth/__tests__/sessionExpiry.spec.ts
@@ -1,11 +1,13 @@
 import { AxiosHeaders } from 'axios';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockSignIn, mockSetSessionExpired, state } = vi.hoisted(() => ({
-  mockSignIn: vi.fn().mockResolvedValue(undefined),
-  mockSetSessionExpired: vi.fn(),
-  state: { inTeams: false },
-}));
+const { mockSignIn, mockSetSessionExpired, mockSetAuthStuck, state } =
+  vi.hoisted(() => ({
+    mockSignIn: vi.fn().mockResolvedValue(undefined),
+    mockSetSessionExpired: vi.fn(),
+    mockSetAuthStuck: vi.fn(),
+    state: { inTeams: false },
+  }));
 
 vi.mock('@/platform/auth/index', () => ({
   getAuthAdapter: () => ({ signIn: mockSignIn }),
@@ -18,6 +20,7 @@ vi.mock('@/platform/auth/msalConfig', () => ({
 vi.mock('@/platform/auth/runtime', () => ({
   getAuthRuntimeState: () => ({ isInTeams: null }),
   setSessionExpired: mockSetSessionExpired,
+  setAuthStuck: mockSetAuthStuck,
 }));
 
 vi.mock('@/platform/log', () => ({
@@ -61,8 +64,10 @@ describe('handleSessionExpired', () => {
   beforeEach(() => {
     state.inTeams = false;
     resetSessionExpiry();
-    mockSignIn.mockClear();
+    mockSignIn.mockReset();
+    mockSignIn.mockResolvedValue(undefined);
     mockSetSessionExpired.mockClear();
+    mockSetAuthStuck.mockClear();
   });
 
   it('web: redirects via signIn() exactly once for concurrent failures', async () => {
@@ -80,5 +85,22 @@ describe('handleSessionExpired', () => {
     await handleSessionExpired();
     expect(mockSetSessionExpired).toHaveBeenCalledWith(true);
     expect(mockSignIn).not.toHaveBeenCalled();
+  });
+
+  it('stops redirecting and flags authStuck after too many attempts', async () => {
+    // signIn rejects so the in-progress guard resets between attempts (mirrors
+    // the page reload that would happen after each real redirect).
+    mockSignIn.mockReset();
+    mockSignIn.mockRejectedValue(new Error('still 401'));
+
+    await handleSessionExpired();
+    await handleSessionExpired();
+    await handleSessionExpired();
+    expect(mockSignIn).toHaveBeenCalledTimes(3);
+
+    mockSignIn.mockClear();
+    await handleSessionExpired(); // 4th within the window — over budget
+    expect(mockSignIn).not.toHaveBeenCalled();
+    expect(mockSetAuthStuck).toHaveBeenCalledWith(true);
   });
 });

--- a/src/platform/auth/providers/msalWeb.ts
+++ b/src/platform/auth/providers/msalWeb.ts
@@ -354,6 +354,7 @@ export function createMsalWebAdapter(): AuthAdapter {
     },
     async signIn(opts?: SignInOptions) {
       const redirectUrl =
+        opts?.redirectUrl ||
         new URLSearchParams(window.location.search).get('redirect') ||
         '/workspace';
       sessionStorage.setItem('msalRedirectUrl', redirectUrl);

--- a/src/platform/auth/providers/msalWeb.ts
+++ b/src/platform/auth/providers/msalWeb.ts
@@ -357,7 +357,6 @@ export function createMsalWebAdapter(): AuthAdapter {
         opts?.redirectUrl ||
         new URLSearchParams(window.location.search).get('redirect') ||
         '/workspace';
-      sessionStorage.setItem('msalRedirectUrl', redirectUrl);
       if (isInTeams()) {
         // Build a loginHint from: caller-provided hint → cached account → nothing.
         const hint =
@@ -401,6 +400,10 @@ export function createMsalWebAdapter(): AuthAdapter {
         );
       } else {
         ssInfo('auth:web', 'signIn -> loginRedirect', { redirectUrl });
+        // Persist the return URL only on the web flow: it lands back on '/'
+        // where the index route consumes it. The Teams popup path stays on the
+        // current page, so storing it there would only leave a stale value.
+        sessionStorage.setItem('msalRedirectUrl', redirectUrl);
         await msalInstance.loginRedirect({
           ...interactiveLoginRequest,
           redirectUri: handleTrailingSlash(window.location.origin),

--- a/src/platform/auth/providers/msalWeb.ts
+++ b/src/platform/auth/providers/msalWeb.ts
@@ -354,7 +354,6 @@ export function createMsalWebAdapter(): AuthAdapter {
     },
     async signIn(opts?: SignInOptions) {
       const redirectUrl =
-        opts?.redirectUrl ||
         new URLSearchParams(window.location.search).get('redirect') ||
         '/workspace';
       sessionStorage.setItem('msalRedirectUrl', redirectUrl);

--- a/src/platform/auth/runtime.ts
+++ b/src/platform/auth/runtime.ts
@@ -12,6 +12,13 @@ export type AuthRuntimeState = {
   /** `null` until we have any signal; `true` inside Teams, `false` otherwise. */
   isInTeams: boolean | null;
   lastError: AuthRuntimeError | null;
+  /**
+   * Set when the session can no longer be silently refreshed and interactive
+   * re-auth needs a user gesture (Teams). A root-level prompt reads this to
+   * offer a "sign in" button. On web, recovery is an automatic redirect, so
+   * this stays false.
+   */
+  sessionExpired: boolean;
 };
 
 type Listener = () => void;
@@ -19,6 +26,7 @@ type Listener = () => void;
 let state: AuthRuntimeState = {
   isInTeams: null,
   lastError: null,
+  sessionExpired: false,
 };
 const listeners = new Set<Listener>();
 
@@ -46,6 +54,12 @@ export function setRuntimeAuthError(
 ) {
   const next = error ? { ...error, at: Date.now() } : null;
   state = { ...state, lastError: next };
+  emit();
+}
+
+export function setSessionExpired(expired: boolean) {
+  if (state.sessionExpired === expired) return;
+  state = { ...state, sessionExpired: expired };
   emit();
 }
 

--- a/src/platform/auth/runtime.ts
+++ b/src/platform/auth/runtime.ts
@@ -19,6 +19,13 @@ export type AuthRuntimeState = {
    * this stays false.
    */
   sessionExpired: boolean;
+  /**
+   * Set when re-auth has fired too many times in a short window — i.e. signing
+   * in didn't resolve the 401 (revoked access, conditional-access gate, backend
+   * rejecting a valid token). Recovery stops auto-redirecting and a terminal
+   * prompt is shown instead of looping the user through login indefinitely.
+   */
+  authStuck: boolean;
 };
 
 type Listener = () => void;
@@ -27,6 +34,7 @@ let state: AuthRuntimeState = {
   isInTeams: null,
   lastError: null,
   sessionExpired: false,
+  authStuck: false,
 };
 const listeners = new Set<Listener>();
 
@@ -60,6 +68,12 @@ export function setRuntimeAuthError(
 export function setSessionExpired(expired: boolean) {
   if (state.sessionExpired === expired) return;
   state = { ...state, sessionExpired: expired };
+  emit();
+}
+
+export function setAuthStuck(stuck: boolean) {
+  if (state.authStuck === stuck) return;
+  state = { ...state, authStuck: stuck };
   emit();
 }
 

--- a/src/platform/auth/sessionExpiry.ts
+++ b/src/platform/auth/sessionExpiry.ts
@@ -56,13 +56,7 @@ export async function handleSessionExpired(): Promise<void> {
       return;
     }
     ssInfoAlways('auth', 'session expired -> interactive sign-in redirect');
-    // Return to the current page after sign-in, not the workspace root.
-    await getAuthAdapter().signIn({
-      redirectUrl:
-        window.location.pathname +
-        window.location.search +
-        window.location.hash,
-    });
+    await getAuthAdapter().signIn();
   } catch (e) {
     ssWarn('auth', 'session-expiry recovery failed', e);
     // Allow a retry on the next failure rather than wedging the guard.

--- a/src/platform/auth/sessionExpiry.ts
+++ b/src/platform/auth/sessionExpiry.ts
@@ -56,7 +56,13 @@ export async function handleSessionExpired(): Promise<void> {
       return;
     }
     ssInfoAlways('auth', 'session expired -> interactive sign-in redirect');
-    await getAuthAdapter().signIn();
+    // Return to the current page after sign-in, not the workspace root.
+    await getAuthAdapter().signIn({
+      redirectUrl:
+        window.location.pathname +
+        window.location.search +
+        window.location.hash,
+    });
   } catch (e) {
     ssWarn('auth', 'session-expiry recovery failed', e);
     // Allow a retry on the next failure rather than wedging the guard.
@@ -94,4 +100,15 @@ export function isReauthRequired(headers: unknown): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * True when a SignalR error is an auth rejection — the negotiate request 401s
+ * once the token can no longer be silently refreshed. This is the reliable
+ * expiry signal (the accessTokenFactory swallows failures and returns '').
+ */
+export function isUnauthorizedError(err: unknown): boolean {
+  const e = err as { statusCode?: number; message?: string } | undefined;
+  if (e?.statusCode === 401) return true;
+  return /\b401\b|unauthorized/i.test(String(e?.message ?? ''));
 }

--- a/src/platform/auth/sessionExpiry.ts
+++ b/src/platform/auth/sessionExpiry.ts
@@ -56,7 +56,14 @@ export async function handleSessionExpired(): Promise<void> {
       return;
     }
     ssInfoAlways('auth', 'session expired -> interactive sign-in redirect');
-    await getAuthAdapter().signIn();
+    // Pass the current page so the user returns here after sign-in (the index
+    // route consumes the stored URL), rather than landing on the workspace root.
+    await getAuthAdapter().signIn({
+      redirectUrl:
+        window.location.pathname +
+        window.location.search +
+        window.location.hash,
+    });
   } catch (e) {
     ssWarn('auth', 'session-expiry recovery failed', e);
     // Allow a retry on the next failure rather than wedging the guard.

--- a/src/platform/auth/sessionExpiry.ts
+++ b/src/platform/auth/sessionExpiry.ts
@@ -1,0 +1,97 @@
+// Reactive recovery for an expired session.
+//
+// The request interceptor acquires tokens silently (`silentOnly`). When silent
+// acquisition stops working — typically a couple of hours in, once the refresh
+// token / hidden-iframe renewal can no longer mint a token — in-flight requests
+// fail and the only redirect-to-login lives in the route `beforeLoad`, which
+// runs on navigation, not while the user idles on a page. The server now marks
+// auth-middleware 401s with `X-Reauth-Required` so we can also react to a live
+// 401. Both paths funnel here.
+//
+// This is the single, de-duplicated escalation point: many concurrent failures
+// trigger exactly one recovery.
+import { getAuthAdapter } from '@/platform/auth/index';
+import { isInTeams } from '@/platform/auth/msalConfig';
+import {
+  getAuthRuntimeState,
+  setSessionExpired,
+} from '@/platform/auth/runtime';
+import { ssInfoAlways, ssWarn } from '@/platform/log';
+
+let reauthInProgress = false;
+
+function isE2E(): boolean {
+  return import.meta.env.VITE_E2E_AUTH_BYPASS === 'true';
+}
+
+function onLoginScreen(): boolean {
+  try {
+    return (window.location?.pathname || '').startsWith('/login');
+  } catch {
+    return false;
+  }
+}
+
+function inTeamsEnvironment(): boolean {
+  return getAuthRuntimeState().isInTeams === true || isInTeams();
+}
+
+/**
+ * Recover from a session whose silent token can no longer be acquired (or whose
+ * requests the server rejects with an auth-middleware 401). De-duplicated.
+ *
+ * - Pure web: redirect through interactive sign-in (`loginRedirect`) — automatic,
+ *   no user gesture needed; `signIn()` stores the return URL.
+ * - Teams: a popup needs a user gesture, so flag the session as expired and let
+ *   the root-level prompt drive `signIn()` on click.
+ */
+export async function handleSessionExpired(): Promise<void> {
+  if (isE2E() || reauthInProgress || onLoginScreen()) return;
+  reauthInProgress = true;
+
+  try {
+    if (inTeamsEnvironment()) {
+      // Can't open a popup without a gesture — surface a prompt instead.
+      setSessionExpired(true);
+      return;
+    }
+    ssInfoAlways('auth', 'session expired -> interactive sign-in redirect');
+    await getAuthAdapter().signIn();
+  } catch (e) {
+    ssWarn('auth', 'session-expiry recovery failed', e);
+    // Allow a retry on the next failure rather than wedging the guard.
+    reauthInProgress = false;
+  }
+}
+
+/** Clear the guard + prompt once a fresh session is established. */
+export function resetSessionExpiry(): void {
+  reauthInProgress = false;
+  setSessionExpired(false);
+}
+
+/**
+ * True when a 401 is an auth-middleware rejection (expired/invalid/missing
+ * token), signalled by the backend's `X-Reauth-Required` header. Domain 401s
+ * (`SmartSpaceException` Security → `application/problem+json`) never carry it,
+ * so they don't trigger re-auth. Accepts AxiosHeaders, a fetch `Headers`, or a
+ * plain record — header names are case-insensitive.
+ */
+export function isReauthRequired(headers: unknown): boolean {
+  try {
+    const h = headers as
+      | { get?: (k: string) => unknown }
+      | Record<string, unknown>
+      | null;
+    if (!h) return false;
+    const get = (h as { get?: (k: string) => unknown }).get;
+    const raw =
+      typeof get === 'function'
+        ? get.call(h, 'x-reauth-required')
+        : (h as Record<string, unknown>)['x-reauth-required'] ??
+          (h as Record<string, unknown>)['X-Reauth-Required'];
+    return String(raw ?? '').toLowerCase() === 'true';
+  } catch {
+    return false;
+  }
+}

--- a/src/platform/auth/sessionExpiry.ts
+++ b/src/platform/auth/sessionExpiry.ts
@@ -14,11 +14,37 @@ import { getAuthAdapter } from '@/platform/auth/index';
 import { isInTeams } from '@/platform/auth/msalConfig';
 import {
   getAuthRuntimeState,
+  setAuthStuck,
   setSessionExpired,
 } from '@/platform/auth/runtime';
 import { ssInfoAlways, ssWarn } from '@/platform/log';
 
 let reauthInProgress = false;
+
+// Loop-breaker: each re-auth is a full-page redirect, so in-memory guards reset
+// on reload. Persist a sliding window of attempt timestamps in sessionStorage;
+// after too many in a short window, stop redirecting (re-auth isn't clearing the
+// 401 — revoked access, a conditional-access gate, or a backend rejecting a
+// valid token) and surface a terminal prompt instead of an infinite loop.
+const REAUTH_LOG_KEY = 'ss_reauth_log';
+const REAUTH_MAX = 3;
+const REAUTH_WINDOW_MS = 60_000;
+
+/** Record an attempt; return false once too many have fired within the window. */
+function withinReauthBudget(): boolean {
+  try {
+    const now = Date.now();
+    const raw = sessionStorage.getItem(REAUTH_LOG_KEY);
+    const recent = (raw ? (JSON.parse(raw) as number[]) : []).filter(
+      (t) => now - t < REAUTH_WINDOW_MS
+    );
+    recent.push(now);
+    sessionStorage.setItem(REAUTH_LOG_KEY, JSON.stringify(recent));
+    return recent.length <= REAUTH_MAX;
+  } catch {
+    return true; // storage unavailable — don't block recovery
+  }
+}
 
 function isE2E(): boolean {
   return import.meta.env.VITE_E2E_AUTH_BYPASS === 'true';
@@ -47,6 +73,14 @@ function inTeamsEnvironment(): boolean {
  */
 export async function handleSessionExpired(): Promise<void> {
   if (isE2E() || reauthInProgress || onLoginScreen()) return;
+
+  // Stop looping if re-auth keeps firing without resolving the 401.
+  if (!withinReauthBudget()) {
+    ssWarn('auth', 'too many re-auth attempts — surfacing stuck state');
+    setAuthStuck(true);
+    return;
+  }
+
   reauthInProgress = true;
 
   try {
@@ -71,10 +105,16 @@ export async function handleSessionExpired(): Promise<void> {
   }
 }
 
-/** Clear the guard + prompt once a fresh session is established. */
+/** Clear the guard + prompt + attempt log once a fresh session is established. */
 export function resetSessionExpiry(): void {
   reauthInProgress = false;
   setSessionExpired(false);
+  setAuthStuck(false);
+  try {
+    sessionStorage.removeItem(REAUTH_LOG_KEY);
+  } catch {
+    /* ignore */
+  }
 }
 
 /**

--- a/src/platform/auth/types.ts
+++ b/src/platform/auth/types.ts
@@ -7,12 +7,6 @@ export type GetTokenOptions = {
 export type SignInOptions = {
   /** UPN or email hint so Azure AD can auto-select the account (avoids "Pick an account" prompt). */
   loginHint?: string;
-  /**
-   * Where to return after sign-in completes. Defaults to the `?redirect` query
-   * param, else `/workspace`. Passed by reactive re-auth so the user lands back
-   * on the page they were on, not the workspace root.
-   */
-  redirectUrl?: string;
 };
 
 export interface AuthAdapter {

--- a/src/platform/auth/types.ts
+++ b/src/platform/auth/types.ts
@@ -7,6 +7,12 @@ export type GetTokenOptions = {
 export type SignInOptions = {
   /** UPN or email hint so Azure AD can auto-select the account (avoids "Pick an account" prompt). */
   loginHint?: string;
+  /**
+   * Where to return after sign-in completes. Defaults to the `?redirect` query
+   * param, else `/workspace`. Passed by reactive re-auth so the user lands back
+   * on the page they were on, not the workspace root.
+   */
+  redirectUrl?: string;
 };
 
 export interface AuthAdapter {

--- a/src/platform/auth/types.ts
+++ b/src/platform/auth/types.ts
@@ -7,6 +7,13 @@ export type GetTokenOptions = {
 export type SignInOptions = {
   /** UPN or email hint so Azure AD can auto-select the account (avoids "Pick an account" prompt). */
   loginHint?: string;
+  /**
+   * Explicit return URL after sign-in completes. Falls back to the `?redirect`
+   * query param, then `/workspace`. Passed by reactive re-auth (which fires from
+   * an arbitrary page with no `?redirect` in the URL) so the user returns to the
+   * page they were on. Consumed on the `/` landing route after the MSAL redirect.
+   */
+  redirectUrl?: string;
 };
 
 export interface AuthAdapter {

--- a/src/platform/realtime/RealtimeProvider.tsx
+++ b/src/platform/realtime/RealtimeProvider.tsx
@@ -18,21 +18,13 @@ import {
 } from 'react';
 
 import { parseScopes } from '@/platform/auth/scopes';
-import { handleSessionExpired } from '@/platform/auth/sessionExpiry';
+import {
+  handleSessionExpired,
+  isUnauthorizedError,
+} from '@/platform/auth/sessionExpiry';
 
 const createChatHub = (connection: HubConnection) =>
   SignalR.getHubProxyFactory('IChatHubInvoker').createHubProxy(connection);
-
-/**
- * True when a SignalR error is an auth rejection — the negotiate request 401s
- * once the token can no longer be silently refreshed. This is the reliable
- * expiry signal (the accessTokenFactory swallows failures and returns '').
- */
-const isUnauthorizedError = (err: unknown): boolean => {
-  const e = err as { statusCode?: number; message?: string } | undefined;
-  if (e?.statusCode === 401) return true;
-  return /\b401\b|unauthorized/i.test(String(e?.message ?? ''));
-};
 
 type RealtimeCtx = {
   connection?: HubConnection;

--- a/src/platform/realtime/RealtimeProvider.tsx
+++ b/src/platform/realtime/RealtimeProvider.tsx
@@ -18,9 +18,21 @@ import {
 } from 'react';
 
 import { parseScopes } from '@/platform/auth/scopes';
+import { handleSessionExpired } from '@/platform/auth/sessionExpiry';
 
 const createChatHub = (connection: HubConnection) =>
   SignalR.getHubProxyFactory('IChatHubInvoker').createHubProxy(connection);
+
+/**
+ * True when a SignalR error is an auth rejection — the negotiate request 401s
+ * once the token can no longer be silently refreshed. This is the reliable
+ * expiry signal (the accessTokenFactory swallows failures and returns '').
+ */
+const isUnauthorizedError = (err: unknown): boolean => {
+  const e = err as { statusCode?: number; message?: string } | undefined;
+  if (e?.statusCode === 401) return true;
+  return /\b401\b|unauthorized/i.test(String(e?.message ?? ''));
+};
 
 type RealtimeCtx = {
   connection?: HubConnection;
@@ -77,10 +89,17 @@ export function RealtimeProvider({
   scopes = parseScopes(import.meta.env.VITE_CLIENT_SCOPES),
 }: RealtimeProviderProps) {
   const [connection, setConnection] = useState<HubConnection>();
+  // Bumped when a connection closes permanently (automatic-reconnect exhausted)
+  // so the build effect rebuilds a fresh connection — without it the hub stays
+  // dead until a full page reload (e.g. after re-auth in Teams).
+  const [rebuildTick, setRebuildTick] = useState(0);
   const desiredGroups = useRef<Set<string>>(new Set());
   const startPromise = useRef<Promise<void> | null>(null);
 
   const hubUrl = (baseUrl ?? '').replace(/\/$/, '') + hubPath;
+  // Stable key for the scopes array so the effect dep is a simple value
+  // (react-hooks/exhaustive-deps rejects complex expressions in the deps array).
+  const scopesKey = JSON.stringify(scopes);
 
   const isConnected = useCallback(
     () => connection?.state === HubConnectionState.Connected,
@@ -197,25 +216,44 @@ export function RealtimeProvider({
     };
     conn.onreconnected(rejoin);
 
+    let disposed = false;
+    let rebuildTimer: ReturnType<typeof setTimeout> | undefined;
+
     // start
     startPromise.current = conn
       .start()
       .catch((err) => {
         console.error('Error starting realtime connection', err);
+        // A negotiate 401 means the session expired — escalate to re-auth.
+        if (isUnauthorizedError(err)) void handleSessionExpired();
       })
       .finally(() => {
         startPromise.current = null;
       });
+
+    // withAutomaticReconnect() gives up after its retry schedule; without this
+    // the hub stays dead until a full page reload. Rebuild a fresh connection
+    // shortly after — by then re-auth has typically restored a usable token.
+    conn.onclose((err) => {
+      if (disposed) return;
+      if (isUnauthorizedError(err)) void handleSessionExpired();
+      rebuildTimer = setTimeout(() => {
+        if (!disposed) setRebuildTick((t) => t + 1);
+      }, 5_000);
+    });
+
     setConnection(conn);
 
     return () => {
+      disposed = true;
+      if (rebuildTimer) clearTimeout(rebuildTimer);
       startPromise.current = null;
       conn.stop().catch(() => {
         console.error('Error stopping connection');
       });
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hubUrl, getAccessToken, webSocketsOnly, JSON.stringify(scopes)]);
+  }, [hubUrl, getAccessToken, webSocketsOnly, scopesKey, rebuildTick]);
 
   const value = useMemo<RealtimeCtx>(
     () => ({

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,8 +1,25 @@
-import { Navigate, createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, redirect } from '@tanstack/react-router';
+
+import { getAuthAdapter } from '@/platform/auth';
+import { normalizeRedirectPath } from '@/platform/routing/normalizeRedirectPath';
 
 export const Route = createFileRoute('/')({
-  component: () => {
-    return <Navigate to="/workspace" replace />;
+  // After an interactive sign-in redirect (navigateToLoginRequestUrl is false),
+  // MSAL lands the user back on '/'. Honour the return URL stored by signIn() so
+  // reactive re-auth — and normal login — returns to the page the user came from
+  // instead of always dumping them on the workspace root. Downstream /_protected
+  // still guards auth, so a stale value is harmless (worst case: a bounce through
+  // the guard back to /login).
+  beforeLoad: () => {
+    const stored = getAuthAdapter().getStoredRedirectUrl?.() ?? null;
+    if (stored) {
+      try {
+        sessionStorage.removeItem('msalRedirectUrl');
+      } catch {
+        /* ignore */
+      }
+      throw redirect({ to: normalizeRedirectPath(stored, '/workspace') });
+    }
+    throw redirect({ to: '/workspace' });
   },
-})
-
+});


### PR DESCRIPTION
## Why

Once silent token acquisition stops working (typically a couple of hours in, when the refresh token / hidden-iframe renewal can no longer mint a token), in-flight requests failed **silently**. The only redirect-to-login lives in the route `beforeLoad`, which runs on navigation — not while a user idles on a page. Result: the page empties out and the user is never routed to re-login.

This is the frontend half of the fix. The backend PR (Smartspace-app-api) now stamps `X-Reauth-Required` on auth-middleware 401s so clients can tell them apart from domain 401s (`SmartSpaceException` Security → `application/problem+json`).

## What

A single, de-duplicated escalation point — `handleSessionExpired()`:
- **Pure web** → redirect through interactive sign-in (`loginRedirect`), automatic, no gesture needed.
- **Teams** → a popup needs a user gesture, so flag the session expired and let a new root-level `SessionExpiryPrompt` drive `signIn()` on click.

Triggers (all funnel into the one de-duped handler):
- **request interceptor catch** — silent acquisition threw (primary path).
- **response interceptor** — a live 401 carrying `X-Reauth-Required`. Domain 401s never carry it, so they don't trigger re-auth (protects flows that legitimately 401, e.g. provider-key validation).
- **`fetchAuthed`** — raw `fetch` bypasses the axios interceptor; same 401 check.
- **SignalR** — recover off the negotiate `401` (the reliable expiry signal; `accessTokenFactory` swallows failures and returns `''`), plus an `onclose → rebuild` net so the hub reconnects once a token is available again (parity with the admin app, which already had this).

Short-circuits: the `/login` screen and the E2E auth bypass never escalate.

## Tests

- New `sessionExpiry.spec.ts` — the `X-Reauth-Required` discriminator (fetch `Headers`, `AxiosHeaders`, plain record, absent/malformed) and the de-dup / web-vs-Teams split.
- Updated `configureApiClient.spec.ts` mock for the new response interceptor.
- `typecheck` clean; touched `api` / `realtime` / `auth` suites green.

## Notes / follow-ups

- Does **not** restore *seamless* realtime in Teams-on-MSAL — it restores *graceful* recovery (prompt → reconnect). Seamless is the parked NAA track.
- `getSession()` still reports "logged in" from a cached MSAL account for the brief window before escalation completes — acceptable transient; the redirect/prompt is driven off the explicit signal, not the session query.
