### PR TITLE
feat(notifications): consume typed ReceiveNotification SignalR event

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,7 +91,7 @@ importers:
         version: 1.2.4(@types/react@18.3.1)(react@18.3.1)
       '@smartspace/api-client':
         specifier: dev
-        version: 0.1.0-dev.4e8dc6b(@faker-js/faker@10.4.0)(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(msw@2.14.6(@types/node@25.6.0)(typescript@5.5.4))(zod@4.3.6)
+        version: 0.1.0-dev.4f08aee(@faker-js/faker@10.4.0)(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(msw@2.14.6(@types/node@25.6.0)(typescript@5.5.4))(zod@4.3.6)
       '@smartspace/chat-ui':
         specifier: workspace:*
         version: link:packages/chat-ui
@@ -465,7 +465,7 @@ importers:
     devDependencies:
       '@smartspace/api-client':
         specifier: dev
-        version: 0.1.0-dev.4e8dc6b(@faker-js/faker@10.4.0)(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(msw@2.14.6(@types/node@25.6.0)(typescript@5.5.4))(zod@4.3.6)
+        version: 0.1.0-dev.4f08aee(@faker-js/faker@10.4.0)(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(msw@2.14.6(@types/node@25.6.0)(typescript@5.5.4))(zod@4.3.6)
       tailwindcss:
         specifier: ^3.4.10
         version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
@@ -2894,8 +2894,8 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
-  '@smartspace/api-client@0.1.0-dev.4e8dc6b':
-    resolution: {integrity: sha512-kEKmMSIOQFX/KpvLr6wMtC6MAxb1y+BJkCeQCytRKix2c5lNxtdNANl3DIm6+toTBMWW52srKC+cKfJMW1VaOA==}
+  '@smartspace/api-client@0.1.0-dev.4f08aee':
+    resolution: {integrity: sha512-gsMOvtSBVlH0Fm4BohjL3HpBuiNlNc6lVGH6g1FUiOs2sZpZaq4CTmHFjCgdIiZeRJTWHDIBFjdonTcRBnMDBQ==}
     peerDependencies:
       '@faker-js/faker': '>=9.0.0'
       '@microsoft/signalr': '>=8.0.0'
@@ -10924,7 +10924,7 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
-  '@smartspace/api-client@0.1.0-dev.4e8dc6b(@faker-js/faker@10.4.0)(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(msw@2.14.6(@types/node@25.6.0)(typescript@5.5.4))(zod@4.3.6)':
+  '@smartspace/api-client@0.1.0-dev.4f08aee(@faker-js/faker@10.4.0)(@microsoft/signalr@8.0.17(encoding@0.1.13))(axios@1.15.1)(msw@2.14.6(@types/node@25.6.0)(typescript@5.5.4))(zod@4.3.6)':
     dependencies:
       '@microsoft/signalr': 8.0.17(encoding@0.1.13)
       axios: 1.15.1

--- a/src/platform/realtime/useWorkspaceRealtime.ts
+++ b/src/platform/realtime/useWorkspaceRealtime.ts
@@ -5,7 +5,7 @@ import { useEffect } from 'react';
 import { useOptionalRealtime } from './RealtimeProvider';
 
 type Handlers = {
-  onMessage?: (name: string, message: string) => void;
+  onNotification?: (notification: SignalR.Notification) => void;
   onThreadUpdate?: (thread: SignalR.MessageThreadSummary) => void;
   onThreadDeleted?: (thread: SignalR.MessageThreadSummary) => void;
   onCommentsUpdate?: (comment: SignalR.CommentSummary) => void;
@@ -35,8 +35,12 @@ export function useWorkspaceRealtime(
     const subscription = SignalR.getReceiverRegister('IChatReceiver').register(
       connection,
       {
-        receiveMessage: async (name, message) => {
-          handlers.onMessage?.(name, message);
+        receiveMessage: async () => {
+          /* legacy JSON-string channel — superseded by receiveNotification,
+             still pushed by the server for clients that haven't migrated */
+        },
+        receiveNotification: async (notification) => {
+          handlers.onNotification?.(notification);
         },
         receiveThreadUpdate: async (thread) => {
           handlers.onThreadUpdate?.(thread);

--- a/src/ui/workspaces/useWorkspaceSubscriptions.ts
+++ b/src/ui/workspaces/useWorkspaceSubscriptions.ts
@@ -64,11 +64,11 @@ export function useWorkspaceSubscriptions() {
   useThreadMessageStream(threadId || undefined, !!thread?.isFlowRunning);
 
   useWorkspaceRealtime(workspaceId || undefined, {
-    // The server pushes a user-targeted message for every persisted
+    // The server pushes a user-targeted notification for every persisted
     // notification (added to thread, comment reply, ...). The payload
     // duplicates what GET /notification returns, so refetch rather than
     // trusting a second write path into the cache.
-    onMessage: () => {
+    onNotification: () => {
       qc.invalidateQueries({ queryKey: notificationsKeys.all });
     },
     onThreadUpdate: (summary) => {


### PR DESCRIPTION
## What
Follow-up to #388 and Smartspace-ai/Smartspace-app-api#956. Switches the live notification refresh from the legacy stringly-typed `ReceiveMessage(name, message)` channel to the typed `ReceiveNotification(Notification)` event.

## Changes
- Bump `@smartspace/api-client` (lockfile, `dev` tag kept) to `0.1.0-dev.4f08aee` — first SDK containing the typed contract (`receiveNotification`, `Notification`, string-valued `NotificationType` enum)
- `useWorkspaceRealtime`: `onMessage(name, message)` handler replaced by `onNotification(notification: SignalR.Notification)`; `receiveMessage` returns to a documented no-op (the server dual-pushes it for clients that haven't migrated — the admin app)
- `useWorkspaceSubscriptions`: same notifications-query invalidation, now driven by the typed event

No behaviour change from #388 — this is the contract cleanup.