### PR TITLE
chore: add .nxignore to exclude Claude worktrees from Nx

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -1,0 +1,1 @@
+.claude/worktrees


### PR DESCRIPTION
## Summary
- Adds `.nxignore` with `.claude/worktrees` so Nx doesn't scan Claude Code agent worktrees when building its project graph.

## Context
`.claude/` is already gitignored (so the worktrees never reach git), but Nx walks the filesystem independently of git and can pick up nested copies of the workspace inside `.claude/worktrees/`, which slows graph computation and can cause duplicate-project errors.

## Test plan
- `pnpm run build` / any `nx` command still works with a worktree present under `.claude/worktrees/`