### PR TITLE
feat(notifications): refresh notifications live on SignalR user message

### DIFF
--- a/src/platform/realtime/useWorkspaceRealtime.ts
+++ b/src/platform/realtime/useWorkspaceRealtime.ts
@@ -5,6 +5,7 @@ import { useEffect } from 'react';
 import { useOptionalRealtime } from './RealtimeProvider';
 
 type Handlers = {
+  onMessage?: (name: string, message: string) => void;
   onThreadUpdate?: (thread: SignalR.MessageThreadSummary) => void;
   onThreadDeleted?: (thread: SignalR.MessageThreadSummary) => void;
   onCommentsUpdate?: (comment: SignalR.CommentSummary) => void;
@@ -34,8 +35,8 @@ export function useWorkspaceRealtime(
     const subscription = SignalR.getReceiverRegister('IChatReceiver').register(
       connection,
       {
-        receiveMessage: async () => {
-          /* no-op: toast/notification handling lives elsewhere */
+        receiveMessage: async (name, message) => {
+          handlers.onMessage?.(name, message);
         },
         receiveThreadUpdate: async (thread) => {
           handlers.onThreadUpdate?.(thread);

--- a/src/ui/workspaces/useWorkspaceSubscriptions.ts
+++ b/src/ui/workspaces/useWorkspaceSubscriptions.ts
@@ -7,6 +7,7 @@ import { useWorkspaceRealtime } from '@/platform/realtime/useWorkspaceRealtime';
 
 import { applyCommentToCache, commentsKeys } from '@/domains/comments';
 import { useThreadMessageStream } from '@/domains/messages/threadStream';
+import { notificationsKeys } from '@/domains/notifications';
 
 import {
   applyThreadToCache,
@@ -63,6 +64,13 @@ export function useWorkspaceSubscriptions() {
   useThreadMessageStream(threadId || undefined, !!thread?.isFlowRunning);
 
   useWorkspaceRealtime(workspaceId || undefined, {
+    // The server pushes a user-targeted message for every persisted
+    // notification (added to thread, comment reply, ...). The payload
+    // duplicates what GET /notification returns, so refetch rather than
+    // trusting a second write path into the cache.
+    onMessage: () => {
+      qc.invalidateQueries({ queryKey: notificationsKeys.all });
+    },
     onThreadUpdate: (summary) => {
       if (!workspaceId) return;
 


### PR DESCRIPTION
## What
Follow-up to #386. Notifications (e.g. the new `AddedToThread`, comment replies) only appeared after a refetch — opening the bell, refocusing the window, or refreshing the page — even though the server pushes a user-targeted SignalR message the moment each notification is persisted.

## Why
`receiveMessage` in `useWorkspaceRealtime` was a no-op (its comment claimed handling lived elsewhere; it didn't). Every `SendUserMessageAsync` push landed there and died.

## Changes
- `useWorkspaceRealtime`: new optional `onMessage(name, message)` handler, wired to `receiveMessage`
- `useWorkspaceSubscriptions`: on message push, invalidate the notifications query so the badge/panel refetch immediately — the push payload duplicates what `GET /notification` returns, so refetching keeps a single write path into the cache

## Test
Add a user to a thread from a second account: the added user's bell badge now updates within a second, no refresh needed.