### PR TITLE
chore(deps): gate React major bumps out of the dependabot react group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,21 @@ updates:
       timezone: Pacific/Auckland
     target-branch: develop
     open-pull-requests-limit: 3
+    # React 19 is a deliberate migration, not a routine bump — it needs
+    # cloneElement typing fixes in src/shared/ui/mui-compat/, @testing-library/react
+    # on 16.x, and widened peer ranges in packages/chat-ui. Left ungated, the react
+    # group re-proposes it every week and the PR fails CI every time (#324, #348,
+    # #402 all closed or red). Gate the majors so the group's minors keep flowing;
+    # drop these entries when the migration is actually scheduled.
+    ignore:
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react-dom"
+        update-types: ["version-update:semver-major"]
     groups:
       react:
         patterns:
@@ -59,6 +74,17 @@ updates:
       timezone: Pacific/Auckland
     target-branch: develop
     open-pull-requests-limit: 3
+    # Mirrors the root entry above — chat-ui declares react/react-dom as peer
+    # dependencies, so its React major has to move in lockstep with the app's.
+    ignore:
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react-dom"
+        update-types: ["version-update:semver-major"]
     groups:
       react:
         patterns:


### PR DESCRIPTION
## Why

The `react` dependabot group has re-proposed the React 18 → 19 migration every week since June. Every attempt has failed CI identically:

| PR | Opened | Outcome |
|---|---|---|
| #324 | Jun 3 | 18.3.1 → 19.2.7 — closed unmerged |
| #348 | Jun 8 | 18.3.1 → 19.2.8 — closed Aug 2, superseded |
| #402 | Aug 2 | 18.3.1 → 19.2.8 — red since it was opened |

Closing the PR teaches Dependabot nothing; it opens a fresh one as soon as the version set shifts (`react-ace` 15 landing is what turned #348's "9 updates" into #402's "10").

## What actually breaks

**TypeScript — 5 errors.** `@types/react` 19 narrows `ReactElement`'s default props from `any` to `unknown`, so `cloneElement(children, { onClick })` resolves to `Partial<unknown> & Attributes` and rejects every prop. Hits all five call sites in `src/shared/ui/mui-compat/`: `alert-dialog.tsx:15`, `dialog.tsx:44`, `dropdown-menu.tsx:36`, `popover.tsx:60`, `sheet.tsx:14`.

**Vitest — 7 failures.** `@testing-library/react` is pinned at 15.0.6, which declares `react: ^18.0.0`. Against a React 19 runtime the dispatcher is null — `Cannot read properties of null (reading 'useContext')` throughout `src/domains/messages/__tests__/mutations.spec.tsx`. RTL 16.x is the React 19 line, and it isn't in the react group, so Dependabot will never fix this on its own.

**Peer ranges.** `packages/chat-ui` declares `react`/`react-dom` `^18.3.1` as peers. Merging root-only leaves every chat-ui consumer with unmet peers, forks included.

Worth noting what *isn't* a blocker: MUI 6.5.0 already accepts React 19 (`^17 || ^18 || ^19`), as do jsonforms, milkdown, and react-ace. The migration is real but narrower than it looks.

## This change

An `ignore` block gating `semver-major` for `react`, `react-dom`, `@types/react`, `@types/react-dom` on both npm entries — root and `/packages/chat-ui`. Both, because chat-ui declares react as a peer and its major has to move in lockstep.

Groups, patterns, and catch-all ordering are untouched. The group's minors keep flowing; only the React majors are gated. Comments in the file point at what to do when the migration gets scheduled, and say to drop the entries then.

## Note on when this takes effect

Dependabot reads `dependabot.yml` from the **default branch** (`main`). This lands on `develop`, so it won't bite until the standing release PR promotes it. Until then Dependabot runs on the old config and can re-open #402 — `@dependabot ignore this major version` on that PR is the lever that works immediately.

## Not covered

`react-ace` 14→15, `react-markdown` 9→10, and `react-virtualized-auto-sizer` 1→2 are still ungated majors in the same group and will appear in the next weekly PR. They may pass CI standalone, but all three sit outside chat-ui's peer ranges — deliberately left as a separate scope call.

## Test plan

- [x] YAML parses; `ignore` schema valid; `other` catch-all still last in every group
- [ ] Next Monday's react-group PR carries no React major (verifiable only after promotion to `main`)
