### PR TITLE
fix(chat-ui): no empty message bubbles; empty response renders as retraction

### DIFF
--- a/packages/chat-ui/src/messages/MessageItem.tsx
+++ b/packages/chat-ui/src/messages/MessageItem.tsx
@@ -157,22 +157,30 @@ export const MessageItem: FC<MessageItemProps> = ({
   // transient status: only the last status is kept, cleared when content follows
   let lastStatusNode: ReactNode | null = null;
 
+  const groupHasAnything = () =>
+    groupContent.length > 0 || groupFiles.length > 0 || groupSources.length > 0;
+
   const flush = (nextType: MessageValueType) => {
-    bubbles.push(
-      <MessageBubble
-        key={`bubble-${message.id ?? 'msg'}-${keyCounter++}`}
-        createdBy={lastCreatedBy}
-        createdByUserId={lastCreatedByUserId}
-        createdAt={lastCreatedAt}
-        type={groupType}
-        content={groupContent}
-        files={groupFiles}
-        sources={groupSources}
-        chatbotName={chatbotName}
-        userOutput={null}
-        userInput={null}
-      />
-    );
+    // A group can be "open" yet hold nothing renderable (e.g. an empty
+    // `sources` output followed by a status flush) — pushing it would
+    // paint an empty bubble.
+    if (groupHasAnything()) {
+      bubbles.push(
+        <MessageBubble
+          key={`bubble-${message.id ?? 'msg'}-${keyCounter++}`}
+          createdBy={lastCreatedBy}
+          createdByUserId={lastCreatedByUserId}
+          createdAt={lastCreatedAt}
+          type={groupType}
+          content={groupContent}
+          files={groupFiles}
+          sources={groupSources}
+          chatbotName={chatbotName}
+          userOutput={null}
+          userInput={null}
+        />
+      );
+    }
     groupContent = [];
     groupFiles = [];
     groupSources = [];
@@ -287,7 +295,9 @@ export const MessageItem: FC<MessageItemProps> = ({
 
       case 'sources': {
         groupSources = coerceSources(v.value);
-        groupOpen = true;
+        // an empty sources output (common when a flow wires the pin but
+        // the round produced no citations) must not open a bubble group
+        if (groupSources.length > 0) groupOpen = true;
         break;
       }
 
@@ -307,7 +317,7 @@ export const MessageItem: FC<MessageItemProps> = ({
   }
 
   // Final pending group
-  if (groupOpen) {
+  if (groupOpen && groupHasAnything()) {
     bubbles.push(
       <MessageBubble
         key={`bubble-final-${message.id ?? 'msg'}-${keyCounter++}`}

--- a/packages/chat-ui/src/messages/MessageItem.tsx
+++ b/packages/chat-ui/src/messages/MessageItem.tsx
@@ -216,6 +216,12 @@ export const MessageItem: FC<MessageItemProps> = ({
       case 'prompt':
       case 'response':
       case 'content': {
+        if (v.value === '') {
+          // A retraction: the block streamed narration onto the response
+          // and then cleared it when the round turned out to be a tool
+          // round. Render nothing (the narration re-arrives as status).
+          continue;
+        }
         lastStatusNode = null;
         // These start a “fresh” content section
         if (groupContent.length > 0) flush(v.type);


### PR DESCRIPTION
## What

Two small rendering guards in `MessageItem`:

1. **Empty bubbles**: an empty `sources` output (a flow with the sources pin wired but no citations that round) opened a bubble group, and a following status value flushed it as a completely blank card. Empty sources no longer open a group, `flush()` skips groups with nothing renderable, and the final pending-group push gets the same check.
2. **Retraction**: the LLM block now clears streamed narration off the response output (empty-string update) when a round turns out to be a tool round — an empty-string `response`/`prompt`/`content` value renders as nothing instead of a blank bubble (the narration re-arrives as a status message).

Display-only; no domain or service changes. Old stored threads render cleaner too.

## Context

Found during MCP Connections v1 testing (multi-round tool flows hit both paths constantly), but the bugs are generic to any tool-calling flow.

## After merge

Needs a chat-ui package publish — the Smartspace-app MCP UI branch currently pins a local build of this fix and swaps to the registry version once available.