### PR TITLE
Restyle message sources: compact pills grouped by kind, expand for detail

### DIFF
--- a/packages/chat-ui/src/messages/MessageSources.tsx
+++ b/packages/chat-ui/src/messages/MessageSources.tsx
@@ -117,7 +117,7 @@ function getSafeUrl(url: string): string | null {
   }
 }
 
-// The hostname is the source's identity; the full URL stays in the tooltip.
+// The hostname is the source's identity; the full URL shows when expanded.
 function getHost(url: string): string {
   try {
     return new URL(url).hostname.replace(/^www\./, '');
@@ -143,19 +143,25 @@ function isLinkSource(s: MessageResponseSource): boolean {
 // The source text couldn't be found to back the model's claim — surface it so
 // the reader knows to double-check. Only the clear signal is flagged;
 // `supported`/`partial` (and older responses with no attribution) stay quiet.
+// `compact` collapses it to just the icon for the pill state.
 function UnverifiedBadge({
   attribution,
+  compact = false,
 }: {
   attribution?: MessageAttribution | null;
+  compact?: boolean;
 }) {
   if (attribution !== MessageAttribution.Unsupported) return null;
   return (
     <span
       title="This citation couldn't be verified against the source text — double-check it."
-      className="inline-flex items-center gap-0.5 rounded px-1 py-px text-[10px] font-medium text-amber-600 dark:text-amber-400 bg-amber-500/10 flex-shrink-0"
+      className={cn(
+        'inline-flex items-center gap-0.5 rounded text-[10px] font-medium text-amber-600 dark:text-amber-400 flex-shrink-0',
+        !compact && 'px-1 py-px bg-amber-500/10'
+      )}
     >
       <ShieldAlert className="h-3 w-3" />
-      Unverified
+      {!compact && 'Unverified'}
     </span>
   );
 }
@@ -174,65 +180,47 @@ function IndexChip({ index }: { index: number }) {
 // for unknown domains, and any load failure drops to the Globe icon.
 function SourceFavicon({ host }: { host: string }) {
   const [failed, setFailed] = useState(false);
+  if (failed) {
+    return <Globe className="h-4 w-4 flex-shrink-0 text-muted-foreground" />;
+  }
   return (
-    <span className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md bg-muted">
-      {failed ? (
-        <Globe className="h-3.5 w-3.5 text-muted-foreground" />
-      ) : (
-        <img
-          src={`https://www.google.com/s2/favicons?domain=${encodeURIComponent(
-            host
-          )}&sz=64`}
-          alt=""
-          width={16}
-          height={16}
-          loading="lazy"
-          onError={() => setFailed(true)}
-          className="h-4 w-4 rounded-sm"
-        />
-      )}
-    </span>
+    <img
+      src={`https://www.google.com/s2/favicons?domain=${encodeURIComponent(
+        host
+      )}&sz=64`}
+      alt=""
+      width={16}
+      height={16}
+      loading="lazy"
+      onError={() => setFailed(true)}
+      className="h-4 w-4 flex-shrink-0 rounded-sm"
+    />
   );
 }
 
-// The verified span the model cited, shown as a visible quote line under
-// the source (the API extracts it from the source's own text, so this is
-// what the source actually says — not the model's paraphrase).
+// The verified span the model cited (the API extracts it from the source's
+// own text, so this is what the source actually says — not the model's
+// paraphrase). Shown only in the expanded state.
 function CitedQuote({ text }: { text?: string | null }) {
   if (!text) return null;
   return (
-    <p
-      title={text}
-      className="m-0 text-xs leading-snug text-muted-foreground line-clamp-2"
-    >
-      “{text}”
+    <p className="m-0 text-xs leading-snug text-muted-foreground">“{text}”</p>
+  );
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="m-0 px-0.5 pb-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+      {children}
     </p>
   );
 }
 
-function CardHeader({
-  icon,
-  label,
-  source,
-}: {
-  icon: React.ReactNode;
-  label: string;
-  source: MessageResponseSource;
-}) {
-  return (
-    <span className="flex w-full min-w-0 items-center gap-2">
-      {icon}
-      <span className="min-w-0 flex-1 truncate text-left text-sm font-medium text-foreground group-hover:underline underline-offset-2">
-        {label}
-      </span>
-      <UnverifiedBadge attribution={source.attribution} />
-      <IndexChip index={source.index} />
-    </span>
-  );
-}
+const pillClasses =
+  'inline-flex max-w-full items-center gap-1.5 rounded-md border border-border/60 bg-background px-2 py-1 text-xs font-medium text-foreground transition-colors hover:border-border hover:bg-muted/40';
 
-const cardClasses =
-  'group flex w-full flex-col items-start gap-1 rounded-lg border border-border/60 bg-background p-2.5 text-left no-underline transition-colors hover:border-border hover:bg-muted/40';
+const expandedCardClasses =
+  'w-full rounded-lg border border-border/60 bg-background p-2.5 flex flex-col gap-1.5';
 
 export function ChatMessageSources({
   sources,
@@ -242,10 +230,23 @@ export function ChatMessageSources({
   const { workspaceId, threadId } = useChatContext();
   const { downloadFileMutation } = useFileMutations({ workspaceId, threadId });
   const [isExpanded, setIsExpanded] = useState(true);
+  const [openIndexes, setOpenIndexes] = useState<ReadonlySet<number>>(
+    new Set()
+  );
+
+  const toggleOpen = (index: number) =>
+    setOpenIndexes((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) next.delete(index);
+      else next.add(index);
+      return next;
+    });
 
   const displaySources = (sources ?? []).filter(
     (s) => isFileSource(s) || isLinkSource(s)
   );
+  const urlSources = displaySources.filter((s) => !isFileSource(s));
+  const fileSources = displaySources.filter(isFileSource);
 
   if (displaySources.length === 0) return null;
 
@@ -271,84 +272,153 @@ export function ChatMessageSources({
         />
       </button>
 
-      {/* Source cards */}
+      {/* Compact pills, grouped by kind; each expands in place for detail */}
       {isExpanded && (
-        <ul className="list-none m-0 grid gap-1.5 p-2 sm:grid-cols-2">
-          {displaySources.map((source) => {
-            if (isFileSource(source)) {
-              return (
-                <li
-                  key={`${source.file.id}-${source.index}`}
-                  className="m-0 p-0 list-none"
-                >
-                  <button
-                    type="button"
-                    title={`Download ${source.file.name}`}
-                    onClick={() => downloadFileMutation.mutate(source.file)}
-                    disabled={downloadFileMutation.isPending}
-                    className={cn(
-                      cardClasses,
-                      'h-full disabled:cursor-not-allowed disabled:opacity-50'
-                    )}
-                  >
-                    <CardHeader
-                      icon={
-                        <span className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md bg-muted">
-                          <Download className="hidden h-3.5 w-3.5 text-muted-foreground group-hover:block" />
-                          {(() => {
-                            const Icon = getFileIcon(source.file.name);
-                            return (
-                              <Icon className="h-3.5 w-3.5 text-muted-foreground group-hover:hidden" />
-                            );
-                          })()}
+        <div className="flex flex-col gap-2.5 p-2.5">
+          {urlSources.length > 0 && (
+            <div>
+              <SectionLabel>URLs</SectionLabel>
+              <div className="flex flex-wrap gap-1.5">
+                {urlSources.map((source) => {
+                  const host = getHost(source.url ?? '');
+                  const safeHref = source.url ? getSafeUrl(source.url) : null;
+
+                  if (!openIndexes.has(source.index)) {
+                    return (
+                      <button
+                        key={`url-${source.index}`}
+                        type="button"
+                        aria-expanded={false}
+                        title={source.url ?? host}
+                        onClick={() => toggleOpen(source.index)}
+                        className={pillClasses}
+                      >
+                        <SourceFavicon host={host} />
+                        <span className="min-w-0 truncate">{host}</span>
+                        <UnverifiedBadge
+                          attribution={source.attribution}
+                          compact
+                        />
+                        <IndexChip index={source.index} />
+                      </button>
+                    );
+                  }
+
+                  return (
+                    <div
+                      key={`url-${source.index}`}
+                      className={expandedCardClasses}
+                    >
+                      <div className="flex w-full items-center gap-2">
+                        <SourceFavicon host={host} />
+                        {safeHref ? (
+                          <a
+                            href={safeHref}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="min-w-0 truncate text-sm font-medium text-foreground no-underline hover:underline underline-offset-2"
+                          >
+                            {host}
+                          </a>
+                        ) : (
+                          <span className="min-w-0 truncate text-sm font-medium text-foreground">
+                            {host}
+                          </span>
+                        )}
+                        <UnverifiedBadge attribution={source.attribution} />
+                        <IndexChip index={source.index} />
+                        <button
+                          type="button"
+                          aria-expanded
+                          aria-label="Collapse source"
+                          onClick={() => toggleOpen(source.index)}
+                          className="ml-auto rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+                        >
+                          <ChevronUp className="h-3.5 w-3.5" />
+                        </button>
+                      </div>
+                      {source.url && (
+                        <p className="m-0 truncate text-xs text-muted-foreground/80">
+                          {source.url}
+                        </p>
+                      )}
+                      <CitedQuote text={source.citedText} />
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {fileSources.length > 0 && (
+            <div>
+              <SectionLabel>Files</SectionLabel>
+              <div className="flex flex-wrap gap-1.5">
+                {fileSources.map((source) => {
+                  const Icon = getFileIcon(source.file.name);
+
+                  if (!openIndexes.has(source.index)) {
+                    return (
+                      <button
+                        key={`${source.file.id}-${source.index}`}
+                        type="button"
+                        aria-expanded={false}
+                        title={source.file.name}
+                        onClick={() => toggleOpen(source.index)}
+                        className={pillClasses}
+                      >
+                        <Icon className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+                        <span className="min-w-0 truncate">
+                          {source.file.name}
                         </span>
-                      }
-                      label={source.file.name}
-                      source={source}
-                    />
-                    <CitedQuote text={source.citedText} />
-                  </button>
-                </li>
-              );
-            }
+                        <UnverifiedBadge
+                          attribution={source.attribution}
+                          compact
+                        />
+                        <IndexChip index={source.index} />
+                      </button>
+                    );
+                  }
 
-            const safeHref = source.url ? getSafeUrl(source.url) : null;
-            const host = getHost(source.url ?? '');
-
-            const body = (
-              <>
-                <CardHeader
-                  icon={<SourceFavicon host={host} />}
-                  label={host}
-                  source={source}
-                />
-                <CitedQuote text={source.citedText} />
-              </>
-            );
-
-            return (
-              <li key={`url-${source.index}`} className="m-0 p-0 list-none">
-                {safeHref ? (
-                  <a
-                    title={source.url ?? host}
-                    href={safeHref}
-                    target="_blank"
-                    rel="noreferrer"
-                    className={cn(cardClasses, 'h-full')}
-                  >
-                    {body}
-                  </a>
-                ) : (
-                  <div
-                    className={cn(cardClasses, 'h-full hover:bg-background')}
-                  >
-                    {body}
-                  </div>
-                )}
-              </li>
-            );
-          })}
-        </ul>
+                  return (
+                    <div
+                      key={`${source.file.id}-${source.index}`}
+                      className={expandedCardClasses}
+                    >
+                      <div className="flex w-full items-center gap-2">
+                        <Icon className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+                        <span className="min-w-0 truncate text-sm font-medium text-foreground">
+                          {source.file.name}
+                        </span>
+                        <UnverifiedBadge attribution={source.attribution} />
+                        <IndexChip index={source.index} />
+                        <button
+                          type="button"
+                          aria-expanded
+                          aria-label="Collapse source"
+                          onClick={() => toggleOpen(source.index)}
+                          className="ml-auto rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+                        >
+                          <ChevronUp className="h-3.5 w-3.5" />
+                        </button>
+                      </div>
+                      <CitedQuote text={source.citedText} />
+                      <button
+                        type="button"
+                        onClick={() => downloadFileMutation.mutate(source.file)}
+                        disabled={downloadFileMutation.isPending}
+                        className="inline-flex w-fit items-center gap-1 rounded-md border border-border/60 px-2 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted/40 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        <Download className="h-3 w-3" />
+                        Download
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
       )}
     </div>
   );

--- a/packages/chat-ui/src/messages/MessageSources.tsx
+++ b/packages/chat-ui/src/messages/MessageSources.tsx
@@ -1,7 +1,6 @@
 import {
   ChevronUp,
   Download,
-  ExternalLink,
   FileArchive,
   FileAudio,
   FileCode,
@@ -9,6 +8,7 @@ import {
   FileSpreadsheet,
   FileText,
   FileVideo,
+  Globe,
   Presentation,
   ShieldAlert,
 } from 'lucide-react';
@@ -117,18 +117,12 @@ function getSafeUrl(url: string): string | null {
   }
 }
 
-// "www.metservice.com/towns-cities/.../7-days" reads as noise in a list; the
-// hostname is the identity, the path is detail. Split so they can be styled apart.
-function getUrlParts(url: string): { host: string; path: string | null } {
+// The hostname is the source's identity; the full URL stays in the tooltip.
+function getHost(url: string): string {
   try {
-    const parsed = new URL(url);
-    const host = parsed.hostname.replace(/^www\./, '');
-    const tail = `${parsed.pathname === '/' ? '' : parsed.pathname}${
-      parsed.search
-    }`;
-    return { host, path: tail || null };
+    return new URL(url).hostname.replace(/^www\./, '');
   } catch {
-    return { host: url, path: null };
+    return url;
   }
 }
 
@@ -170,8 +164,33 @@ function UnverifiedBadge({
 // from a claim to its source.
 function IndexChip({ index }: { index: number }) {
   return (
-    <span className="mt-0.5 flex h-5 min-w-[20px] flex-shrink-0 items-center justify-center rounded-full bg-muted px-1 text-[10px] font-medium tabular-nums text-muted-foreground">
+    <span className="flex h-4 min-w-[16px] flex-shrink-0 items-center justify-center rounded-full bg-muted px-1 text-[10px] font-medium tabular-nums text-muted-foreground">
       {index}
+    </span>
+  );
+}
+
+// Site favicon with a graceful fallback — the service returns a default globe
+// for unknown domains, and any load failure drops to the Globe icon.
+function SourceFavicon({ host }: { host: string }) {
+  const [failed, setFailed] = useState(false);
+  return (
+    <span className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md bg-muted">
+      {failed ? (
+        <Globe className="h-3.5 w-3.5 text-muted-foreground" />
+      ) : (
+        <img
+          src={`https://www.google.com/s2/favicons?domain=${encodeURIComponent(
+            host
+          )}&sz=64`}
+          alt=""
+          width={16}
+          height={16}
+          loading="lazy"
+          onError={() => setFailed(true)}
+          className="h-4 w-4 rounded-sm"
+        />
+      )}
     </span>
   );
 }
@@ -184,12 +203,36 @@ function CitedQuote({ text }: { text?: string | null }) {
   return (
     <p
       title={text}
-      className="m-0 mt-0.5 text-xs leading-snug text-muted-foreground line-clamp-2"
+      className="m-0 text-xs leading-snug text-muted-foreground line-clamp-2"
     >
       “{text}”
     </p>
   );
 }
+
+function CardHeader({
+  icon,
+  label,
+  source,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  source: MessageResponseSource;
+}) {
+  return (
+    <span className="flex w-full min-w-0 items-center gap-2">
+      {icon}
+      <span className="min-w-0 flex-1 truncate text-left text-sm font-medium text-foreground group-hover:underline underline-offset-2">
+        {label}
+      </span>
+      <UnverifiedBadge attribution={source.attribution} />
+      <IndexChip index={source.index} />
+    </span>
+  );
+}
+
+const cardClasses =
+  'group flex w-full flex-col items-start gap-1 rounded-lg border border-border/60 bg-background p-2.5 text-left no-underline transition-colors hover:border-border hover:bg-muted/40';
 
 export function ChatMessageSources({
   sources,
@@ -228,12 +271,11 @@ export function ChatMessageSources({
         />
       </button>
 
-      {/* Content area */}
+      {/* Source cards */}
       {isExpanded && (
-        <ul className="list-none m-0 bg-background p-1.5 divide-y divide-border/50">
+        <ul className="list-none m-0 grid gap-1.5 p-2 sm:grid-cols-2">
           {displaySources.map((source) => {
             if (isFileSource(source)) {
-              const Icon = getFileIcon(source.file.name);
               return (
                 <li
                   key={`${source.file.id}-${source.index}`}
@@ -241,46 +283,47 @@ export function ChatMessageSources({
                 >
                   <button
                     type="button"
-                    title={source.file.name}
+                    title={`Download ${source.file.name}`}
                     onClick={() => downloadFileMutation.mutate(source.file)}
                     disabled={downloadFileMutation.isPending}
-                    className="group flex w-full items-start gap-2 rounded-md px-1.5 py-1.5 text-left transition-colors hover:bg-muted/50 disabled:cursor-not-allowed disabled:opacity-50"
+                    className={cn(
+                      cardClasses,
+                      'h-full disabled:cursor-not-allowed disabled:opacity-50'
+                    )}
                   >
-                    <IndexChip index={source.index} />
-                    <span className="min-w-0 flex-1">
-                      <span className="flex items-center gap-1.5">
-                        <Icon className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
-                        <span className="min-w-0 truncate text-sm font-medium text-foreground group-hover:underline underline-offset-2">
-                          {source.file.name}
+                    <CardHeader
+                      icon={
+                        <span className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md bg-muted">
+                          <Download className="hidden h-3.5 w-3.5 text-muted-foreground group-hover:block" />
+                          {(() => {
+                            const Icon = getFileIcon(source.file.name);
+                            return (
+                              <Icon className="h-3.5 w-3.5 text-muted-foreground group-hover:hidden" />
+                            );
+                          })()}
                         </span>
-                        <UnverifiedBadge attribution={source.attribution} />
-                      </span>
-                      <CitedQuote text={source.citedText} />
-                    </span>
-                    <Download className="ml-auto mt-1 h-3.5 w-3.5 flex-shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100" />
+                      }
+                      label={source.file.name}
+                      source={source}
+                    />
+                    <CitedQuote text={source.citedText} />
                   </button>
                 </li>
               );
             }
 
             const safeHref = source.url ? getSafeUrl(source.url) : null;
-            const { host, path } = getUrlParts(source.url ?? '');
+            const host = getHost(source.url ?? '');
 
-            const nameLine = (
-              <span className="min-w-0 flex-1">
-                <span className="flex min-w-0 items-baseline gap-1.5">
-                  <span className="flex-shrink-0 text-sm font-medium text-foreground group-hover:underline underline-offset-2">
-                    {host}
-                  </span>
-                  {path && (
-                    <span className="min-w-0 truncate text-xs text-muted-foreground">
-                      {path}
-                    </span>
-                  )}
-                  <UnverifiedBadge attribution={source.attribution} />
-                </span>
+            const body = (
+              <>
+                <CardHeader
+                  icon={<SourceFavicon host={host} />}
+                  label={host}
+                  source={source}
+                />
                 <CitedQuote text={source.citedText} />
-              </span>
+              </>
             );
 
             return (
@@ -291,16 +334,15 @@ export function ChatMessageSources({
                     href={safeHref}
                     target="_blank"
                     rel="noreferrer"
-                    className="group flex items-start gap-2 rounded-md px-1.5 py-1.5 transition-colors hover:bg-muted/50"
+                    className={cn(cardClasses, 'h-full')}
                   >
-                    <IndexChip index={source.index} />
-                    {nameLine}
-                    <ExternalLink className="ml-auto mt-1 h-3.5 w-3.5 flex-shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100" />
+                    {body}
                   </a>
                 ) : (
-                  <div className="group flex items-start gap-2 rounded-md px-1.5 py-1.5">
-                    <IndexChip index={source.index} />
-                    {nameLine}
+                  <div
+                    className={cn(cardClasses, 'h-full hover:bg-background')}
+                  >
+                    {body}
                   </div>
                 )}
               </li>

--- a/packages/chat-ui/src/messages/MessageSources.tsx
+++ b/packages/chat-ui/src/messages/MessageSources.tsx
@@ -1,5 +1,6 @@
 import {
   ChevronUp,
+  Download,
   ExternalLink,
   FileArchive,
   FileAudio,
@@ -116,17 +117,19 @@ function getSafeUrl(url: string): string | null {
   }
 }
 
-function getDisplayName(source: MessageResponseSource): string {
-  if (source.file?.name) return source.file.name;
-  if (source.url) {
-    try {
-      const parsed = new URL(source.url);
-      return parsed.hostname + (parsed.pathname !== '/' ? parsed.pathname : '');
-    } catch {
-      return source.url;
-    }
+// "www.metservice.com/towns-cities/.../7-days" reads as noise in a list; the
+// hostname is the identity, the path is detail. Split so they can be styled apart.
+function getUrlParts(url: string): { host: string; path: string | null } {
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.replace(/^www\./, '');
+    const tail = `${parsed.pathname === '/' ? '' : parsed.pathname}${
+      parsed.search
+    }`;
+    return { host, path: tail || null };
+  } catch {
+    return { host: url, path: null };
   }
-  return `Source ${source.index}`;
 }
 
 function isFileSource(
@@ -163,17 +166,27 @@ function UnverifiedBadge({
   );
 }
 
+// Matches the (N) markers in the message body so the reader can jump
+// from a claim to its source.
+function IndexChip({ index }: { index: number }) {
+  return (
+    <span className="mt-0.5 flex h-5 min-w-[20px] flex-shrink-0 items-center justify-center rounded-full bg-muted px-1 text-[10px] font-medium tabular-nums text-muted-foreground">
+      {index}
+    </span>
+  );
+}
+
 // The verified span the model cited, shown as a visible quote line under
 // the source (the API extracts it from the source's own text, so this is
 // what the source actually says — not the model's paraphrase).
-function CitedQuote({ source }: { source: MessageResponseSource }) {
-  if (!source.citedText) return null;
+function CitedQuote({ text }: { text?: string | null }) {
+  if (!text) return null;
   return (
     <p
-      title={source.citedText}
-      className="m-0 pl-6 pr-2 pb-0.5 text-xs italic text-muted-foreground line-clamp-2 border-l-2 border-border ml-1"
+      title={text}
+      className="m-0 mt-0.5 text-xs leading-snug text-muted-foreground line-clamp-2"
     >
-      “{source.citedText}”
+      “{text}”
     </p>
   );
 }
@@ -217,77 +230,83 @@ export function ChatMessageSources({
 
       {/* Content area */}
       {isExpanded && (
-        <div className="bg-background px-3 py-0.5">
-          <ul
-            className="list-none space-y-1 m-0 p-0"
-            style={{ paddingLeft: 0, marginLeft: 0 }}
-          >
-            {displaySources.map((source) => {
-              const displayName = getDisplayName(source);
-
-              if (isFileSource(source)) {
-                const Icon = getFileIcon(source.file.name);
-                return (
-                  <li
-                    key={`${source.file.id}-${source.index}`}
-                    className="list-none text-sm text-foreground m-0 p-0"
-                    style={{ paddingLeft: 0, marginLeft: 0 }}
-                  >
-                    <div className="flex items-center gap-1.5">
-                      <span>{`(${source.index})`} : </span>
-                      {Icon && (
-                        <Icon className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
-                      )}
-                      <button
-                        type="button"
-                        title={displayName}
-                        onClick={() => downloadFileMutation.mutate(source.file)}
-                        className="text-foreground hover:bg-muted/50 rounded px-1 py-0.5 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed truncate"
-                        disabled={downloadFileMutation.isPending}
-                      >
-                        {displayName}
-                      </button>
-                      <UnverifiedBadge attribution={source.attribution} />
-                    </div>
-                    <CitedQuote source={source} />
-                  </li>
-                );
-              }
-
-              const safeHref = source.url ? getSafeUrl(source.url) : null;
-
+        <ul className="list-none m-0 bg-background p-1.5 divide-y divide-border/50">
+          {displaySources.map((source) => {
+            if (isFileSource(source)) {
+              const Icon = getFileIcon(source.file.name);
               return (
                 <li
-                  key={`url-${source.index}`}
-                  className="list-none text-sm text-foreground m-0 p-0"
-                  style={{ paddingLeft: 0, marginLeft: 0 }}
+                  key={`${source.file.id}-${source.index}`}
+                  className="m-0 p-0 list-none"
                 >
-                  <div className="flex items-center gap-1.5">
-                    <span>{`(${source.index})`} : </span>
-                    <ExternalLink className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
-                    {safeHref ? (
-                      <a
-                        title={source.url ?? displayName}
-                        href={safeHref}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="text-foreground hover:bg-muted/50 rounded px-1 py-0.5 underline underline-offset-2 truncate"
-                      >
-                        {displayName}
-                      </a>
-                    ) : (
-                      <span className="text-foreground rounded px-1 py-0.5 truncate">
-                        {displayName}
+                  <button
+                    type="button"
+                    title={source.file.name}
+                    onClick={() => downloadFileMutation.mutate(source.file)}
+                    disabled={downloadFileMutation.isPending}
+                    className="group flex w-full items-start gap-2 rounded-md px-1.5 py-1.5 text-left transition-colors hover:bg-muted/50 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    <IndexChip index={source.index} />
+                    <span className="min-w-0 flex-1">
+                      <span className="flex items-center gap-1.5">
+                        <Icon className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+                        <span className="min-w-0 truncate text-sm font-medium text-foreground group-hover:underline underline-offset-2">
+                          {source.file.name}
+                        </span>
+                        <UnverifiedBadge attribution={source.attribution} />
                       </span>
-                    )}
-                    <UnverifiedBadge attribution={source.attribution} />
-                  </div>
-                  <CitedQuote source={source} />
+                      <CitedQuote text={source.citedText} />
+                    </span>
+                    <Download className="ml-auto mt-1 h-3.5 w-3.5 flex-shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100" />
+                  </button>
                 </li>
               );
-            })}
-          </ul>
-        </div>
+            }
+
+            const safeHref = source.url ? getSafeUrl(source.url) : null;
+            const { host, path } = getUrlParts(source.url ?? '');
+
+            const nameLine = (
+              <span className="min-w-0 flex-1">
+                <span className="flex min-w-0 items-baseline gap-1.5">
+                  <span className="flex-shrink-0 text-sm font-medium text-foreground group-hover:underline underline-offset-2">
+                    {host}
+                  </span>
+                  {path && (
+                    <span className="min-w-0 truncate text-xs text-muted-foreground">
+                      {path}
+                    </span>
+                  )}
+                  <UnverifiedBadge attribution={source.attribution} />
+                </span>
+                <CitedQuote text={source.citedText} />
+              </span>
+            );
+
+            return (
+              <li key={`url-${source.index}`} className="m-0 p-0 list-none">
+                {safeHref ? (
+                  <a
+                    title={source.url ?? host}
+                    href={safeHref}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="group flex items-start gap-2 rounded-md px-1.5 py-1.5 transition-colors hover:bg-muted/50"
+                  >
+                    <IndexChip index={source.index} />
+                    {nameLine}
+                    <ExternalLink className="ml-auto mt-1 h-3.5 w-3.5 flex-shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100" />
+                  </a>
+                ) : (
+                  <div className="group flex items-start gap-2 rounded-md px-1.5 py-1.5">
+                    <IndexChip index={source.index} />
+                    {nameLine}
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
       )}
     </div>
   );


### PR DESCRIPTION
## What

Redesigns the sources panel under assistant messages. The previous list rendered every source as a full-width `(N) : url` row with an indented quote block, which read as clunky and didn't scale visually.

Sources now render as **compact pills grouped into URLs / Files subsections**:

- Pill = favicon (Google s2, with a Globe icon fallback on load failure) or file-type icon + hostname/file name + a small index chip that maps to the `(N)` citation markers in the message body.
- Clicking a pill **expands it in place** to a full-width card: the clickable link (or a Download action for files), the full URL, and the verified quote. A chevron collapses it back.
- The Unverified attribution badge shrinks to icon-only on pills and shows the full label when expanded.
- Hostnames drop the `www.` prefix; paths only appear in the expanded state.

## Notes

- No data/behaviour changes: same source filtering, same download mutation, same attribution semantics.
- Favicons are fetched client-side from `google.com/s2/favicons`; the fallback path means deployments can strip this to icons-only trivially if the third-party request is unwanted.
- Links carry explicit `no-underline` so global anchor styling can't leak in.

## Testing

- `eslint` clean on the file; `tsc --noEmit` clean; package builds (tsup + tailwind).
- Validated in-product against a live response with 6 URL sources (light theme): pill row, expand/collapse, quote rendering, tooltips.
- No existing specs for this component.