### PR TITLE
feat(chat-ui): show citation attribution — flag unverified sources

### DIFF
--- a/packages/chat-ui/src/domains/messages/enums.ts
+++ b/packages/chat-ui/src/domains/messages/enums.ts
@@ -9,3 +9,11 @@ export enum MessageResponseSourceType {
   File = 'File',
   URL = 'URL',
 }
+
+// How well a citation's source text backs the model's claim (WS3c, AIS
+// vocabulary). Absent on responses from before citation verification shipped.
+export enum MessageAttribution {
+  Supported = 'supported',
+  Partial = 'partial',
+  Unsupported = 'unsupported',
+}

--- a/packages/chat-ui/src/domains/messages/schemas.ts
+++ b/packages/chat-ui/src/domains/messages/schemas.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import {
+  MessageAttribution,
   MessageResponseSourceType,
   MessageValueType,
 } from '@/domains/messages/enums';
@@ -18,6 +19,10 @@ export const MessageResponseSourceSchema = z.object({
   file: FileInfoSchema.nullish(),
   url: z.string().nullish(),
   sourceType: z.nativeEnum(MessageResponseSourceType),
+  // WS3c citation grounding (additive; absent on older responses).
+  uri: z.string().nullish(),
+  citedText: z.string().nullish(),
+  attribution: z.nativeEnum(MessageAttribution).nullish(),
 });
 
 // MessageResponse schema

--- a/packages/chat-ui/src/messages/MessageSources.tsx
+++ b/packages/chat-ui/src/messages/MessageSources.tsx
@@ -9,13 +9,17 @@ import {
   FileText,
   FileVideo,
   Presentation,
+  ShieldAlert,
 } from 'lucide-react';
 import { useState } from 'react';
 
 import { useChatContext } from '@/platform/chat';
 
 import { useFileMutations } from '@/domains/files/mutations';
-import { MessageResponseSourceType } from '@/domains/messages/enums';
+import {
+  MessageAttribution,
+  MessageResponseSourceType,
+} from '@/domains/messages/enums';
 // Keeping this component generic; adjust type if needed in the future
 
 import { cn } from '@/shared/utils/utils';
@@ -28,6 +32,9 @@ export type MessageResponseSource = {
   file?: { id: string; name: string } | null;
   url?: string | null;
   sourceType: MessageResponseSourceType;
+  uri?: string | null;
+  citedText?: string | null;
+  attribution?: MessageAttribution | null;
 };
 
 // Utility function to get file type icon (mirrors Spencers-Ui behavior)
@@ -136,6 +143,33 @@ function isLinkSource(s: MessageResponseSource): boolean {
   );
 }
 
+// The source text couldn't be found to back the model's claim — surface it so
+// the reader knows to double-check. Only the clear signal is flagged;
+// `supported`/`partial` (and older responses with no attribution) stay quiet.
+function UnverifiedBadge({
+  attribution,
+}: {
+  attribution?: MessageAttribution | null;
+}) {
+  if (attribution !== MessageAttribution.Unsupported) return null;
+  return (
+    <span
+      title="This citation couldn't be verified against the source text — double-check it."
+      className="inline-flex items-center gap-0.5 rounded px-1 py-px text-[10px] font-medium text-amber-600 dark:text-amber-400 bg-amber-500/10 flex-shrink-0"
+    >
+      <ShieldAlert className="h-3 w-3" />
+      Unverified
+    </span>
+  );
+}
+
+// Hover reveals the exact span the model cited from the source (when verified).
+function nameTitle(source: MessageResponseSource, displayName: string): string {
+  return source.citedText
+    ? `${displayName} — “${source.citedText}”`
+    : displayName;
+}
+
 export function ChatMessageSources({
   sources,
 }: {
@@ -197,13 +231,14 @@ export function ChatMessageSources({
                     )}
                     <button
                       type="button"
-                      title={displayName}
+                      title={nameTitle(source, displayName)}
                       onClick={() => downloadFileMutation.mutate(source.file)}
                       className="text-foreground hover:bg-muted/50 rounded px-1 py-0.5 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                       disabled={downloadFileMutation.isPending}
                     >
                       {displayName}
                     </button>
+                    <UnverifiedBadge attribution={source.attribution} />
                   </li>
                 );
               }
@@ -220,7 +255,7 @@ export function ChatMessageSources({
                   <ExternalLink className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
                   {safeHref ? (
                     <a
-                      title={source.url ?? displayName}
+                      title={nameTitle(source, source.url ?? displayName)}
                       href={safeHref}
                       target="_blank"
                       rel="noreferrer"
@@ -233,6 +268,7 @@ export function ChatMessageSources({
                       {displayName}
                     </span>
                   )}
+                  <UnverifiedBadge attribution={source.attribution} />
                 </li>
               );
             })}


### PR DESCRIPTION
Companion to the ai-api WS3c **R2** citation-attribution PR ([Smartspace-ai-api#801](https://github.com/Smartspace-ai/Smartspace-ai-api/pull/801)). The API now returns each source with a server-verified `citedText` span and an `attribution` status; this surfaces it in the chat UI.

## What the reader sees
- An **"Unverified"** badge (amber, `ShieldAlert`) on any source whose `attribution` is `unsupported` — meaning the model's cited quote could **not** be found in the source text (a possible fabrication). This is the one actionable signal, so it's the only one flagged.
- `supported` and `partial` citations — and any response from **before** verification shipped (no `attribution`) — render exactly as today. No new noise.
- Hovering a source reveals the exact **verified span** the model cited (`citedText`) as a tooltip.

## Changes
- `domains/messages/enums.ts` — new `MessageAttribution` enum (supported/partial/unsupported).
- `domains/messages/schemas.ts` — additive `uri`, `citedText`, `attribution` on the source schema (all `nullish`, so old payloads validate unchanged).
- `messages/MessageSources.tsx` — `UnverifiedBadge` (renders only for `unsupported`) + the `citedText` hover tooltip.

## Safety / compatibility
- Fully additive and backward-compatible: sources without `attribution` (older API, or citations that predate R2) behave exactly as before.
- Lives in the shared `chat-ui` package, so it flows to the app and forks (e.g. Spencers-Ui) consistently.
- Warning uses amber (caution), not `destructive` (error) — an unverified citation isn't an error, just something to double-check. Dark-mode contrast handled.

## Verification
- `chat-ui` typecheck clean; package build clean; the amber utilities generate into the published `dist` CSS. Pre-commit prettier + eslint clean.

Merge after ai-api #801 (the fields are additive, so order isn't strictly required, but the affordance only lights up once the API sends `attribution`).