### PR TITLE
fix(notifications): join the user SignalR group so pushes actually arrive

### DIFF
--- a/src/ui/workspaces/useWorkspaceSubscriptions.ts
+++ b/src/ui/workspaces/useWorkspaceSubscriptions.ts
@@ -1,8 +1,11 @@
 // src/ui/workspaces/useWorkspaceSubscriptions.ts
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useMatch, useNavigate } from '@tanstack/react-router';
+import { useEffect } from 'react';
 
+import { useUserId } from '@/platform/auth/session';
 import { defaultChatService } from '@/platform/chat/defaultChatService';
+import { useOptionalRealtime } from '@/platform/realtime/RealtimeProvider';
 import { useWorkspaceRealtime } from '@/platform/realtime/useWorkspaceRealtime';
 
 import { applyCommentToCache, commentsKeys } from '@/domains/comments';
@@ -62,6 +65,24 @@ export function useWorkspaceSubscriptions() {
     enabled: !!workspaceId && !!threadId,
   });
   useThreadMessageStream(threadId || undefined, !!thread?.isFlowRunning);
+
+  // User-targeted pushes (ReceiveNotification / legacy ReceiveMessage) go to
+  // a SignalR group named after the user's id, and the hub has no automatic
+  // membership — clients must join explicitly (the admin app does the same
+  // right after connecting). Without this join, notification pushes never
+  // reach this client at all. subscribeToGroup records the group as desired,
+  // so the provider re-joins it after reconnects.
+  const userId = useUserId();
+  const realtime = useOptionalRealtime();
+  const subscribeToGroup = realtime?.subscribeToGroup;
+  const unsubscribeFromGroup = realtime?.unsubscribeFromGroup;
+  useEffect(() => {
+    if (!userId || !subscribeToGroup || !unsubscribeFromGroup) return;
+    subscribeToGroup(userId);
+    return () => {
+      unsubscribeFromGroup(userId);
+    };
+  }, [userId, subscribeToGroup, unsubscribeFromGroup]);
 
   useWorkspaceRealtime(workspaceId || undefined, {
     // The server pushes a user-targeted notification for every persisted


### PR DESCRIPTION
## Problem
Even with the push wiring from #388/#389, live notifications never arrived: notification pushes go to a SignalR group named after the user's id, the hub has no automatic membership (`ChatHub` only exposes explicit `JoinGroup`/`LeaveGroup`), and this app only ever joined the *workspace* group. User-targeted pushes — typed `ReceiveNotification` and legacy `ReceiveMessage` alike — were sent to a group this client was never in. That's why thread updates (workspace-group events) were live while the bell only updated on refetch. The admin app has always invoked `joinGroup(userId)` right after connecting, which is why its bell works.

## Fix
Subscribe to the user's own group from `useWorkspaceSubscriptions` (mounted at the auth layout, so it spans the session). Uses the provider's `subscribeToGroup`, which records the group as desired and re-joins it after SignalR reconnects.

## Tested
Verified locally against the dev backend with two accounts: adding a user to a thread now ticks the added user's bell within a second, no refresh.