### PR TITLE
feat(chat): friendly message for llm.unsupported_modality errors

### DIFF
--- a/packages/chat-ui/src/domains/messages/errors.ts
+++ b/packages/chat-ui/src/domains/messages/errors.ts
@@ -33,6 +33,8 @@ const ERROR_CODE_TEXT: Record<string, string> = {
     '⚠️ **The response was blocked by a content filter**\n\nPlease rephrase your request.',
   'llm.schema_validation':
     '⚠️ **The model returned an invalid response**\n\nPlease try again.',
+  'llm.unsupported_modality':
+    "⚠️ **This model can't read images**\n\nSwitch to a vision-capable model, or remove the attachment and describe it instead.",
   'llm.unknown': GENERIC_ERROR_TEXT,
 };
 

--- a/src/domains/messages/__tests__/llmErrorSurface.spec.ts
+++ b/src/domains/messages/__tests__/llmErrorSurface.spec.ts
@@ -33,6 +33,7 @@ describe('getMessageErrorText', () => {
     ['llm.invalid_request', 'rejected'],
     ['llm.content_policy', 'content filter'],
     ['llm.schema_validation', 'invalid response'],
+    ['llm.unsupported_modality', "can't read images"],
   ])('has a specific message for %s', (errorCode, fragment) => {
     expect(getMessageErrorText({ code: 500, errorCode })).toContain(fragment);
   });


### PR DESCRIPTION
Companion to Smartspace-ai-api #787 (WS3b PR E — vision gate): image requests to models known to lack vision now fail with `errorCode: "llm.unsupported_modality"`. This adds the mapped bubble text — *"This model can't read images — switch to a vision-capable model, or remove the attachment and describe it instead."* — plus the contract test row. One string, zero behaviour change otherwise; unknown codes still fall back as before.