### PR TITLE
refactor(chat): rename error code llm.server_error → llm.upstream_error

### DIFF
--- a/packages/chat-ui/src/domains/messages/errors.ts
+++ b/packages/chat-ui/src/domains/messages/errors.ts
@@ -19,7 +19,7 @@ const ERROR_CODE_TEXT: Record<string, string> = {
     '⚠️ **The model took too long to respond**\n\nPlease try again. If this keeps happening, try a shorter question.',
   'llm.transient_connection':
     '⚠️ **The connection to the model was interrupted**\n\nThis is usually temporary. Please try again.',
-  'llm.server_error':
+  'llm.upstream_error':
     '⚠️ **The model provider had a problem**\n\nPlease try again in a moment.',
   'llm.auth':
     "⚠️ **The model connection isn't authorised**\n\nAn administrator needs to check the model configuration.",
@@ -42,8 +42,8 @@ const STATUS_CODE_TEXT: Record<number, string> = {
   401: ERROR_CODE_TEXT['llm.auth'],
   403: ERROR_CODE_TEXT['llm.auth'],
   404: ERROR_CODE_TEXT['llm.not_found'],
-  500: ERROR_CODE_TEXT['llm.server_error'],
-  502: ERROR_CODE_TEXT['llm.server_error'],
+  500: ERROR_CODE_TEXT['llm.upstream_error'],
+  502: ERROR_CODE_TEXT['llm.upstream_error'],
   503: ERROR_CODE_TEXT['llm.transient_connection'],
   504: ERROR_CODE_TEXT['llm.timeout'],
 };

--- a/src/domains/messages/__tests__/llmErrorSurface.spec.ts
+++ b/src/domains/messages/__tests__/llmErrorSurface.spec.ts
@@ -27,7 +27,7 @@ describe('getMessageErrorText', () => {
     ['llm.rate_limit', 'too many requests'],
     ['llm.timeout', 'took too long'],
     ['llm.transient_connection', 'interrupted'],
-    ['llm.server_error', 'provider had a problem'],
+    ['llm.upstream_error', 'provider had a problem'],
     ['llm.auth', "isn't authorised"],
     ['llm.not_found', 'could not be found'],
     ['llm.invalid_request', 'rejected'],


### PR DESCRIPTION
Companion to Smartspace-ai-api #790 (error-vocabulary reconciliation with the intelligence-layer operation contract, done on merit while both sides are unreleased). Map key + contract test row renamed; the HTTP-status fallbacks (500/502) now point at the renamed text. No behaviour change otherwise — unknown codes still fall back to the HTTP-status map, so mixed-version windows degrade gracefully.