### PR TITLE
feat(notifications): surface AddedToThread notifications

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,7 +91,7 @@ importers:
         version: 1.2.4(@types/react@18.3.1)(react@18.3.1)
       '@smartspace/api-client':
         specifier: dev
-        version: 0.1.0-dev.77f1216(@faker-js/faker@10.4.0)(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(msw@2.14.6(@types/node@25.6.0)(typescript@5.5.4))(zod@4.3.6)
+        version: 0.1.0-dev.4e8dc6b(@faker-js/faker@10.4.0)(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(msw@2.14.6(@types/node@25.6.0)(typescript@5.5.4))(zod@4.3.6)
       '@smartspace/chat-ui':
         specifier: workspace:*
         version: link:packages/chat-ui
@@ -465,7 +465,7 @@ importers:
     devDependencies:
       '@smartspace/api-client':
         specifier: dev
-        version: 0.1.0-dev.77f1216(@faker-js/faker@10.4.0)(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(msw@2.14.6(@types/node@25.6.0)(typescript@5.5.4))(zod@4.3.6)
+        version: 0.1.0-dev.4e8dc6b(@faker-js/faker@10.4.0)(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(msw@2.14.6(@types/node@25.6.0)(typescript@5.5.4))(zod@4.3.6)
       tailwindcss:
         specifier: ^3.4.10
         version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
@@ -2894,8 +2894,8 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
-  '@smartspace/api-client@0.1.0-dev.77f1216':
-    resolution: {integrity: sha512-7UamzXoexBSU7DVPiezf21gWfgOzznn36kjC65gin5ZamkPQz8OCHQrZFbDnd36JIr+jxfaah2eUT4kJ7HrWug==}
+  '@smartspace/api-client@0.1.0-dev.4e8dc6b':
+    resolution: {integrity: sha512-kEKmMSIOQFX/KpvLr6wMtC6MAxb1y+BJkCeQCytRKix2c5lNxtdNANl3DIm6+toTBMWW52srKC+cKfJMW1VaOA==}
     peerDependencies:
       '@faker-js/faker': '>=9.0.0'
       '@microsoft/signalr': '>=8.0.0'
@@ -10924,7 +10924,7 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
-  '@smartspace/api-client@0.1.0-dev.77f1216(@faker-js/faker@10.4.0)(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(msw@2.14.6(@types/node@25.6.0)(typescript@5.5.4))(zod@4.3.6)':
+  '@smartspace/api-client@0.1.0-dev.4e8dc6b(@faker-js/faker@10.4.0)(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(msw@2.14.6(@types/node@25.6.0)(typescript@5.5.4))(zod@4.3.6)':
     dependencies:
       '@microsoft/signalr': 8.0.17(encoding@0.1.13)
       axios: 1.15.1

--- a/src/domains/notifications/__tests__/mapper.spec.ts
+++ b/src/domains/notifications/__tests__/mapper.spec.ts
@@ -41,6 +41,22 @@ describe('notifications mapper', () => {
     expect(n.notificationType).toBe(NotificationType.CommentUpdated);
   });
 
+  it('maps AddedToThread string enum from SDK', () => {
+    const n = mapNotificationDtoToModel({
+      ...baseDto,
+      notificationType: 'AddedToThread',
+    } as never);
+    expect(n.notificationType).toBe(NotificationType.AddedToThread);
+  });
+
+  it('maps AddedToThread numeric enum', () => {
+    const n = mapNotificationDtoToModel({
+      ...baseDto,
+      notificationType: 3,
+    } as never);
+    expect(n.notificationType).toBe(NotificationType.AddedToThread);
+  });
+
   it('falls back to WorkSpaceUpdated for unknown values', () => {
     const n = mapNotificationDtoToModel({
       ...baseDto,

--- a/src/domains/notifications/mapper.ts
+++ b/src/domains/notifications/mapper.ts
@@ -16,6 +16,8 @@ const normalizeType = (value: unknown): NotificationType => {
       ? NotificationType.MessageThreadUpdated
       : value === 2
       ? NotificationType.CommentUpdated
+      : value === 3
+      ? NotificationType.AddedToThread
       : NotificationType.WorkSpaceUpdated;
   }
   if (typeof value === 'string') {
@@ -26,6 +28,8 @@ const normalizeType = (value: unknown): NotificationType => {
       return NotificationType.MessageThreadUpdated;
     if (lowered === '2' || lowered === 'commentupdated')
       return NotificationType.CommentUpdated;
+    if (lowered === '3' || lowered === 'addedtothread')
+      return NotificationType.AddedToThread;
     const numeric = Number(value);
     if (Number.isFinite(numeric)) return normalizeType(numeric);
   }

--- a/src/domains/notifications/model.ts
+++ b/src/domains/notifications/model.ts
@@ -2,6 +2,7 @@ export enum NotificationType {
   WorkSpaceUpdated = 0,
   MessageThreadUpdated = 1,
   CommentUpdated = 2,
+  AddedToThread = 3,
 }
 
 export type Notification = {

--- a/src/ui/header/notifications-panel.tsx
+++ b/src/ui/header/notifications-panel.tsx
@@ -1,6 +1,6 @@
 import { useMatch, useNavigate } from '@tanstack/react-router';
 import { AnimatePresence, motion } from 'framer-motion';
-import { Bell, MessageCircle, MessageSquare } from 'lucide-react';
+import { Bell, MessageCircle, MessageSquare, UserPlus } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import type { Notification } from '@/domains/notifications';
@@ -108,6 +108,8 @@ export function NotificationPanel() {
         return <MessageSquare className="h-3.5 w-3.5 text-blue-500" />;
       case NotificationType.CommentUpdated:
         return <MessageCircle className="h-3.5 w-3.5 text-purple-500" />;
+      case NotificationType.AddedToThread:
+        return <UserPlus className="h-3.5 w-3.5 text-green-500" />;
       default:
         return <Bell className="h-3.5 w-3.5 text-gray-500" />;
     }


### PR DESCRIPTION
## What
The API now sends a dedicated `AddedToThread` notification to a user who is added to a thread, and includes it in the Chat API notification feed (Smartspace-ai/Smartspace-app-api#955). This PR makes the public app understand and display it.

## Changes
- Bump `@smartspace/api-client` (lockfile, `dev` tag kept) to `0.1.0-dev.4e8dc6b` — built from the merged API change; without this bump the generated zod schema rejects the entire notifications response when an `AddedToThread` item is present
- Add `AddedToThread` to the notifications model enum and mapper normalisation
- `UserPlus` icon for the new type in the notifications panel (click-through to the thread already works via `threadId`/`workSpaceId`)
- Mapper tests for the string and numeric enum forms

Supersedes #385 (bumped the SDK to the previous commit).