### PR TITLE
feat(chat): surface LLM error codes and retry status in messages

### DIFF
--- a/packages/chat-ui/src/domains/messages/errors.ts
+++ b/packages/chat-ui/src/domains/messages/errors.ts
@@ -1,9 +1,63 @@
-export const getMessageErrorText = (code: number): string => {
-  switch (code) {
-    case 429:
-      return "⚠️**Rate Limit Exceeded**\n\nI'm receiving too many requests right now. Please wait a moment and try again.";
+/**
+ * User-facing text for message errors.
+ *
+ * The backend attaches a stable machine-readable category to LLM failures
+ * (`errorCode`, e.g. "llm.rate_limit") alongside the numeric HTTP `code`.
+ * Prefer the category — it distinguishes causes the HTTP code can't (a 400
+ * can be a content filter, a context-window blowout, or a malformed
+ * request), and it's the key a translation layer maps from. The numeric
+ * fallback keeps older messages and not-yet-upgraded backends readable.
+ */
 
-    default:
-      return '⚠️**Error**\n\nAn unexpected error occurred. Please try again.';
+const GENERIC_ERROR_TEXT =
+  '⚠️ **Error**\n\nAn unexpected error occurred. Please try again.';
+
+const ERROR_CODE_TEXT: Record<string, string> = {
+  'llm.rate_limit':
+    "⚠️ **The model is receiving too many requests**\n\nI'm being rate limited right now. Please wait a moment and try again.",
+  'llm.timeout':
+    '⚠️ **The model took too long to respond**\n\nPlease try again. If this keeps happening, try a shorter question.',
+  'llm.transient_connection':
+    '⚠️ **The connection to the model was interrupted**\n\nThis is usually temporary. Please try again.',
+  'llm.server_error':
+    '⚠️ **The model provider had a problem**\n\nPlease try again in a moment.',
+  'llm.auth':
+    "⚠️ **The model connection isn't authorised**\n\nAn administrator needs to check the model configuration.",
+  'llm.not_found':
+    '⚠️ **The model or deployment could not be found**\n\nAn administrator needs to check the model configuration.',
+  'llm.invalid_request':
+    '⚠️ **The request was rejected by the model provider**\n\nPlease try rephrasing your message.',
+  'llm.context_window':
+    '⚠️ **This conversation is too long for the model**\n\nPlease start a new thread, or ask a shorter question.',
+  'llm.content_policy':
+    '⚠️ **The response was blocked by a content filter**\n\nPlease rephrase your request.',
+  'llm.schema_validation':
+    '⚠️ **The model returned an invalid response**\n\nPlease try again.',
+  'llm.unknown': GENERIC_ERROR_TEXT,
+};
+
+const STATUS_CODE_TEXT: Record<number, string> = {
+  408: ERROR_CODE_TEXT['llm.timeout'],
+  429: ERROR_CODE_TEXT['llm.rate_limit'],
+  401: ERROR_CODE_TEXT['llm.auth'],
+  403: ERROR_CODE_TEXT['llm.auth'],
+  404: ERROR_CODE_TEXT['llm.not_found'],
+  500: ERROR_CODE_TEXT['llm.server_error'],
+  502: ERROR_CODE_TEXT['llm.server_error'],
+  503: ERROR_CODE_TEXT['llm.transient_connection'],
+  504: ERROR_CODE_TEXT['llm.timeout'],
+};
+
+export type MessageErrorLike =
+  | number
+  | { code: number; errorCode?: string | null };
+
+export const getMessageErrorText = (error: MessageErrorLike): string => {
+  if (typeof error === 'number') {
+    return STATUS_CODE_TEXT[error] ?? GENERIC_ERROR_TEXT;
   }
+  if (error.errorCode && ERROR_CODE_TEXT[error.errorCode]) {
+    return ERROR_CODE_TEXT[error.errorCode];
+  }
+  return STATUS_CODE_TEXT[error.code] ?? GENERIC_ERROR_TEXT;
 };

--- a/packages/chat-ui/src/domains/messages/mapper.ts
+++ b/packages/chat-ui/src/domains/messages/mapper.ts
@@ -13,7 +13,13 @@ const {
 type MessagesResponseDto = z.infer<typeof messagesResponseSchema>;
 type MessageDto = MessagesResponseDto['data'][number];
 type MessageValueDto = NonNullable<MessageDto['values']>[number];
-type MessageErrorDto = NonNullable<MessageDto['errors']>[number];
+// The generated api-client schema doesn't carry the machine-readable error
+// category yet — callers re-attach it from the raw payload (either spelling)
+// before mapping, so the field survives api-client regeneration lag.
+type MessageErrorDto = NonNullable<MessageDto['errors']>[number] & {
+  errorCode?: string | null;
+  error_code?: string | null;
+};
 
 export type MessageError = NonNullable<Message['errors']>[number];
 
@@ -47,8 +53,10 @@ export function mapMessageValueDtoToModel(dto: MessageValueDto): MessageValue {
 }
 
 export function mapMessageErrorDtoToModel(dto: MessageErrorDto): MessageError {
+  const { error_code, ...rest } = dto;
   return {
-    ...dto,
+    ...rest,
+    errorCode: dto.errorCode ?? error_code ?? undefined,
     data: dto.data as string | null | undefined,
   };
 }

--- a/packages/chat-ui/src/domains/messages/model.ts
+++ b/packages/chat-ui/src/domains/messages/model.ts
@@ -28,6 +28,12 @@ export type Message = {
   errors?:
     | {
         code: number;
+        /**
+         * Stable machine-readable category from the backend (e.g.
+         * "llm.rate_limit", "llm.context_window") — preferred over the
+         * numeric HTTP code for user-facing/localised error text.
+         */
+        errorCode?: string | null;
         message?: string | null;
         data?: string | null;
         blockId?: string | null;

--- a/packages/chat-ui/src/domains/messages/schemas.ts
+++ b/packages/chat-ui/src/domains/messages/schemas.ts
@@ -31,6 +31,11 @@ export const MessageResponseSchema = z.object({
 
 export const MessageErrorMessageSchema = z.object({
   code: z.number(),
+  // Stable machine-readable category (e.g. "llm.rate_limit"). Accept both
+  // spellings: app-api serialises camelCase, the ai-api origin field is
+  // snake_case — the mapper coalesces them.
+  errorCode: z.string().nullish(),
+  error_code: z.string().nullish(),
   message: z.string().nullish(),
   data: z.string().nullish(),
   blockId: z.string().nullish(),

--- a/packages/chat-ui/src/domains/messages/statuses.ts
+++ b/packages/chat-ui/src/domains/messages/statuses.ts
@@ -1,0 +1,84 @@
+/**
+ * Structured transient statuses carried on a message's `status` value.
+ *
+ * Historically the `status` value is a plain string rendered verbatim in the
+ * transient status bubble. The backend's LLM retry loop additionally emits a
+ * structured payload — `{"type": "retry", attempt, max_attempts,
+ * delay_seconds, error_code}` — so the UI can say *why* the response is
+ * paused instead of freezing silently through a backoff wait. Anything that
+ * doesn't parse as a known structured status falls back to today's
+ * plain-string behaviour.
+ */
+
+export type RetryStatus = {
+  type: 'retry';
+  attempt: number;
+  maxAttempts: number;
+  delaySeconds?: number;
+  errorCode?: string;
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | null => {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value === 'string' && value.trimStart().startsWith('{')) {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      return asRecord(parsed);
+    } catch {
+      return null;
+    }
+  }
+  return null;
+};
+
+const asNumber = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+
+/**
+ * Parse a `status` value into a RetryStatus, or null when it's not one.
+ * Accepts both camelCase and snake_case field spellings (the payload
+ * originates in the Python ai-api and may be relayed verbatim).
+ */
+export const parseRetryStatus = (value: unknown): RetryStatus | null => {
+  const record = asRecord(value);
+  if (!record || record['type'] !== 'retry') return null;
+
+  const attempt = asNumber(record['attempt']);
+  const maxAttempts =
+    asNumber(record['maxAttempts']) ?? asNumber(record['max_attempts']);
+  if (attempt === undefined || maxAttempts === undefined) return null;
+
+  const delaySeconds =
+    asNumber(record['delaySeconds']) ?? asNumber(record['delay_seconds']);
+  const rawErrorCode = record['errorCode'] ?? record['error_code'];
+
+  return {
+    type: 'retry',
+    attempt,
+    maxAttempts,
+    delaySeconds,
+    errorCode: typeof rawErrorCode === 'string' ? rawErrorCode : undefined,
+  };
+};
+
+const RETRY_REASON_TEXT: Record<string, string> = {
+  'llm.rate_limit': 'the model is busy',
+  'llm.timeout': 'the model took too long',
+  'llm.transient_connection': 'the connection dropped',
+  'llm.server_error': 'the model provider had a problem',
+};
+
+export const getRetryStatusText = (status: RetryStatus): string => {
+  const reason = status.errorCode
+    ? RETRY_REASON_TEXT[status.errorCode]
+    : undefined;
+  const waiting =
+    status.delaySeconds && status.delaySeconds >= 1
+      ? ` (waiting ~${Math.round(status.delaySeconds)}s)`
+      : '';
+  return `${
+    reason ? `Hit a snag — ${reason}. ` : 'Hit a snag. '
+  }Retrying, attempt ${status.attempt + 1} of ${status.maxAttempts}${waiting}…`;
+};

--- a/packages/chat-ui/src/index.ts
+++ b/packages/chat-ui/src/index.ts
@@ -58,6 +58,17 @@ export {
   mapMessagesDtoToModels,
   type MessageError,
 } from './domains/messages/mapper';
+// Error/status text helpers — exported so forks can override copy and tests
+// can pin the error-code contract with the backend.
+export {
+  getMessageErrorText,
+  type MessageErrorLike,
+} from './domains/messages/errors';
+export {
+  getRetryStatusText,
+  parseRetryStatus,
+  type RetryStatus,
+} from './domains/messages/statuses';
 export { mapFileInfoDtoToModel } from './domains/files/mapper';
 export {
   mapSignalRThreadSummaryToModel,

--- a/packages/chat-ui/src/messages/MessageItem.tsx
+++ b/packages/chat-ui/src/messages/MessageItem.tsx
@@ -8,6 +8,10 @@ import { FileInfo } from '@/domains/files';
 import { Message, MessageContentItem } from '@/domains/messages';
 import { MessageValueType } from '@/domains/messages/enums';
 import { getMessageErrorText } from '@/domains/messages/errors';
+import {
+  getRetryStatusText,
+  parseRetryStatus,
+} from '@/domains/messages/statuses';
 import { useAddInputToMessage } from '@/domains/messages/mutations';
 import { useWorkspace } from '@/domains/workspaces';
 
@@ -197,10 +201,17 @@ export const MessageItem: FC<MessageItemProps> = ({
       }
       case 'status': {
         if (groupOpen) flush(v.type);
+        // Structured statuses (e.g. the LLM retry loop's backoff notice)
+        // render a human sentence; plain strings render verbatim as before.
+        const retryStatus = parseRetryStatus(v.value);
         lastStatusNode = (
           <MessageStatus
             key={`status-${message.id ?? 'msg'}-${keyCounter++}`}
-            text={String(v.value ?? '')}
+            text={
+              retryStatus
+                ? getRetryStatusText(retryStatus)
+                : String(v.value ?? '')
+            }
           />
         );
         continue;
@@ -339,11 +350,11 @@ export const MessageItem: FC<MessageItemProps> = ({
   for (const error of message.errors ?? []) {
     bubbles.push(
       <MessageBubble
-        key={`error-${message.id ?? 'msg'}-${error.code}`}
+        key={`error-${message.id ?? 'msg'}-${error.errorCode ?? error.code}`}
         createdBy={chatbotName}
         createdAt={message.createdAt}
         type={MessageValueType.OUTPUT}
-        content={[{ text: getMessageErrorText(error.code) }]}
+        content={[{ text: getMessageErrorText(error) }]}
         files={[]}
         sources={[]}
         chatbotName={chatbotName}

--- a/src/domains/messages/__tests__/llmErrorSurface.spec.ts
+++ b/src/domains/messages/__tests__/llmErrorSurface.spec.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getMessageErrorText,
+  getRetryStatusText,
+  mapMessageErrorDtoToModel,
+  parseRetryStatus,
+} from '@smartspace/chat-ui';
+
+import { preserveErrorCodes, rawErrorCode } from '../service';
+
+// Pins the error/status contract with the backend LLM reliability work:
+// errors carry a stable machine-readable category (errorCode, e.g.
+// "llm.rate_limit") alongside the numeric HTTP code, and the retry loop
+// emits a structured status payload during backoff waits.
+
+describe('getMessageErrorText', () => {
+  it('prefers the machine-readable error code over the HTTP code', () => {
+    const text = getMessageErrorText({
+      code: 400,
+      errorCode: 'llm.context_window',
+    });
+    expect(text).toContain('too long for the model');
+  });
+
+  it.each([
+    ['llm.rate_limit', 'too many requests'],
+    ['llm.timeout', 'took too long'],
+    ['llm.transient_connection', 'interrupted'],
+    ['llm.server_error', 'provider had a problem'],
+    ['llm.auth', "isn't authorised"],
+    ['llm.not_found', 'could not be found'],
+    ['llm.invalid_request', 'rejected'],
+    ['llm.content_policy', 'content filter'],
+    ['llm.schema_validation', 'invalid response'],
+  ])('has a specific message for %s', (errorCode, fragment) => {
+    expect(getMessageErrorText({ code: 500, errorCode })).toContain(fragment);
+  });
+
+  it('falls back to the HTTP code when the error code is unknown', () => {
+    const text = getMessageErrorText({
+      code: 429,
+      errorCode: 'llm.something_new',
+    });
+    expect(text).toContain('too many requests');
+  });
+
+  it('maps bare HTTP codes for older messages (back-compat)', () => {
+    expect(getMessageErrorText(429)).toContain('too many requests');
+    expect(getMessageErrorText({ code: 503 })).toContain('interrupted');
+    expect(getMessageErrorText({ code: 418 })).toContain('unexpected error');
+  });
+});
+
+describe('parseRetryStatus', () => {
+  it('parses the backend retry payload (snake_case, as emitted by ai-api)', () => {
+    const status = parseRetryStatus({
+      type: 'retry',
+      attempt: 1,
+      max_attempts: 3,
+      delay_seconds: 7.5,
+      error_code: 'llm.rate_limit',
+    });
+    expect(status).toEqual({
+      type: 'retry',
+      attempt: 1,
+      maxAttempts: 3,
+      delaySeconds: 7.5,
+      errorCode: 'llm.rate_limit',
+    });
+  });
+
+  it('parses camelCase and JSON-string payloads', () => {
+    const camel = parseRetryStatus({
+      type: 'retry',
+      attempt: 2,
+      maxAttempts: 3,
+    });
+    expect(camel?.attempt).toBe(2);
+
+    const fromString = parseRetryStatus(
+      JSON.stringify({ type: 'retry', attempt: 1, max_attempts: 3 })
+    );
+    expect(fromString?.maxAttempts).toBe(3);
+  });
+
+  it('returns null for plain-string statuses and unknown shapes', () => {
+    expect(parseRetryStatus('Searching documents…')).toBeNull();
+    expect(parseRetryStatus(null)).toBeNull();
+    expect(parseRetryStatus({ type: 'retry' })).toBeNull(); // missing counts
+    expect(parseRetryStatus({ type: 'other', attempt: 1 })).toBeNull();
+  });
+});
+
+describe('getRetryStatusText', () => {
+  it('describes the retry in progress with reason and wait', () => {
+    const text = getRetryStatusText({
+      type: 'retry',
+      attempt: 1,
+      maxAttempts: 3,
+      delaySeconds: 8,
+      errorCode: 'llm.rate_limit',
+    });
+    expect(text).toContain('the model is busy');
+    expect(text).toContain('attempt 2 of 3');
+    expect(text).toContain('~8s');
+  });
+
+  it('stays readable without optional fields', () => {
+    const text = getRetryStatusText({
+      type: 'retry',
+      attempt: 2,
+      maxAttempts: 3,
+    });
+    expect(text).toContain('attempt 3 of 3');
+    expect(text).not.toContain('~');
+  });
+});
+
+describe('mapMessageErrorDtoToModel', () => {
+  it('coalesces snake_case error_code into errorCode', () => {
+    const model = mapMessageErrorDtoToModel({
+      code: 503,
+      error_code: 'llm.transient_connection',
+    } as never);
+    expect(model.errorCode).toBe('llm.transient_connection');
+    expect('error_code' in model).toBe(false);
+  });
+
+  it('keeps errors without any code working (back-compat)', () => {
+    const model = mapMessageErrorDtoToModel({ code: 500 } as never);
+    expect(model.errorCode).toBeUndefined();
+    expect(model.code).toBe(500);
+  });
+});
+
+describe('preserveErrorCodes', () => {
+  // The generated api-client zod schema strips unknown fields — these
+  // helpers re-attach the machine-readable category from the raw payload.
+  it('copies errorCode from raw errors onto the parsed DTO by index', () => {
+    const raw = {
+      errors: [
+        { code: 503, error_code: 'llm.transient_connection' },
+        { code: 429, errorCode: 'llm.rate_limit' },
+      ],
+    };
+    const parsed = { errors: [{ code: 503 }, { code: 429 }] };
+    preserveErrorCodes(raw, parsed);
+    expect(parsed.errors).toEqual([
+      { code: 503, errorCode: 'llm.transient_connection' },
+      { code: 429, errorCode: 'llm.rate_limit' },
+    ]);
+  });
+
+  it('is a no-op without raw errors or parsed errors', () => {
+    const parsed = { errors: [{ code: 500 }] };
+    preserveErrorCodes({}, parsed);
+    expect(parsed.errors).toEqual([{ code: 500 }]);
+    expect(preserveErrorCodes(null, { errors: null }).errors).toBeNull();
+  });
+
+  it('rawErrorCode accepts both spellings and rejects non-strings', () => {
+    expect(rawErrorCode({ error_code: 'llm.timeout' })).toBe('llm.timeout');
+    expect(rawErrorCode({ errorCode: 'llm.auth' })).toBe('llm.auth');
+    expect(rawErrorCode({ errorCode: 42 })).toBeUndefined();
+    expect(rawErrorCode('nope')).toBeUndefined();
+  });
+});

--- a/src/domains/messages/service.ts
+++ b/src/domains/messages/service.ts
@@ -41,6 +41,46 @@ export function coerceMessageDto(raw: Record<string, unknown>): void {
   }
 }
 
+/**
+ * The generated api-client schema doesn't know the machine-readable error
+ * category (`errorCode`, e.g. "llm.rate_limit") yet, so zod strips it at
+ * parse time. Pull it off the raw payload (either spelling — the field
+ * originates in the Python ai-api) so the UI can map codes to friendly text
+ * without waiting on an api-client regeneration.
+ */
+export function rawErrorCode(raw: unknown): string | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const record = raw as Record<string, unknown>;
+  const value = record['errorCode'] ?? record['error_code'];
+  return typeof value === 'string' ? value : undefined;
+}
+
+/**
+ * Copy machine-readable error codes from a raw message payload back onto the
+ * zod-parsed message DTO (index-aligned — zod preserves array order).
+ */
+export function preserveErrorCodes<
+  T extends { errors?: unknown[] | null | undefined }
+>(raw: unknown, parsed: T): T {
+  const rawErrors =
+    raw && typeof raw === 'object'
+      ? (raw as Record<string, unknown>)['errors']
+      : undefined;
+  if (!Array.isArray(rawErrors) || !parsed.errors?.length) return parsed;
+  parsed.errors.forEach((err, i) => {
+    const code = rawErrorCode(rawErrors[i]);
+    if (
+      code &&
+      err &&
+      typeof err === 'object' &&
+      (err as { errorCode?: unknown }).errorCode == null
+    ) {
+      (err as { errorCode?: string }).errorCode = code;
+    }
+  });
+  return parsed;
+}
+
 // Fetch all messages in a given message thread
 export async function fetchMessages(
   threadId: string,
@@ -55,6 +95,8 @@ export async function fetchMessages(
     response.data,
     `GET /messageThreads/${threadId}/messages`
   );
+  const rawData = (response.data as { data?: unknown[] } | null)?.data;
+  parsed.data.forEach((m, i) => preserveErrorCodes(rawData?.[i], m));
   return mapMessagesDtoToModels(parsed.data);
 }
 
@@ -99,7 +141,9 @@ export async function addInputToMessage({
     try {
       const parsed = JSON.parse(frame.data) as Record<string, unknown>;
       coerceMessageDto(parsed);
-      last = mapMessageDtoToModel(messageDtoSchema.parse(parsed));
+      last = mapMessageDtoToModel(
+        preserveErrorCodes(parsed, messageDtoSchema.parse(parsed))
+      );
     } catch {
       // Ignore malformed/partial frames; the next frame will bring fresh state.
     }
@@ -192,7 +236,10 @@ export async function postMessage({
   if (!raw) throw new Error('POST /Messages/start returned no body');
   coerceMessageDto(raw);
   return mapMessageDtoToModel(
-    messagesResponseSchema.shape.data.element.parse(raw)
+    preserveErrorCodes(
+      raw,
+      messagesResponseSchema.shape.data.element.parse(raw)
+    )
   );
 }
 
@@ -306,7 +353,9 @@ export async function streamThreadMessages({
         const messages = envelope.snapshot.map((raw) => {
           const obj = raw as Record<string, unknown>;
           coerceMessageDto(obj);
-          return mapMessageDtoToModel(messageDtoSchema.parse(obj));
+          return mapMessageDtoToModel(
+            preserveErrorCodes(obj, messageDtoSchema.parse(obj))
+          );
         });
         onSnapshot(messages);
         continue;
@@ -316,7 +365,9 @@ export async function streamThreadMessages({
       if (envelope.messageId && envelope.message) {
         const raw = envelope.message as Record<string, unknown>;
         coerceMessageDto(raw);
-        const message = mapMessageDtoToModel(messageDtoSchema.parse(raw));
+        const message = mapMessageDtoToModel(
+          preserveErrorCodes(raw, messageDtoSchema.parse(raw))
+        );
         onMessage(envelope.messageId, message, terminal);
         continue;
       }
@@ -331,7 +382,10 @@ export async function streamThreadMessages({
           return mapMessageValueDtoToModel(valueDtoSchema.parse(obj));
         });
         const errors = (envelope.delta.errors ?? []).map((raw) =>
-          mapMessageErrorDtoToModel(errorDtoSchema.parse(raw))
+          mapMessageErrorDtoToModel({
+            ...errorDtoSchema.parse(raw),
+            errorCode: rawErrorCode(raw),
+          })
         );
         onDelta(targetId, { outputs, errors }, terminal);
       }


### PR DESCRIPTION
## Why
Companion to the backend LLM reliability work in Smartspace-ai-api (#772 telemetry, #780 retries — with PR B/C to follow): LLM failures now carry a **stable machine-readable category** (`errorCode`, e.g. `llm.rate_limit`) alongside the numeric HTTP code, and the retry loop emits a **structured status payload** during backoff waits (`{"type": "retry", attempt, max_attempts, delay_seconds, error_code}`). Today the UI shows a specific message only for 429 and freezes silently through retry waits.

## What
**Error text by code** (`getMessageErrorText`)
- Maps the full backend vocabulary — `rate_limit`, `timeout`, `transient_connection`, `server_error`, `auth`, `not_found`, `invalid_request`, `context_window`, `content_policy`, `schema_validation` — to specific, actionable messages (e.g. context_window → "This conversation is too long for the model — start a new thread").
- Expanded HTTP-status fallback: 503/408/5xx/401/404 now read sensibly **immediately**, even before the backend sends categories (previously everything except 429 was "An unexpected error occurred").

**Retry status** (`parseRetryStatus` / `getRetryStatusText`)
- The existing transient status bubble now understands the structured retry payload (either field casing, object or JSON string) and renders *"Hit a snag — the model is busy. Retrying, attempt 2 of 3 (waiting ~8s)…"* instead of freezing. Plain-string statuses render verbatim as before; unknown shapes fall back safely.

**Contract resilience**
- The generated api-client zod schema doesn't know `errorCode` yet and strips unknown fields, so the service **re-attaches it from the raw payload at every parse site** (list fetch, SSE snapshot/full-message/delta, input stream). The UI lights up the moment the backend sends the field — no api-client regeneration required, and no breakage if it never arrives.
- New helpers exported from `@smartspace/chat-ui` so forks (Spencers-Ui etc.) can override copy and tests can pin the contract.

## Backend contract (for reference)
- Error: `errors[]` entries gain `errorCode: "llm.<category>"` (ai-api WS1 PR C + app-api DTO passthrough).
- Retry: a `status` message value carrying `{"type": "retry", "attempt": 1, "max_attempts": 3, "delay_seconds": 8, "error_code": "llm.rate_limit"}` (ai-api WS1 PR B forwards the seam's existing retry events through the status channel).

## Verified
22 new tests (`llmErrorSurface.spec.ts`) pinning the vocabulary, retry parsing (both casings, JSON-string, malformed), text rendering, and the raw-payload preservation helpers. Full suite: 254/254, typecheck + lint clean.