### PR TITLE
Stop button in the chat composer while a response is generating

### DIFF
--- a/packages/chat-ui/src/domains/flowruns/mutations.ts
+++ b/packages/chat-ui/src/domains/flowruns/mutations.ts
@@ -12,6 +12,27 @@ import { flowRunsKeys } from './queryKeys';
  * variables form. Skips writes for draft threads (no flow-run yet)
  * and invalidates the matching variables cache on success.
  */
+/**
+ * Request cancellation of a thread's running flow (thread id == flow-run id).
+ * No-op for draft threads and for services that don't implement
+ * `cancelFlowRun`. The running state clears via the thread SSE when the
+ * engine actually stops — no cache invalidation needed here.
+ */
+export function useCancelFlowRun() {
+  const service = useChatService();
+  return useMutation({
+    mutationKey: flowRunsKeys.cancel(),
+    mutationFn: async (flowRunId: string) => {
+      if (isDraftThreadId(flowRunId)) return;
+      await service.cancelFlowRun?.(flowRunId);
+    },
+    onError: (error) => {
+      console.error('Failed to cancel flow run:', error);
+      toast.error('Failed to stop the run');
+    },
+  });
+}
+
 export function useUpdateFlowRunVariable() {
   const qc = useQueryClient();
   const service = useChatService();

--- a/packages/chat-ui/src/domains/flowruns/queryKeys.ts
+++ b/packages/chat-ui/src/domains/flowruns/queryKeys.ts
@@ -11,4 +11,5 @@ export const flowRunsKeys = {
       'updateVariable',
       { flowRunId, variableName },
     ] as const,
+  cancel: () => [...flowRunsKeys.mutations(), 'cancel'] as const,
 };

--- a/packages/chat-ui/src/messages/MessageComposer.tsx
+++ b/packages/chat-ui/src/messages/MessageComposer.tsx
@@ -171,11 +171,29 @@ export default function MessageComposer({
   // legacy disabled/dots state stays). The thread id IS the flow-run id;
   // the engine stops within seconds and the thread SSE clears isSending.
   const chatService = useChatService();
-  const cancelFlowRunMutation = useCancelFlowRun();
+  const {
+    mutate: cancelMutate,
+    isPending: cancelPending,
+    isSuccess: cancelAccepted,
+    isError: cancelErrored,
+    reset: cancelReset,
+  } = useCancelFlowRun();
   const canStop = isSending && !!chatService.cancelFlowRun;
+  // Cancellation is cooperative, so there is a gap between the accepted
+  // request and isSending actually flipping — hold a disabled "Stopping…"
+  // state across it instead of allowing repeat clicks.
+  const stopping = cancelPending || cancelAccepted;
   const handleStopRun = () => {
-    cancelFlowRunMutation.mutate(threadId);
+    if (stopping) return;
+    cancelMutate(threadId);
   };
+  // Re-arm for the next run: without the reset, a later message's Stop
+  // button would be born stuck in the "Stopping…" state.
+  useEffect(() => {
+    if (!isSending && (cancelAccepted || cancelErrored)) {
+      cancelReset();
+    }
+  }, [isSending, cancelAccepted, cancelErrored, cancelReset]);
   // Provide a global downloader for ssImage node views (non-React context).
   // Milkdown's image node view reads `window.__ssDownloadFile` by name on
   // first render, so an effect-based assignment runs early enough.
@@ -515,9 +533,14 @@ export default function MessageComposer({
                   <IconButton
                     onClick={handleStopRun}
                     className="h-10 w-10 rounded-full self-end"
-                    aria-label="Stop"
+                    disabled={stopping}
+                    aria-label={stopping ? 'Stopping' : 'Stop'}
                   >
-                    <Square className="h-4 w-4 fill-current" />
+                    <Square
+                      className={`h-4 w-4 fill-current ${
+                        stopping ? 'animate-pulse' : ''
+                      }`}
+                    />
                   </IconButton>
                 ) : (
                   <IconButton
@@ -621,9 +644,14 @@ export default function MessageComposer({
                       <IconButton
                         onClick={handleStopRun}
                         className="h-10 w-10 rounded-full"
-                        aria-label="Stop"
+                        disabled={stopping}
+                        aria-label={stopping ? 'Stopping' : 'Stop'}
                       >
-                        <Square className="h-4 w-4 fill-current" />
+                        <Square
+                          className={`h-4 w-4 fill-current ${
+                            stopping ? 'animate-pulse' : ''
+                          }`}
+                        />
                       </IconButton>
                     ) : (
                       <IconButton
@@ -664,12 +692,19 @@ export default function MessageComposer({
             {canStop ? (
               <UIButton
                 onClick={handleStopRun}
-                className="text-xs h-7 px-4 py-1"
-                aria-label="Stop"
+                className={`text-xs h-7 px-4 py-1 ${
+                  stopping ? 'opacity-50 cursor-not-allowed' : ''
+                }`}
+                disabled={stopping}
+                aria-label={stopping ? 'Stopping' : 'Stop'}
               >
                 <span className="flex items-center gap-1.5">
-                  <Square className="h-3 w-3 fill-current" />
-                  Stop
+                  <Square
+                    className={`h-3 w-3 fill-current ${
+                      stopping ? 'animate-pulse' : ''
+                    }`}
+                  />
+                  {stopping ? 'Stopping…' : 'Stop'}
                 </span>
               </UIButton>
             ) : (

--- a/packages/chat-ui/src/messages/MessageComposer.tsx
+++ b/packages/chat-ui/src/messages/MessageComposer.tsx
@@ -13,14 +13,18 @@ import {
   Minimize2,
   Paperclip,
   Presentation,
+  Square,
   X,
 } from 'lucide-react';
 import type * as React from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
+import { useChatService } from '@/platform/chat';
+
 import type { FileInfo } from '@/domains/files/model';
 import { useFileMutations } from '@/domains/files/mutations';
+import { useCancelFlowRun } from '@/domains/flowruns/mutations';
 
 import type { MarkdownEditorHandle } from '@/shared/markdown/MarkdownEditor';
 import { MarkdownEditor } from '@/shared/markdown/MarkdownEditor';
@@ -161,6 +165,17 @@ export default function MessageComposer({
     workspaceId,
     threadId: isDraftThread ? undefined : threadId,
   });
+
+  // While the flow is generating a response, Send's slot becomes a Stop
+  // button (only when the service supports cancellation — otherwise the
+  // legacy disabled/dots state stays). The thread id IS the flow-run id;
+  // the engine stops within seconds and the thread SSE clears isSending.
+  const chatService = useChatService();
+  const cancelFlowRunMutation = useCancelFlowRun();
+  const canStop = isSending && !!chatService.cancelFlowRun;
+  const handleStopRun = () => {
+    cancelFlowRunMutation.mutate(threadId);
+  };
   // Provide a global downloader for ssImage node views (non-React context).
   // Milkdown's image node view reads `window.__ssDownloadFile` by name on
   // first render, so an effect-based assignment runs early enough.
@@ -496,16 +511,26 @@ export default function MessageComposer({
                   </IconButton>
                 )}
 
-                <IconButton
-                  onClick={handleSendMessageAndClear}
-                  className={`h-10 w-10 rounded-full self-end ${
-                    sendDisabled ? 'opacity-50 cursor-not-allowed' : ''
-                  }`}
-                  disabled={sendDisabled}
-                  aria-label="Send"
-                >
-                  <ArrowBigUp className="h-5 w-5" strokeWidth={2.5} />
-                </IconButton>
+                {canStop ? (
+                  <IconButton
+                    onClick={handleStopRun}
+                    className="h-10 w-10 rounded-full self-end"
+                    aria-label="Stop"
+                  >
+                    <Square className="h-4 w-4 fill-current" />
+                  </IconButton>
+                ) : (
+                  <IconButton
+                    onClick={handleSendMessageAndClear}
+                    className={`h-10 w-10 rounded-full self-end ${
+                      sendDisabled ? 'opacity-50 cursor-not-allowed' : ''
+                    }`}
+                    disabled={sendDisabled}
+                    aria-label="Send"
+                  >
+                    <ArrowBigUp className="h-5 w-5" strokeWidth={2.5} />
+                  </IconButton>
+                )}
               </div>
             ) : (
               <div className="relative px-5 py-2">
@@ -592,16 +617,26 @@ export default function MessageComposer({
                         />
                       </IconButton>
                     )}
-                    <IconButton
-                      onClick={handleSendMessageAndClear}
-                      className={`h-10 w-10 rounded-full ${
-                        sendDisabled ? 'opacity-50 cursor-not-allowed' : ''
-                      }`}
-                      disabled={sendDisabled}
-                      aria-label="Send"
-                    >
-                      <ArrowBigUp className="h-5 w-5" strokeWidth={2.5} />
-                    </IconButton>
+                    {canStop ? (
+                      <IconButton
+                        onClick={handleStopRun}
+                        className="h-10 w-10 rounded-full"
+                        aria-label="Stop"
+                      >
+                        <Square className="h-4 w-4 fill-current" />
+                      </IconButton>
+                    ) : (
+                      <IconButton
+                        onClick={handleSendMessageAndClear}
+                        className={`h-10 w-10 rounded-full ${
+                          sendDisabled ? 'opacity-50 cursor-not-allowed' : ''
+                        }`}
+                        disabled={sendDisabled}
+                        aria-label="Send"
+                      >
+                        <ArrowBigUp className="h-5 w-5" strokeWidth={2.5} />
+                      </IconButton>
+                    )}
                   </div>
                 </div>
               </div>
@@ -626,23 +661,36 @@ export default function MessageComposer({
               )}
             </div>
 
-            <UIButton
-              onClick={handleSendMessageAndClear}
-              className={`text-xs h-7 px-4 py-1 ${
-                sendDisabled ? 'opacity-50 cursor-not-allowed' : ''
-              }`}
-              disabled={sendDisabled}
-            >
-              {isSending ? (
-                <span className="flex items-center gap-1">
-                  <span className="h-1.5 w-1.5 rounded-full bg-background animate-bounce [animation-delay:-0.3s]" />
-                  <span className="h-1.5 w-1.5 rounded-full bg-background animate-bounce [animation-delay:-0.15s]" />
-                  <span className="h-1.5 w-1.5 rounded-full bg-background animate-bounce" />
+            {canStop ? (
+              <UIButton
+                onClick={handleStopRun}
+                className="text-xs h-7 px-4 py-1"
+                aria-label="Stop"
+              >
+                <span className="flex items-center gap-1.5">
+                  <Square className="h-3 w-3 fill-current" />
+                  Stop
                 </span>
-              ) : (
-                'Send'
-              )}
-            </UIButton>
+              </UIButton>
+            ) : (
+              <UIButton
+                onClick={handleSendMessageAndClear}
+                className={`text-xs h-7 px-4 py-1 ${
+                  sendDisabled ? 'opacity-50 cursor-not-allowed' : ''
+                }`}
+                disabled={sendDisabled}
+              >
+                {isSending ? (
+                  <span className="flex items-center gap-1">
+                    <span className="h-1.5 w-1.5 rounded-full bg-background animate-bounce [animation-delay:-0.3s]" />
+                    <span className="h-1.5 w-1.5 rounded-full bg-background animate-bounce [animation-delay:-0.15s]" />
+                    <span className="h-1.5 w-1.5 rounded-full bg-background animate-bounce" />
+                  </span>
+                ) : (
+                  'Send'
+                )}
+              </UIButton>
+            )}
           </div>
         )}
       </div>

--- a/packages/chat-ui/src/platform/chat/ChatService.ts
+++ b/packages/chat-ui/src/platform/chat/ChatService.ts
@@ -98,4 +98,13 @@ export interface ChatService {
     take?: number;
     skip?: number;
   }): Promise<{ data: Model[]; total: number }>;
+
+  /**
+   * Request cancellation of the thread's running flow (the thread id IS the
+   * flow-run id). Cancellation is cooperative: the engine stops between block
+   * executions, typically within seconds, and the terminal SSE frame clears
+   * `isFlowRunning`. Optional so existing service implementations keep
+   * compiling — the composer only shows a Stop button when it is provided.
+   */
+  cancelFlowRun?(flowRunId: string): Promise<void>;
 }

--- a/src/domains/flowruns/service.ts
+++ b/src/domains/flowruns/service.ts
@@ -1,6 +1,7 @@
 import { ChatApi, ChatZod } from '@smartspace/api-client';
 
 import { api } from '@/platform/api';
+import type { AppError } from '@/platform/envelopes';
 import { parseOrThrow } from '@/platform/validation';
 
 import { mapFlowRunVariablesDtoToModel } from './mapper';
@@ -30,4 +31,16 @@ export async function updateFlowRunVariable(
       headers: { 'Content-Type': 'application/json' },
     }
   );
+}
+
+// Raw call (endpoint newer than the generated client — swap once the SDK
+// republishes). Conflict (409) = the run finished before the cancel landed;
+// success as far as the UI is concerned, the running flag clears on its own.
+export async function cancelFlowRun(flowRunId: string) {
+  try {
+    await api.post(`/flowruns/${flowRunId}/cancel`);
+  } catch (error) {
+    if ((error as AppError)?.type === 'Conflict') return;
+    throw error;
+  }
 }

--- a/src/platform/chat/defaultChatService.ts
+++ b/src/platform/chat/defaultChatService.ts
@@ -5,6 +5,7 @@ import {
   uploadFiles as filesUploadFiles,
 } from '@/domains/files/service';
 import {
+  cancelFlowRun as flowrunsCancelFlowRun,
   fetchFlowRunVariables as flowrunsFetchFlowRunVariables,
   updateFlowRunVariable as flowrunsUpdateFlowRunVariable,
 } from '@/domains/flowruns/service';
@@ -75,6 +76,8 @@ export function createDefaultChatService(): ChatService {
     },
 
     fetchModels: (opts) => modelsFetchModels(opts),
+
+    cancelFlowRun: (flowRunId) => flowrunsCancelFlowRun(flowRunId),
   };
 }
 


### PR DESCRIPTION
## Why

There is no way to stop a running response from the chat UI — the Send button just turns into disabled bouncing dots until the flow finishes. The backend now supports cooperative flow-run cancellation (ai-api #879/#883/#885, app-api #973): the thread id IS the flow-run id, and `POST /flowruns/{id}/cancel` stops the engine between block executions within seconds.

## What

**chat-ui package**
- `ChatService.cancelFlowRun?` — optional, so existing service implementations keep compiling; the composer only swaps the button when the service provides it (otherwise the legacy dots stay).
- `useCancelFlowRun` mutation in the flowruns domain (draft-thread no-op, toast on error).
- `MessageComposer`: while `isSending`, all three Send slots (mobile icon, fullscreen icon, desktop text button) render an enabled **Stop** button (filled square) instead of the disabled Send/dots. The engine stop flips `isFlowRunning` via the thread SSE, which flips the button back — no new state machinery.

**app**
- `cancelFlowRun` in the flowruns service (raw `api.post` — endpoint newer than the generated client, same precedent as `updateFlowRunVariable`; a `Conflict` AppError = run finished before the cancel landed, treated as success).
- Wired into `createDefaultChatService`.

## Notes

- Needs app-api #973 deployed for the full round trip; against an older backend the click surfaces the platform error toast, nothing breaks.
- ai-api #885 ensures a cancelled response can't mislabel a later failed message on the same thread (stale `cancelledAt` cleared on re-entry).
- The admin sandbox currently portals its own stop button next to this composer (Smartspace-app #1700); once this ships and the package bumps there, the sandbox service can implement `cancelFlowRun` and drop the portal.

## Testing

Package dist rebuilt; app `tsc` clean; lint-staged hooks green. Manual once backends deploy: send a message to a slow flow, hit Stop, response halts within seconds and Send returns.