### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!-- Title: short, imperative, under 70 chars. Don't repeat a single commit message. -->
+
+## What & why
+<!-- 1-3 bullets: what changed and why it matters. -->
+-
+
+## Test plan
+<!-- How a reviewer can verify this. Required — be specific. -->
+- [ ]
+
+## Risk & rollback
+<!-- Blast radius if this is wrong. How would we roll back? -->
+
+## Screenshots
+<!-- UI changes only. Before / after. Delete this section if N/A. -->
+
+## Linked work
+<!-- Monday ticket URL / ADR / design doc / "n/a" -->


### PR DESCRIPTION
## What & why
- Adds `.github/PULL_REQUEST_TEMPLATE.md`, matching the template already used in Smartspace-app, Smartspace-app-api, and Smartspace-ai-api. This was the only one of the four repos without one.

## Test plan
- [ ] Open a new PR in this repo and confirm GitHub pre-fills the description with the template sections.