### PR TITLE
fix(chat-ui): render structured JSON array output instead of a blank bubble

### DIFF
--- a/packages/chat-ui/src/messages/MessageItem.tsx
+++ b/packages/chat-ui/src/messages/MessageItem.tsx
@@ -53,8 +53,25 @@ function pushContent(items: MessageContentItem[], value: unknown) {
     return;
   }
   if (Array.isArray(value)) {
-    // assume already MessageContentItem[]
-    items.push(...(value as MessageContentItem[]));
+    // A normal LLM response arrives as MessageContentItem[] (each part a
+    // { text } / { image }). But a block that emits structured output —
+    // e.g. a content checker returning [{ category, issue, ... }] — hands
+    // us a top-level array whose items are NOT content parts. Spreading
+    // those verbatim pushes text/image-less items that render to nothing
+    // (contentIsList in MessageBubble fails), painting a blank bubble.
+    // Only spread when the items really are content parts; otherwise fall
+    // back to a JSON code block, mirroring the object branch below.
+    const looksLikeContent = value.every(
+      (it) =>
+        it != null &&
+        typeof it === 'object' &&
+        ('text' in it || 'image' in it)
+    );
+    if (looksLikeContent) {
+      items.push(...(value as MessageContentItem[]));
+    } else {
+      items.push({ text: '```json\n' + JSON.stringify(value, null, 2) + '\n```' });
+    }
     return;
   }
   if (typeof value === 'object') {


### PR DESCRIPTION
## What

`pushContent` in `MessageItem` assumed **any array** value was already `MessageContentItem[]` and spread it verbatim into the content group. A block that emits structured output — e.g. a content checker returning a top-level array `[{ category, issue, suggestedFix, severity }, ...]` — hands the renderer items that are **not** content parts (no `text`/`image`). Those get pushed anyway, so `contentIsList` in `MessageBubble` evaluates `false`, the entire content render block is skipped, and the message paints as a **blank bubble**.

The fix: only spread when the array items are genuinely content parts (have `text` or `image`); otherwise fall back to a fenced JSON code block — mirroring the `JSON.stringify` fallback the object branch already has. So a single JSON *object* output already rendered as JSON; now a JSON *array* does too, instead of vanishing.

## Why it was asymmetric

- JSON **object** output → object branch → no text/image → `JSON.stringify` fallback → rendered. ✓
- JSON **array** output → array branch → assumed pre-shaped content parts, spread raw, no fallback → blank. ✗

## Scope

Display-only; no domain or service changes. Complementary to #393 (which guards *empty* groups — empty sources / empty-string retractions); this handles a *non-empty* array of non-content-part items, a distinct path in `pushContent` that #393 doesn't touch.

## After merge

Like #393, consumers pin a built `@smartspace/chat-ui`, so this needs a package publish to reach the apps.