### PR TITLE
fix(teams): stop Teams-iframe freeze and fix Teams-web auth (NAA)

### DIFF
--- a/src/app/providers/TeamsProvider.tsx
+++ b/src/app/providers/TeamsProvider.tsx
@@ -116,21 +116,52 @@ export function TeamsProvider({ children }: { children: ReactNode }) {
       root.setAttribute('data-teams-theme', 'default');
 
       // Teams web can re-apply classes/styles after load; keep light pinned.
-      const obs = new MutationObserver(() => applyLight());
-      obs.observe(root, {
-        attributes: true,
-        attributeFilter: ['class', 'style'],
+      //
+      // CRITICAL: applyLight() mutates root/body `style` + `class` — the very
+      // attributes this observer watches. A naive `new MutationObserver(() =>
+      // applyLight())` therefore re-triggers itself (and fights Teams' own theme
+      // observer) in an UNBOUNDED microtask loop that pegs the Teams-iframe main
+      // thread — timers and network callbacks never run, so the app freezes on
+      // the boot splash (and can lock the whole tab/machine). This only runs in
+      // Teams, which is why the app works fine in a plain browser.
+      //
+      // Guard it two ways: (1) disconnect while we mutate so our own changes
+      // can't re-fire the observer, and (2) throttle re-application via a macro-
+      // task timer so even a tug-of-war with Teams stays bounded (≤ a few/sec)
+      // and always yields the event loop.
+      let reapplyScheduled = false;
+      let lastApplyAt = Date.now();
+      let obs: MutationObserver | null = null;
+      const observe = () => {
+        if (!obs) return;
+        obs.observe(root, {
+          attributes: true,
+          attributeFilter: ['class', 'style'],
+        });
+        try {
+          if (document.body)
+            obs.observe(document.body, {
+              attributes: true,
+              attributeFilter: ['class', 'style'],
+            });
+        } catch {
+          /* ignore */
+        }
+      };
+      obs = new MutationObserver(() => {
+        if (reapplyScheduled) return;
+        reapplyScheduled = true;
+        const wait = Math.max(0, 250 - (Date.now() - lastApplyAt));
+        window.setTimeout(() => {
+          reapplyScheduled = false;
+          lastApplyAt = Date.now();
+          obs?.disconnect();
+          applyLight();
+          observe();
+        }, wait);
       });
-      try {
-        if (document.body)
-          obs.observe(document.body, {
-            attributes: true,
-            attributeFilter: ['class', 'style'],
-          });
-      } catch {
-        /* ignore */
-      }
-      return () => obs.disconnect();
+      observe();
+      return () => obs?.disconnect();
     } catch {
       // ignore DOM failures
     }

--- a/src/platform/auth/index.ts
+++ b/src/platform/auth/index.ts
@@ -10,8 +10,8 @@ let cached: { adapter: AuthAdapter; key: string } | null = null;
 
 function adapterKey(): string {
   const r = getAuthRuntimeState();
-  const force = import.meta.env.VITE_TEAMS_USE_MSAL === 'true';
-  return `${r.isInTeams}-${force}-${getStoredUseMsalInTeams()}`;
+  const env = String(import.meta.env.VITE_TEAMS_USE_MSAL);
+  return `${r.isInTeams}-${env}-${getStoredUseMsalInTeams()}`;
 }
 
 /**
@@ -23,11 +23,18 @@ export function getAuthAdapter(): AuthAdapter {
   if (cached?.key === key) return cached.adapter;
 
   const runtime = getAuthRuntimeState();
-  const forceMsalInTeams = import.meta.env.VITE_TEAMS_USE_MSAL === 'true';
+  // The env flag is authoritative: 'true' forces MSAL, 'false' forces NAA.
+  // The `storedUseMsal` runtime escape-hatch only applies when the env flag is
+  // unset — otherwise a stale flag from a prior MSAL success would stick and
+  // override an explicit NAA configuration.
+  const envMsal = import.meta.env.VITE_TEAMS_USE_MSAL;
+  const forceMsalInTeams = envMsal === 'true';
+  const forceNaaInTeams = envMsal === 'false';
   const inTeams = runtime.isInTeams === true || isInTeams();
   const storedUseMsal = getStoredUseMsalInTeams();
 
-  const useMsalInTeams = forceMsalInTeams || storedUseMsal === true;
+  const useMsalInTeams =
+    forceMsalInTeams || (!forceNaaInTeams && storedUseMsal === true);
   const useTeamsNaa = inTeams && !useMsalInTeams;
 
   ssInfoAlways(
@@ -36,6 +43,7 @@ export function getAuthAdapter(): AuthAdapter {
     {
       inTeams,
       forceMsalInTeams,
+      forceNaaInTeams,
       storedUseMsal,
     }
   );

--- a/src/platform/auth/naaClient.ts
+++ b/src/platform/auth/naaClient.ts
@@ -1,6 +1,5 @@
 import {
   createNestablePublicClientApplication,
-  InteractionRequiredAuthError,
   type Configuration,
   type IPublicClientApplication,
 } from '@azure/msal-browser';
@@ -143,6 +142,19 @@ const isExpired = (exp: number, skew = 60) =>
 
 export type AcquireNaaTokenOptions = { silentOnly?: boolean };
 
+/** Login hint from the Teams context — used to seed ssoSilent on first load. */
+async function getTeamsLoginHint(): Promise<string | undefined> {
+  try {
+    const ctx = await teamsApp.getContext();
+    const user = ctx.user as
+      | { loginHint?: string; userPrincipalName?: string }
+      | undefined;
+    return user?.loginHint ?? user?.userPrincipalName ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export const acquireNaaToken = async (
   scopes: string[],
   opts?: AcquireNaaTokenOptions
@@ -160,13 +172,29 @@ export const acquireNaaToken = async (
   const account = accounts[0];
 
   try {
-    if (!account) {
-      ssWarn('auth:naa', 'No account found for NAA token acquisition');
-      throw new InteractionRequiredAuthError('No account available');
+    let res;
+    if (account) {
+      ssInfo(
+        'auth:naa',
+        'Attempting silent token acquisition (cached account)'
+      );
+      res = await pca.acquireTokenSilent({ account, scopes });
+    } else {
+      // No account in the nested PCA (expected on first load / after a reload in
+      // the partitioned Teams web iframe). Acquire via the host broker with
+      // ssoSilent. Unlike a hidden-iframe ssoSilent, the NAA broker path is NOT
+      // blocked by third-party-cookie partitioning — this is the seamless,
+      // popup-free SSO that NAA is designed to provide.
+      const loginHint = await getTeamsLoginHint();
+      ssInfo('auth:naa', 'No cached account — ssoSilent via host broker', {
+        hasLoginHint: !!loginHint,
+      });
+      res = await pca.ssoSilent({
+        scopes,
+        ...(loginHint ? { loginHint } : {}),
+      });
+      if (res.account) pca.setActiveAccount(res.account);
     }
-
-    ssInfo('auth:naa', 'Attempting silent token acquisition');
-    const res = await pca.acquireTokenSilent({ account, scopes });
     const token = res.accessToken;
     const exp = JSON.parse(atob(token.split('.')[1])).exp as number | undefined;
     setCachedToken(key, token, exp ?? Math.floor(Date.now() / 1000) + 900);

--- a/src/platform/auth/providers/msalWeb.ts
+++ b/src/platform/auth/providers/msalWeb.ts
@@ -7,10 +7,7 @@ import {
   isInTeams,
   loginRequest,
 } from '@/platform/auth/msalConfig';
-import {
-  authenticateViaTeamsSdk,
-  setActiveAccountFromTeamsAuth,
-} from '@/platform/auth/teamsAuthHelper';
+import { interactiveTeamsAuth } from '@/platform/auth/teamsAuthHelper';
 import { ssInfo, ssWarn } from '@/platform/log';
 
 import { setStoredUseMsalInTeams } from '../runtime';
@@ -158,8 +155,10 @@ export function createMsalWebAdapter(): AuthAdapter {
           throw new Error('No active account');
         }
         if (isInTeams()) {
-          const result = await authenticateViaTeamsSdk();
-          setActiveAccountFromTeamsAuth(msalInstance, result.homeAccountId);
+          const result = await interactiveTeamsAuth(
+            msalInstance,
+            interactiveLoginRequest
+          );
           setPopupFallbackToken(
             result.homeAccountId,
             result.accessToken,
@@ -250,11 +249,14 @@ export function createMsalWebAdapter(): AuthAdapter {
           if (inFlightPopupPromise) return inFlightPopupPromise;
           inFlightPopupPromise = (async () => {
             if (isInTeams()) {
-              // Teams SDK popup flow instead of acquireTokenPopup
+              // Client-aware interactive popup: native on Teams web, Teams SDK on desktop.
               const account = msalInstance.getActiveAccount();
               const hint = account?.username;
-              const result = await authenticateViaTeamsSdk(hint);
-              setActiveAccountFromTeamsAuth(msalInstance, result.homeAccountId);
+              const result = await interactiveTeamsAuth(
+                msalInstance,
+                interactiveLoginRequest,
+                hint
+              );
               setPopupFallbackToken(
                 result.homeAccountId,
                 result.accessToken,
@@ -389,10 +391,13 @@ export function createMsalWebAdapter(): AuthAdapter {
             );
           }
         }
-        // 2) Teams SDK popup flow — uses authentication.authenticate() which
-        //    opens a Teams-controlled popup (bypasses WebView2 popup blocking).
-        const result = await authenticateViaTeamsSdk(hint);
-        setActiveAccountFromTeamsAuth(msalInstance, result.homeAccountId);
+        // 2) Interactive popup — native acquireTokenPopup on Teams web, with a
+        //    Teams SDK popup fallback for desktop (WebView2 popup blocking).
+        const result = await interactiveTeamsAuth(
+          msalInstance,
+          interactiveLoginRequest,
+          hint
+        );
         setPopupFallbackToken(
           result.homeAccountId,
           result.accessToken,

--- a/src/platform/auth/teamsAuthHelper.ts
+++ b/src/platform/auth/teamsAuthHelper.ts
@@ -6,7 +6,10 @@
  * `authentication.authenticate()` API, which bypasses WebView2
  * popup blocking in Teams Desktop.
  */
-import type { PublicClientApplication } from '@azure/msal-browser';
+import type {
+  PopupRequest,
+  PublicClientApplication,
+} from '@azure/msal-browser';
 import { authentication, app as teamsApp } from '@microsoft/teams-js';
 
 import { ssInfo, ssWarn } from '@/platform/log';
@@ -145,5 +148,48 @@ export function setActiveAccountFromTeamsAuth(
     if (allAccounts.length > 0) {
       msalInstance.setActiveAccount(allAccounts[0]);
     }
+  }
+}
+
+/**
+ * Interactive Teams token acquisition that picks the popup mechanism the current
+ * client supports:
+ *  - Teams web: MSAL's native `acquireTokenPopup` works and is simplest.
+ *  - Teams desktop (WebView2): native popups are blocked, so fall back to the
+ *    Teams SDK authentication popup (the teams-auth-*.html round-trip).
+ * Native is tried first with a Teams-SDK fallback, so it's robust without relying
+ * on host-client-type detection (which is null in new Teams web). Returns the
+ * same shape as `authenticateViaTeamsSdk`, so callers are unchanged.
+ */
+export async function interactiveTeamsAuth(
+  msalInstance: PublicClientApplication,
+  request: PopupRequest,
+  loginHint?: string
+): Promise<TeamsAuthResult> {
+  try {
+    ssInfo(
+      'auth:teams-helper',
+      'interactiveTeamsAuth -> native acquireTokenPopup'
+    );
+    const r = await msalInstance.acquireTokenPopup({
+      ...request,
+      ...(loginHint ? { loginHint } : {}),
+    });
+    if (r.account) msalInstance.setActiveAccount(r.account);
+    ssInfo('auth:teams-helper', 'native acquireTokenPopup succeeded');
+    return {
+      homeAccountId: r.account?.homeAccountId ?? '',
+      accessToken: r.accessToken,
+      expiresOn: r.expiresOn?.toISOString(),
+    };
+  } catch (nativeErr) {
+    ssWarn(
+      'auth:teams-helper',
+      'native popup failed; falling back to Teams SDK popup',
+      nativeErr
+    );
+    const result = await authenticateViaTeamsSdk(loginHint);
+    setActiveAccountFromTeamsAuth(msalInstance, result.homeAccountId);
+    return result;
   }
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,7 +1,10 @@
 // src/routes/__root.tsx
 import { Outlet, createRootRouteWithContext } from '@tanstack/react-router';
+import { useEffect } from 'react';
 
+import { removeSplash } from '@/platform/boot/removeSplash';
 import type { RouterContext } from '@/platform/router/context';
+
 
 import { RootErrorBoundary } from '@/app/ui/RouteErrorEnvelope';
 
@@ -9,6 +12,14 @@ import { useTeamsViewport } from '@/hooks/useTeamsViewport';
 
 function RootContent() {
   const { viewportHeight, isAndroidTeams } = useTeamsViewport();
+
+  // Remove the boot splash as soon as React mounts the root — not only when a
+  // specific route's component commits. In the Teams web flow the router can sit
+  // in the pending/beforeLoad phase (no route component mounts), which left the
+  // z-9999 splash covering a fully-loaded app indefinitely.
+  useEffect(() => {
+    removeSplash();
+  }, []);
 
   return (
     <div

--- a/src/routes/_protected/workspace/$workspaceId/_layout/thread/$threadId.tsx
+++ b/src/routes/_protected/workspace/$workspaceId/_layout/thread/$threadId.tsx
@@ -39,8 +39,13 @@ export const Route = createFileRoute(
         })
       );
     } catch (e: unknown) {
-      // If user deep-links to a random GUID that doesn't exist, redirect to the first thread
-      // (same behavior as /workspace/$workspaceId/ without a threadId).
+      // If a thread can't be loaded, fall back to the first thread — but ONLY if
+      // it's a DIFFERENT thread. A thread can appear in the list while its detail
+      // endpoint 404s (data inconsistency); "redirect to first" then resolves
+      // back to the same id → an infinite redirect loop that never commits, so
+      // the boot splash stays up forever and requests fire endlessly. When there
+      // is no different thread to show, commit the route with no thread instead
+      // of looping (the component renders an empty state and the splash lifts).
       if (!isNotFoundError(e)) throw e;
 
       const list = await context.queryClient.ensureQueryData(
@@ -48,7 +53,7 @@ export const Route = createFileRoute(
       );
       const first = list.data[0];
 
-      if (first?.id) {
+      if (first?.id && first.id !== params.threadId) {
         throw redirect({
           to: '/workspace/$workspaceId/thread/$threadId',
           params: { workspaceId: params.workspaceId, threadId: first.id },
@@ -56,11 +61,7 @@ export const Route = createFileRoute(
         });
       }
 
-      throw redirect({
-        to: '/workspace/$workspaceId',
-        params: { workspaceId: params.workspaceId },
-        replace: true,
-      });
+      return null;
     }
   },
   component: ThreadRouteComponent,


### PR DESCRIPTION
## Problem
Side-loaded into Microsoft Teams (web + desktop), the app froze on the boot splash and never loaded — while working perfectly in a normal browser.

## Root causes (two independent)

### 1. Main-thread freeze (the primary blocker)
`TeamsProvider`'s theme-pinning `MutationObserver` re-triggered itself in an **unbounded microtask loop**: `applyLight()` mutates the root/body `style`+`class` attributes the observer is watching, so every apply fired it again (and fought Teams' own theme observer). This **pegged the iframe main thread**, so timers, XHR/fetch completion callbacks and React commits never ran — the splash never lifted, requests showed `200` headers but their bodies "never arrived", and the tab/machine could lock up.

It's gated by `likelyInTeams`, which is exactly why a plain browser was unaffected.

**Fix:** disconnect the observer while we mutate (so our own changes can't re-fire it) and throttle re-application via a macrotask timer, so even a tug-of-war with Teams stays bounded and always yields the event loop.

### 2. Teams-web auth
The app was forced onto **MSAL-in-Teams**, which can't re-auth in Teams web (third-party-cookie-blocked `ssoSilent` hidden iframe + a Teams-SDK popup that fails with "URL was unable to be opened"). Switched to **NAA** (Nested App Authentication), the recommended path for Teams tabs:
- `acquireNaaToken` now uses `ssoSilent` via the host broker when the nested PCA cache is empty, instead of throwing — seamless, popup-free SSO.
- adapter selection is **env-authoritative** (`VITE_TEAMS_USE_MSAL`) so a stale `ss_teams_use_msal` localStorage flag can't override an explicit NAA config.
- interactive popup is **client-aware** (`interactiveTeamsAuth`): native `acquireTokenPopup` on Teams web (which works) with the Teams-SDK popup as a desktop fallback for WebView2.

### Also
- Remove the boot splash when the **React root mounts**, not only when a route component commits (which never happened while stuck in a `beforeLoad`).
- Guard the thread loader against redirecting to **itself** when a listed thread's detail endpoint 404s (would otherwise loop).

## Testing
- ✅ Loads correctly side-loaded in Teams **web** (devtunnel + deployed), against the dev tenant / greencoast API.
- ✅ NAA path: silent SSO via broker, no popup.
- ✅ MSAL path (`VITE_TEAMS_USE_MSAL=true`): also loads now (freeze fix + native popup).
- ✅ Still works in a normal browser; typecheck + lint-staged clean.

Notes: `VITE_TEAMS_USE_MSAL` is set in deploy/dev env config (NAA recommended in Teams). The dev Container App is HTTP/1.1 (`transport: Http`) — unrelated to this fix.