### PR TITLE
Fix/no workspaces access redirect

### DIFF
--- a/src/pages/no_workspaces_available.tsx
+++ b/src/pages/no_workspaces_available.tsx
@@ -14,13 +14,14 @@ import {
 
 // Polled while this page stays mounted, so a user granted workspace access
 // (e.g. via admin's access control tab) gets redirected automatically
-// instead of being stuck here until they reload the tab. Background/focus
-// overrides matter here specifically because the realistic flow is
-// granting access from an *other* tab (Admin UI) then switching back —
-// the app's QueryClient default disables refetchOnWindowFocus globally, and
-// React Query pauses refetchInterval in the background by default too, so
-// without these overrides that switch-back would sit stale until the next
-// 15s tick instead of checking immediately.
+// instead of being stuck here until they reload the tab. refetchOnWindowFocus
+// overrides the app's QueryClient default (disabled globally) because the
+// realistic flow is granting access from an *other* tab (Admin UI) then
+// switching back — that switch-back should check immediately, not wait for
+// the next 15s tick. Deliberately NOT refetchIntervalInBackground: a user
+// with no workspace access is exactly who leaves this tab open and walks
+// away, and background polling would mean indefinite request traffic per
+// abandoned tab for no UX benefit (focus already covers the return trip).
 const ACCESS_POLL_INTERVAL_MS = 15_000;
 
 export default function NoWorkspacesAvailable() {
@@ -28,15 +29,19 @@ export default function NoWorkspacesAvailable() {
   const { data: workspaces } = useQuery({
     ...workspacesListOptions(),
     refetchInterval: ACCESS_POLL_INTERVAL_MS,
-    refetchIntervalInBackground: true,
     refetchOnWindowFocus: true,
   });
 
   useEffect(() => {
     if (workspaces?.length) {
+      // replace: true — this fires after the user already has a history
+      // entry for /workspace/no-workspaces from before access was granted.
+      // A plain push leaves Back trapped: no-workspaces' loader sees access
+      // now exists and redirects forward again.
       navigate({
         to: '/workspace/$workspaceId',
         params: { workspaceId: workspaces[0].id },
+        replace: true,
       });
     }
   }, [workspaces, navigate]);

--- a/src/pages/no_workspaces_available.tsx
+++ b/src/pages/no_workspaces_available.tsx
@@ -1,20 +1,52 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui/mui-compat/card'
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { useEffect } from 'react';
+
+import { workspacesListOptions } from '@/domains/workspaces';
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/shared/ui/mui-compat/card';
+
+// Polled while this page stays mounted, so a user granted workspace access
+// (e.g. via admin's access control tab) gets redirected automatically
+// instead of being stuck here until they reload the tab.
+const ACCESS_POLL_INTERVAL_MS = 15_000;
 
 export default function NoWorkspacesAvailable() {
+  const navigate = useNavigate();
+  const { data: workspaces } = useQuery({
+    ...workspacesListOptions(),
+    refetchInterval: ACCESS_POLL_INTERVAL_MS,
+  });
+
+  useEffect(() => {
+    if (workspaces?.length) {
+      navigate({
+        to: '/workspace/$workspaceId',
+        params: { workspaceId: workspaces[0].id },
+      });
+    }
+  }, [workspaces, navigate]);
 
   return (
     <div className="fixed inset-0 z-[1] flex items-center justify-center px-4">
       <Card className="w-full max-w-lg rounded-2xl shadow-xl">
         <CardHeader className="items-center text-center space-y-4 px-6 pt-10 pb-16">
-          <CardTitle className="text-2xl md:text-3xl text-gray-700 dark:text-gray-200">No Workspaces Available</CardTitle>
+          <CardTitle className="text-2xl md:text-3xl text-gray-700 dark:text-gray-200">
+            No Workspaces Available
+          </CardTitle>
           <CardDescription className="text-sm md:text-base max-w-md mx-auto text-gray-500 dark:text-gray-400">
-            It looks like you don't have access to any workspaces yet. Please contact your administrator
-            to get access to a workspace.
+            It looks like you don't have access to any workspaces yet. Please
+            contact your administrator to get access to a workspace.
           </CardDescription>
         </CardHeader>
-        <CardContent className="px-6 pb-8 text-[11px] text-gray-600 dark:text-gray-300">
-        </CardContent>
+        <CardContent className="px-6 pb-8 text-[11px] text-gray-600 dark:text-gray-300"></CardContent>
       </Card>
     </div>
-  )
+  );
 }

--- a/src/pages/no_workspaces_available.tsx
+++ b/src/pages/no_workspaces_available.tsx
@@ -14,7 +14,13 @@ import {
 
 // Polled while this page stays mounted, so a user granted workspace access
 // (e.g. via admin's access control tab) gets redirected automatically
-// instead of being stuck here until they reload the tab.
+// instead of being stuck here until they reload the tab. Background/focus
+// overrides matter here specifically because the realistic flow is
+// granting access from an *other* tab (Admin UI) then switching back —
+// the app's QueryClient default disables refetchOnWindowFocus globally, and
+// React Query pauses refetchInterval in the background by default too, so
+// without these overrides that switch-back would sit stale until the next
+// 15s tick instead of checking immediately.
 const ACCESS_POLL_INTERVAL_MS = 15_000;
 
 export default function NoWorkspacesAvailable() {
@@ -22,6 +28,8 @@ export default function NoWorkspacesAvailable() {
   const { data: workspaces } = useQuery({
     ...workspacesListOptions(),
     refetchInterval: ACCESS_POLL_INTERVAL_MS,
+    refetchIntervalInBackground: true,
+    refetchOnWindowFocus: true,
   });
 
   useEffect(() => {

--- a/src/routes/_protected/workspace/$workspaceId/_layout.tsx
+++ b/src/routes/_protected/workspace/$workspaceId/_layout.tsx
@@ -1,9 +1,10 @@
 // routes/_protected/workspace/$workspaceId/_layout.tsx
-import { createFileRoute, Outlet } from '@tanstack/react-router';
+import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
 import { Suspense, useEffect, useMemo, type ReactNode } from 'react';
 
 import { useUserDisplayName, useUserId } from '@/platform/auth/session';
 import { defaultChatService } from '@/platform/chat/defaultChatService';
+import { isNotFoundError } from '@/platform/envelopes';
 import {
   RouteIdsProvider,
   useRouteIds,
@@ -83,13 +84,25 @@ function WorkspaceBodyBackground() {
 export const Route = createFileRoute(
   '/_protected/workspace/$workspaceId/_layout'
 )({
-  loader: ({ params, context }) =>
-    context.queryClient.ensureQueryData(
-      workspaceDetailOptions({
-        service: defaultChatService,
-        workspaceId: params.workspaceId,
-      })
-    ),
+  loader: async ({ params, context }) => {
+    try {
+      return await context.queryClient.ensureQueryData(
+        workspaceDetailOptions({
+          service: defaultChatService,
+          workspaceId: params.workspaceId,
+        })
+      );
+    } catch (e: unknown) {
+      // Access can be revoked (or the workspace deleted) while a user is
+      // already viewing it, or they can navigate back to a stale URL for a
+      // workspace they've since lost access to. Without this, the 404
+      // bubbles into ProtectedErrorBoundary as a generic "Oops" screen
+      // instead of sending them back to /workspace, whose own loader picks
+      // another accessible workspace or lands on /workspace/no-workspaces.
+      if (!isNotFoundError(e)) throw e;
+      throw redirect({ to: '/workspace', replace: true });
+    }
+  },
   component: () => (
     <RouteIdsProvider>
       <ChatProviderBridge>

--- a/src/routes/_protected/workspace/no-workspaces.tsx
+++ b/src/routes/_protected/workspace/no-workspaces.tsx
@@ -1,8 +1,25 @@
 // src/routes/_protected/workspace/no-workspaces.tsx
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, redirect } from '@tanstack/react-router';
 
-import NoWorkspacesAvailable from '@/pages/no_workspaces_available'
+import { workspacesListOptions } from '@/domains/workspaces';
+
+import NoWorkspacesAvailable from '@/pages/no_workspaces_available';
 
 export const Route = createFileRoute('/_protected/workspace/no-workspaces')({
+  loader: async ({ context }) => {
+    // Bypass the list's normal 30s staleTime: the user may have just been
+    // granted access to a workspace (e.g. via admin's access control tab),
+    // and a cached "no access" result would strand them here on refresh.
+    const list = await context.queryClient.ensureQueryData({
+      ...workspacesListOptions(),
+      staleTime: 0,
+    });
+    if (list?.length) {
+      throw redirect({
+        to: '/workspace/$workspaceId',
+        params: { workspaceId: list[0].id },
+      });
+    }
+  },
   component: NoWorkspacesAvailable,
-})
+});

--- a/src/routes/_protected/workspace/no-workspaces.tsx
+++ b/src/routes/_protected/workspace/no-workspaces.tsx
@@ -7,13 +7,23 @@ import NoWorkspacesAvailable from '@/pages/no_workspaces_available';
 
 export const Route = createFileRoute('/_protected/workspace/no-workspaces')({
   loader: async ({ context }) => {
-    // Bypass the list's normal 30s staleTime: the user may have just been
-    // granted access to a workspace (e.g. via admin's access control tab),
-    // and a cached "no access" result would strand them here on refresh.
-    const list = await context.queryClient.ensureQueryData({
-      ...workspacesListOptions(),
-      staleTime: 0,
-    });
+    // fetchQuery, not ensureQueryData: ensureQueryData only fetches when the
+    // cache is empty, returning whatever's cached otherwise regardless of
+    // staleTime — it wouldn't bypass a cached "no access" result the way we
+    // need here. fetchQuery treats staleTime: 0 as "always refetch", so a
+    // user who was just granted access (e.g. via admin's access control tab)
+    // isn't stranded by a stale cached result on refresh.
+    //
+    // Fails open on error (backend 5xx past retries, transient auth glitch):
+    // this page used to be fully static and could never error, so a thrown
+    // fetch here would newly regress a no-access user on a flaky backend
+    // into ProtectedErrorBoundary instead of the intended card.
+    const list = await context.queryClient
+      .fetchQuery({
+        ...workspacesListOptions(),
+        staleTime: 0,
+      })
+      .catch(() => undefined);
     if (list?.length) {
       throw redirect({
         to: '/workspace/$workspaceId',


### PR DESCRIPTION
Fixes the no-workspaces page not detecting when a user is granted workspace access — previously it was fully static and never re-checked, not even on a manual refresh.

## Changes

- `src/routes/_protected/workspace/no-workspaces.tsx` - added a loader that force-refetches the workspace list on page load (bypassing the list's normal 30s `staleTime`) and redirects to the user's first workspace if access already exists. Covers the refresh/page-load case.
- `src/pages/no_workspaces_available.tsx`- the page now polls the workspace list every 15s while mounted and redirects automatically the moment access is granted, no refresh required.
