### PR TITLE
feat(chat): smart message copy with chart rasterization + streaming polish

### DIFF
--- a/packages/chat-ui/src/messages/MessageBubble.tsx
+++ b/packages/chat-ui/src/messages/MessageBubble.tsx
@@ -2,7 +2,7 @@
 import { JsonSchema } from '@jsonforms/core';
 import { JsonForms } from '@jsonforms/react';
 import Button from '@mui/material/Button';
-import { FC, useEffect, useState } from 'react';
+import { FC, useEffect, useRef, useState } from 'react';
 
 import { FileInfo } from '@/domains/files';
 import { getFileIcon } from '@/domains/files/utils';
@@ -64,6 +64,7 @@ export const MessageBubble: FC<MessageBubbleProps> = (props) => {
   } = props;
   const [responseFormData, setResponseFormData] = useState<unknown>(userInput);
   const [responseFormValid, setResponseFormValid] = useState<boolean>(false);
+  const contentRef = useRef<HTMLDivElement>(null);
   const isBotResponse = type === MessageValueType.OUTPUT;
   const showForm = userOutput;
 
@@ -116,25 +117,27 @@ export const MessageBubble: FC<MessageBubbleProps> = (props) => {
             </span>
           </div>
         </div>
-        <ChatMessageCopyButton content={content} />
+        <ChatMessageCopyButton content={content} contentRef={contentRef} />
       </div>
 
       <div className={cn(isBotResponse ? 'p-4' : 'px-4 py-2')}>
-        {contentIsList &&
-          content?.map((item, i) =>
-            item.text ? (
-              <div
-                key={`content-${i}`}
-                className="prose prose-sm max-w-none dark:prose-invert text-sm leading-relaxed mb-3 last:mb-0"
-              >
-                <MessageMarkdown value={item.text} />
-              </div>
-            ) : item.image ? (
-              <div key={`image-${i}`} className="mb-3 last:mb-0">
-                <ChatMessageImage image={item.image} />
-              </div>
-            ) : null
-          )}
+        <div ref={contentRef}>
+          {contentIsList &&
+            content?.map((item, i) =>
+              item.text ? (
+                <div
+                  key={`content-${i}`}
+                  className="prose prose-sm max-w-none dark:prose-invert text-sm leading-relaxed mb-3 last:mb-0"
+                >
+                  <MessageMarkdown value={item.text} />
+                </div>
+              ) : item.image ? (
+                <div key={`image-${i}`} className="mb-3 last:mb-0">
+                  <ChatMessageImage image={item.image} />
+                </div>
+              ) : null
+            )}
+        </div>
 
         {files.length > 0 && (
           <div className="ss-chat-message__attachments mt-4 space-y-2">

--- a/packages/chat-ui/src/messages/MessageCopyButton.tsx
+++ b/packages/chat-ui/src/messages/MessageCopyButton.tsx
@@ -1,9 +1,12 @@
 import { Check, Copy } from 'lucide-react';
-import { useState } from 'react';
+import { RefObject, useState } from 'react';
 
 import { MessageContentItem } from '@/domains/messages';
 
+import { copyText } from '@/shared/markdown/htmlPreviewShared';
 import { Button } from '@/shared/mui-compat/button';
+
+import { copyMessageRich } from './smartCopy';
 
 enum CopyState {
   IDLE = 'idle',
@@ -14,8 +17,12 @@ const RESET_DELAY = 1000;
 
 export function ChatMessageCopyButton({
   content,
+  contentRef,
 }: {
   content: MessageContentItem[];
+  /** Live rendered message element — its chart iframes are rasterized so the
+   *  copy pastes into Word as images. Falls back to plain text when absent. */
+  contentRef?: RefObject<HTMLElement | null>;
 }) {
   const [state, setState] = useState<CopyState>(CopyState.IDLE);
 
@@ -29,14 +36,18 @@ export function ChatMessageCopyButton({
 
     if (!textToCopy) return;
 
-    try {
-      await navigator.clipboard.writeText(textToCopy);
+    const container = contentRef?.current;
+    const ok = container
+      ? await copyMessageRich(container, textToCopy)
+      : await copyText(textToCopy);
+
+    if (ok) {
       setState(CopyState.SUCCESS);
       setTimeout(() => {
         setState(CopyState.IDLE);
       }, RESET_DELAY);
-    } catch (err) {
-      console.error('Failed to copy text:', err);
+    } else {
+      console.error('Failed to copy message content');
     }
   };
 

--- a/packages/chat-ui/src/messages/smartCopy.ts
+++ b/packages/chat-ui/src/messages/smartCopy.ts
@@ -1,0 +1,157 @@
+import {
+  copyText,
+  encodeMarkdownMarker,
+  snapshotIframe,
+  SS_MARKDOWN_CLIPBOARD_TYPE,
+  type SnapshotImage,
+} from '@/shared/markdown/htmlPreviewShared';
+
+export { SS_MARKDOWN_CLIPBOARD_TYPE };
+
+/**
+ * "Smart copy" for a chat message. Writes several representations to the
+ * clipboard at once so a single Copy click does the right thing in every
+ * paste target:
+ *
+ *  - `text/html`   — the message with each client-side chart rasterized to an
+ *                    `<img>`, so it pastes into Word/Docs as a real image
+ *                    instead of dead `<canvas>`/`<script>` source.
+ *  - `text/plain`  — the raw markdown (universal fallback).
+ *  - `image/png`   — the chart bitmap, when the message is a single chart, for
+ *                    image-only paste targets.
+ *  - `web text/markdown` — the raw markdown, for round-tripping back into
+ *                    SmartSpace with live charts intact (Chromium only).
+ *
+ * `container` is the live, rendered message element (its preview iframes are
+ * snapshotted in place). `markdown` is the original message source.
+ *
+ * Returns `true` on success. Falls back to a plain-text copy (and still
+ * returns its result) if the rich write isn't supported or fails.
+ */
+export async function copyMessageRich(
+  container: HTMLElement,
+  markdown: string
+): Promise<boolean> {
+  try {
+    const canRichWrite =
+      typeof ClipboardItem !== 'undefined' && !!navigator.clipboard?.write;
+    if (!canRichWrite) return copyText(markdown);
+
+    const { html, images } = await buildHtmlPayload(container);
+
+    // Embed the live markdown as a hidden comment so pasting back into the
+    // SmartSpace composer recovers the source (charts re-render) while external
+    // apps still see only the image HTML.
+    const htmlWithMarker = `${html}${encodeMarkdownMarker(markdown)}`;
+
+    const parts: Record<string, Blob> = {
+      'text/html': new Blob([htmlWithMarker], { type: 'text/html' }),
+      'text/plain': new Blob([markdown], { type: 'text/plain' }),
+    };
+
+    // Only attach a top-level image when the message is essentially one chart —
+    // otherwise an image-only paste target can't tell which chart was meant.
+    if (images.length === 1) {
+      const pngBlob = await dataUrlToBlob(images[0].dataUrl);
+      if (pngBlob) parts['image/png'] = pngBlob;
+    }
+
+    // Try with the custom format first; retry without it for browsers that
+    // reject unknown `web ` formats; fall back to plain text as a last resort.
+    const withCustom: Record<string, Blob> = {
+      ...parts,
+      [SS_MARKDOWN_CLIPBOARD_TYPE]: new Blob([markdown], {
+        type: SS_MARKDOWN_CLIPBOARD_TYPE,
+      }),
+    };
+
+    if (await tryWrite(withCustom)) return true;
+    if (await tryWrite(parts)) return true;
+    return copyText(markdown);
+  } catch {
+    return copyText(markdown);
+  }
+}
+
+async function tryWrite(parts: Record<string, Blob>): Promise<boolean> {
+  try {
+    await navigator.clipboard.write([new ClipboardItem(parts)]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Clone the rendered message, swap each previewable HTML block for its
+ * rasterized chart (or inline static HTML), strip interactive chrome, and
+ * serialize to an HTML string suitable for the clipboard.
+ */
+async function buildHtmlPayload(
+  container: HTMLElement
+): Promise<{ html: string; images: SnapshotImage[] }> {
+  // Snapshot the LIVE iframes (the clone's iframes have no contentWindow).
+  const liveBlocks = Array.from(
+    container.querySelectorAll<HTMLElement>('.ss-code-block--previewable')
+  );
+  const snapshots = await Promise.all(
+    liveBlocks.map((block) => {
+      const iframe = block.querySelector('iframe');
+      return iframe ? snapshotIframe(iframe) : Promise.resolve([]);
+    })
+  );
+
+  const clone = container.cloneNode(true) as HTMLElement;
+  const cloneBlocks = Array.from(
+    clone.querySelectorAll<HTMLElement>('.ss-code-block--previewable')
+  );
+
+  const allImages: SnapshotImage[] = [];
+
+  cloneBlocks.forEach((block, i) => {
+    const images = snapshots[i] ?? [];
+    if (images.length > 0) {
+      allImages.push(...images);
+      const frag = block.ownerDocument.createElement('div');
+      for (const img of images) {
+        const el = block.ownerDocument.createElement('img');
+        el.src = img.dataUrl;
+        el.setAttribute('width', String(img.cssWidth));
+        el.setAttribute('height', String(img.cssHeight));
+        el.style.maxWidth = '100%';
+        frag.appendChild(el);
+      }
+      block.replaceWith(frag);
+    } else {
+      // No usable canvas — inline the static HTML source (tables, divs) minus
+      // any scripts, so Word still gets real formatted content.
+      const source = block.querySelector('code')?.textContent ?? '';
+      const div = block.ownerDocument.createElement('div');
+      div.innerHTML = stripScripts(source);
+      block.replaceWith(div);
+    }
+  });
+
+  // Drop interactive chrome that has no meaning on the clipboard.
+  clone
+    .querySelectorAll(
+      'iframe, button, .ss-code-block__header, .ss-code-block__copy, .ss-code-block__toggle'
+    )
+    .forEach((el) => el.remove());
+
+  const html = `<meta charset="utf-8">${clone.innerHTML}`;
+  return { html, images: allImages };
+}
+
+function stripScripts(html: string): string {
+  return html.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '');
+}
+
+async function dataUrlToBlob(dataUrl: string): Promise<Blob | null> {
+  try {
+    const res = await fetch(dataUrl);
+    return await res.blob();
+  } catch {
+    return null;
+  }
+}

--- a/packages/chat-ui/src/shared/markdown/MarkdownEditor.tsx
+++ b/packages/chat-ui/src/shared/markdown/MarkdownEditor.tsx
@@ -3,6 +3,7 @@ import {
   Editor,
   editorViewCtx,
   editorViewOptionsCtx,
+  parserCtx,
   rootCtx,
   serializerCtx,
 } from '@milkdown/core';
@@ -34,6 +35,10 @@ import { fileTag } from './extensions/fileTag';
 import { htmlPreviewView } from './extensions/htmlPreview';
 import { mention } from './extensions/mention';
 import { ssImageNode, ssImageView } from './extensions/ssImage';
+import {
+  extractMarkdownMarker,
+  SS_MARKDOWN_CLIPBOARD_TYPE,
+} from './htmlPreviewShared';
 import './styles.css';
 
 const initial = [
@@ -180,6 +185,7 @@ function EditorInner({
   const [_isDragging, setIsDragging] = useState(false);
   const viewRef = useRef<EditorView | null>(null);
   const serializerRef = useRef<((doc: PMNode) => string) | null>(null);
+  const parserRef = useRef<((markdown: string) => PMNode | null) | null>(null);
 
   function guessImageExt(mime: string) {
     const t = (mime || '').toLowerCase();
@@ -342,6 +348,13 @@ function EditorInner({
               } catch {
                 /* serializer not ready yet */
               }
+              try {
+                parserRef.current = anyCtx.get(parserCtx) as (
+                  markdown: string
+                ) => PMNode | null;
+              } catch {
+                /* parser not ready yet */
+              }
               const handle = () => {
                 try {
                   if (enableMentions) updateMentionFromView();
@@ -465,6 +478,23 @@ function EditorInner({
     const { from, to } = view.state.selection;
     const tr = view.state.tr.replaceWith(from, to, node);
     view.dispatch(tr.scrollIntoView());
+  }
+
+  // Parse a markdown string and replace the current selection with it. Used
+  // when pasting SmartSpace's own custom clipboard format so charts paste as
+  // live `html` source rather than the rasterized-image `text/html`.
+  function insertMarkdownAtSelection(view: EditorView, markdown: string) {
+    const parser = parserRef.current;
+    if (!parser) return false;
+    try {
+      const doc = parser(markdown);
+      if (!doc) return false;
+      const slice = new Slice(doc.content, 0, 0);
+      view.dispatch(view.state.tr.replaceSelection(slice).scrollIntoView());
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   async function insertUploadedFilesIntoEditor(files: File[]) {
@@ -791,6 +821,25 @@ function EditorInner({
       }}
       onPasteCapture={(e) => {
         try {
+          // SmartSpace's own "smart copy" embeds the live markdown in the
+          // copied content so a chart pastes back as live `html` source instead
+          // of the rasterized image we hand to Word. Recover it from the hidden
+          // HTML marker (works in every browser), falling back to the custom
+          // web format. When neither is present this is a normal external paste
+          // and we let the default handler run.
+          const view = viewRef.current;
+          if (isEditable && view) {
+            const ssMarkdown =
+              extractMarkdownMarker(
+                e.clipboardData?.getData('text/html') ?? ''
+              ) ?? e.clipboardData?.getData(SS_MARKDOWN_CLIPBOARD_TYPE);
+            if (ssMarkdown && insertMarkdownAtSelection(view, ssMarkdown)) {
+              e.preventDefault();
+              e.stopPropagation();
+              return;
+            }
+          }
+
           const items = e.clipboardData?.items;
           if (!items) return;
           const imageFiles: File[] = [];

--- a/packages/chat-ui/src/shared/markdown/htmlPreviewShared.ts
+++ b/packages/chat-ui/src/shared/markdown/htmlPreviewShared.ts
@@ -4,6 +4,46 @@
 export const MAX_IFRAME_HEIGHT = 5000;
 export const HEIGHT_MESSAGE = 'ss-html-preview-height';
 export const ERROR_MESSAGE = 'ss-html-preview-error';
+export const SNAPSHOT_REQUEST = 'ss-html-preview-snapshot';
+export const SNAPSHOT_RESULT = 'ss-html-preview-snapshot-result';
+
+// Custom web clipboard format (Chromium 104+). External apps (Word, Outlook,
+// Google Docs) ignore unknown `web ` formats and fall back to `text/html` — so
+// they get the rasterized-image version. Written as a belt-and-braces channel
+// alongside the HTML marker below; note Chromium does NOT expose custom web
+// formats to the synchronous `paste` event's `getData`, so the HTML marker is
+// the mechanism the composer paste handler actually relies on.
+export const SS_MARKDOWN_CLIPBOARD_TYPE = 'web text/markdown';
+
+// SmartSpace recovers the live markdown on paste by embedding it in the
+// `text/html` payload as a hidden comment. `text/html` IS reliably exposed to
+// the paste event (unlike custom web formats), and Word/Docs ignore comments —
+// so this round-trips charts back as live source in every browser, while
+// external apps still see only the rasterized image.
+const MARKDOWN_MARKER_PREFIX = '<!--ss-md:';
+const MARKDOWN_MARKER_SUFFIX = '-->';
+const MARKDOWN_MARKER_RE = /<!--ss-md:([A-Za-z0-9+/=]+)-->/;
+
+/** Wrap markdown in the hidden HTML comment marker (UTF-8 → base64). */
+export function encodeMarkdownMarker(markdown: string): string {
+  try {
+    const b64 = btoa(unescape(encodeURIComponent(markdown)));
+    return `${MARKDOWN_MARKER_PREFIX}${b64}${MARKDOWN_MARKER_SUFFIX}`;
+  } catch {
+    return '';
+  }
+}
+
+/** Pull SmartSpace markdown back out of a pasted `text/html` string, if present. */
+export function extractMarkdownMarker(html: string): string | null {
+  const match = html.match(MARKDOWN_MARKER_RE);
+  if (!match) return null;
+  try {
+    return decodeURIComponent(escape(atob(match[1])));
+  } catch {
+    return null;
+  }
+}
 
 // Injected into each previewed HTML document. Because the iframe uses
 // `sandbox="allow-scripts"` (no `allow-same-origin`), the parent cannot read
@@ -34,6 +74,48 @@ const HEIGHT_REPORTER_SCRIPT = `
   });
   window.addEventListener('unhandledrejection', function(ev){
     reportError(ev && ev.reason && ev.reason.message);
+  });
+  // Snapshot responder. The parent can't read this sandboxed (no
+  // allow-same-origin) document, so when it asks for a snapshot we rasterize
+  // our own <canvas> elements via toDataURL and post just the PNG strings
+  // back out — strings cross the sandbox boundary fine. Used by the message
+  // "smart copy" so client-side charts (Chart.js etc.) paste into Word as
+  // images instead of dead <canvas>/<script> source.
+  window.addEventListener('message', function(ev){
+    var d = ev && ev.data;
+    if (!d || d.type !== ${JSON.stringify(SNAPSHOT_REQUEST)}) return;
+    var images = [];
+    try {
+      var canvases = document.querySelectorAll('canvas');
+      for (var i = 0; i < canvases.length; i++) {
+        var c = canvases[i];
+        // Skip zero-area canvases (off-screen / not yet drawn).
+        if (!c.width || !c.height) continue;
+        try {
+          var rect = c.getBoundingClientRect();
+          images.push({
+            dataUrl: c.toDataURL('image/png'),
+            width: c.width,
+            height: c.height,
+            // On-screen CSS size, independent of devicePixelRatio scaling, so
+            // the pasted <img> renders at the chart's intended size rather than
+            // 2x on a retina display. Falls back to the pixel size.
+            cssWidth: Math.round(rect.width) || c.width,
+            cssHeight: Math.round(rect.height) || c.height
+          });
+        } catch (e) {
+          // Tainted canvas (cross-origin image drawn without CORS) — skip it;
+          // the host falls back to inlining the static HTML source.
+        }
+      }
+    } catch (e) {}
+    try {
+      parent.postMessage({
+        type: ${JSON.stringify(SNAPSHOT_RESULT)},
+        id: d.id,
+        images: images
+      }, '*');
+    } catch (e) {}
   });
   var lastSent = -1;
   function send(){
@@ -144,4 +226,64 @@ export async function copyText(text: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+export type SnapshotImage = {
+  dataUrl: string;
+  width: number;
+  height: number;
+  cssWidth: number;
+  cssHeight: number;
+};
+
+let snapshotSeq = 0;
+
+/**
+ * Ask a previewed HTML iframe to rasterize its own `<canvas>` elements and
+ * return them as PNG data URLs. The iframe is sandboxed without
+ * `allow-same-origin`, so the parent can't read its DOM — instead the injected
+ * reporter script (see `HEIGHT_REPORTER_SCRIPT`) does the `toDataURL` and posts
+ * the strings back. Resolves to `[]` if the iframe has no (usable) canvas or
+ * doesn't reply before `timeoutMs`.
+ */
+export function snapshotIframe(
+  iframe: HTMLIFrameElement,
+  timeoutMs = 1500
+): Promise<SnapshotImage[]> {
+  return new Promise((resolve) => {
+    const win = iframe.contentWindow;
+    if (!win || typeof window === 'undefined') {
+      resolve([]);
+      return;
+    }
+    const id = `snap-${++snapshotSeq}`;
+    let settled = false;
+
+    const finish = (images: SnapshotImage[]) => {
+      if (settled) return;
+      settled = true;
+      window.removeEventListener('message', onMessage);
+      clearTimeout(timer);
+      resolve(images);
+    };
+
+    const onMessage = (event: MessageEvent) => {
+      if (event.source !== win) return;
+      const data = event.data as {
+        type?: string;
+        id?: string;
+        images?: SnapshotImage[];
+      } | null;
+      if (!data || data.type !== SNAPSHOT_RESULT || data.id !== id) return;
+      finish(Array.isArray(data.images) ? data.images : []);
+    };
+
+    const timer = setTimeout(() => finish([]), timeoutMs);
+    window.addEventListener('message', onMessage);
+    try {
+      win.postMessage({ type: SNAPSHOT_REQUEST, id }, '*');
+    } catch {
+      finish([]);
+    }
+  });
 }

--- a/packages/chat-ui/src/shared/markdown/renderers/HtmlPreview.tsx
+++ b/packages/chat-ui/src/shared/markdown/renderers/HtmlPreview.tsx
@@ -12,19 +12,49 @@ type HtmlPreviewProps = {
   source: string;
 };
 
+// While a message streams in, react-markdown re-renders this component on every
+// token, so the `source` grows piece by piece. Reloading the iframe on each
+// change makes it measure (and lock in) a height against half-arrived HTML —
+// leaving a few-px-tall chart that only fixes itself on a manual refresh. We
+// debounce instead: the iframe only reloads once the source has been stable for
+// this long, so it renders and measures the *complete* document. An
+// already-complete message (history) renders immediately because the debounced
+// value is seeded from the first source.
+const STREAM_SETTLE_MS = 250;
+
 export function HtmlPreview({ source }: HtmlPreviewProps) {
   const [showingPreview, setShowingPreview] = useState(true);
   const [copyLabel, setCopyLabel] = useState<'Copy' | 'Copied' | 'Failed'>(
     'Copy'
   );
   const [iframeHeight, setIframeHeight] = useState<number | null>(null);
+  const [settledSource, setSettledSource] = useState(source);
+  // Whether the iframe for the *current* settled source has reported a height
+  // yet. Drives the loading overlay so we don't show a half-measured preview.
+  const [measured, setMeasured] = useState(false);
+
+  // Content is still arriving (debounce pending) or the settled document hasn't
+  // measured yet — show the loading shimmer instead of a partial/tiny preview.
+  const loading = showingPreview && (source !== settledSource || !measured);
 
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const rafIdRef = useRef<number | null>(null);
   const pendingHeightRef = useRef<number | null>(null);
   const copyResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const srcdoc = injectHeightReporter(source);
+  const srcdoc = injectHeightReporter(settledSource);
+
+  // Trailing-debounce the source feeding the iframe (see STREAM_SETTLE_MS).
+  useEffect(() => {
+    if (source === settledSource) return;
+    const id = setTimeout(() => setSettledSource(source), STREAM_SETTLE_MS);
+    return () => clearTimeout(id);
+  }, [source, settledSource]);
+
+  // A new settled document needs a fresh measurement before we trust its size.
+  useEffect(() => {
+    setMeasured(false);
+  }, [settledSource]);
 
   useEffect(() => {
     ensureGlobalListener();
@@ -43,6 +73,7 @@ export function HtmlPreview({ source }: HtmlPreviewProps) {
       pendingHeightRef.current = null;
       if (next <= 0) return;
       setIframeHeight(next);
+      setMeasured(true);
     };
 
     const scheduleHeight = (height: number) => {
@@ -140,18 +171,36 @@ export function HtmlPreview({ source }: HtmlPreviewProps) {
           </button>
         </div>
       </div>
-      <iframe
-        ref={iframeRef}
-        className="ss-code-block__iframe"
-        sandbox="allow-scripts"
-        loading="lazy"
-        title="HTML preview"
-        srcDoc={srcdoc}
+      <div
+        className="ss-code-block__preview"
         style={{
           display: showingPreview ? 'block' : 'none',
-          ...(iframeHeight != null ? { height: `${iframeHeight}px` } : {}),
+          ...(loading ? { minHeight: 180 } : {}),
         }}
-      />
+      >
+        {loading && (
+          <div className="ss-code-block__loading">
+            <div className="ss-code-block__spinner" />
+            <span>Rendering preview…</span>
+          </div>
+        )}
+        <iframe
+          ref={iframeRef}
+          className="ss-code-block__iframe"
+          sandbox="allow-scripts"
+          loading="lazy"
+          title="HTML preview"
+          srcDoc={srcdoc}
+          style={{
+            opacity: loading ? 0 : 1,
+            ...(loading
+              ? { position: 'absolute', inset: 0, height: '100%' }
+              : iframeHeight != null
+              ? { height: `${iframeHeight}px` }
+              : {}),
+          }}
+        />
+      </div>
       <pre
         data-language="html"
         style={{ display: showingPreview ? 'none' : 'block' }}

--- a/packages/chat-ui/src/shared/markdown/styles.css
+++ b/packages/chat-ui/src/shared/markdown/styles.css
@@ -280,6 +280,75 @@
   /* Kill the baseline gap under replaced elements (iframe is inline by
      default), which otherwise adds ~4px of empty space below the preview. */
   vertical-align: top;
+  /* Fade in once the rendered preview replaces the loading shimmer. */
+  transition: opacity 0.2s ease;
+}
+
+/* Loading state shown while the previewed HTML is still streaming in or the
+   iframe hasn't reported its measured height yet. Sits on a white backdrop so
+   there's no dark flash before a (white) chart appears, and is covered by an
+   absolutely-positioned shimmer so the box keeps a stable size. */
+.ss-markdown .ss-code-block__preview {
+  position: relative;
+}
+
+.ss-markdown .ss-code-block__loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  z-index: 1;
+  color: #6b7280;
+  font-size: 12px;
+  letter-spacing: 0.02em;
+  background-color: #ffffff;
+  background-image: linear-gradient(
+    100deg,
+    rgba(0, 0, 0, 0) 30%,
+    rgba(0, 0, 0, 0.05) 50%,
+    rgba(0, 0, 0, 0) 70%
+  );
+  background-size: 200% 100%;
+  animation: ss-code-block-shimmer 1.4s ease-in-out infinite;
+}
+
+.ss-markdown .ss-code-block__spinner {
+  width: 22px;
+  height: 22px;
+  border: 2.5px solid rgba(0, 0, 0, 0.12);
+  border-top-color: rgba(0, 0, 0, 0.5);
+  border-radius: 50%;
+  animation: ss-code-block-spin 0.8s linear infinite;
+}
+
+@keyframes ss-code-block-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes ss-code-block-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ss-markdown .ss-code-block__loading {
+    animation: none;
+  }
+  .ss-markdown .ss-code-block__spinner {
+    animation-duration: 1.6s;
+  }
+  .ss-markdown .ss-code-block__iframe {
+    transition: none;
+  }
 }
 
 /* Inline code in read-only messages — matches the Milkdown editor's

--- a/packages/chat-ui/src/styles.css
+++ b/packages/chat-ui/src/styles.css
@@ -423,6 +423,75 @@
   /* Kill the baseline gap under replaced elements (iframe is inline by
      default), which otherwise adds ~4px of empty space below the preview. */
   vertical-align: top;
+  /* Fade in once the rendered preview replaces the loading shimmer. */
+  transition: opacity 0.2s ease;
+}
+
+/* Loading state shown while the previewed HTML is still streaming in or the
+   iframe hasn't reported its measured height yet. Sits on a white backdrop so
+   there's no dark flash before a (white) chart appears, and is covered by an
+   absolutely-positioned shimmer so the box keeps a stable size. */
+.ss-markdown .ss-code-block__preview {
+  position: relative;
+}
+
+.ss-markdown .ss-code-block__loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  z-index: 1;
+  color: #6b7280;
+  font-size: 12px;
+  letter-spacing: 0.02em;
+  background-color: #ffffff;
+  background-image: linear-gradient(
+    100deg,
+    rgba(0, 0, 0, 0) 30%,
+    rgba(0, 0, 0, 0.05) 50%,
+    rgba(0, 0, 0, 0) 70%
+  );
+  background-size: 200% 100%;
+  animation: ss-code-block-shimmer 1.4s ease-in-out infinite;
+}
+
+.ss-markdown .ss-code-block__spinner {
+  width: 22px;
+  height: 22px;
+  border: 2.5px solid rgba(0, 0, 0, 0.12);
+  border-top-color: rgba(0, 0, 0, 0.5);
+  border-radius: 50%;
+  animation: ss-code-block-spin 0.8s linear infinite;
+}
+
+@keyframes ss-code-block-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes ss-code-block-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ss-markdown .ss-code-block__loading {
+    animation: none;
+  }
+  .ss-markdown .ss-code-block__spinner {
+    animation-duration: 1.6s;
+  }
+  .ss-markdown .ss-code-block__iframe {
+    transition: none;
+  }
 }
 
 /* Inline code in read-only messages — matches the Milkdown editor's


### PR DESCRIPTION
## What & why

The message **Copy** button copied joined plain text, so a chat message containing a client-side chart (Chart.js etc.) pasted into Word/Outlook/Docs as dead `<canvas>`/`<script>` source — Word has no JS engine to run it. This makes copy do the right thing in every paste target, and fixes a long-standing streaming glitch in the HTML preview along the way.

## Changes

**Smart copy** ([`smartCopy.ts`](packages/chat-ui/src/messages/smartCopy.ts), [`MessageCopyButton`](packages/chat-ui/src/messages/MessageCopyButton.tsx), [`MessageBubble`](packages/chat-ui/src/messages/MessageBubble.tsx)) — one click writes several clipboard representations at once:
- `text/html` with each chart **rasterized to an `<img>`** → pastes into Word/Docs/Outlook as a real image. Non-chart HTML blocks inline their static markup (tables paste as tables).
- `text/plain` (markdown) and `image/png` (single-chart) fallbacks.
- The **live markdown embedded as a hidden HTML comment marker**, so pasting back into the SmartSpace composer recovers the source and charts re-render instead of coming in as a flat image.

**Sandbox-safe rasterization** ([`htmlPreviewShared.ts`](packages/chat-ui/src/shared/markdown/htmlPreviewShared.ts)) — the preview iframe is `sandbox="allow-scripts"` with no `allow-same-origin`, so the parent can't read its canvas. The injected reporter script now rasterizes its own canvases via `toDataURL` and `postMessage`s the PNGs out.

**Composer round-trip** ([`MarkdownEditor.tsx`](packages/chat-ui/src/shared/markdown/MarkdownEditor.tsx)) — `onPasteCapture` recovers the markdown from the `text/html` marker and parses it into Milkdown. Reads from `text/html` (reliably exposed to the paste event) rather than a custom `web` format (which Chromium does **not** expose to sync paste), so it works in every browser.

**Streaming preview fix** ([`HtmlPreview.tsx`](packages/chat-ui/src/shared/markdown/renderers/HtmlPreview.tsx)) — the iframe used to reload on every streamed token and lock in a height measured against half-arrived HTML, leaving a few-px-tall chart until a manual refresh. It now trailing-debounces the source (renders the *complete* document once) and shows a **shimmer + spinner loading state** until measured, then fades the chart in. Respects `prefers-reduced-motion`.

## Notes
- CSS is applied to **both** `src/styles.css` (the inlined Tailwind build entry that produces `dist/index.css`) and `src/shared/markdown/styles.css`, because the package keeps two copies in sync — local `@import`s get dropped by the Tailwind v3 CLI. Worth a future cleanup.
- Graceful degradation throughout: no `ClipboardItem` → plain-text copy; tainted canvas (cross-origin image without CORS) → inline static source; non-Chromium → still round-trips via the HTML marker.

## Testing
Verified locally against the dev backend: chart copies into Word as an image; pastes back into the composer as a live re-rendering chart; streamed charts now render at full height without a refresh, with the loading shimmer in between.