### PR TITLE
fix: comment section stays disabled after first message on a new thread

### DIFF
--- a/packages/chat-ui/src/index.ts
+++ b/packages/chat-ui/src/index.ts
@@ -88,6 +88,7 @@ export {
   isDraftThreadId,
   markDraftThreadId,
   unmarkDraftThreadId,
+  useIsDraftThreadId,
 } from './shared/utils/threadId';
 
 // Safe crypto.randomUUID() wrapper with environment fallback.

--- a/packages/chat-ui/src/shared/utils/threadId.ts
+++ b/packages/chat-ui/src/shared/utils/threadId.ts
@@ -1,3 +1,5 @@
+import { useSyncExternalStore } from 'react';
+
 /** Synthetic id for the "New Thread" row in the thread list; links to thread/new route. */
 export const NEW_THREAD_ID = '__new__';
 
@@ -17,6 +19,24 @@ const DRAFT_THREAD_STORAGE_KEY = 'ss:draftThreadIds';
 // Used so useThread/loaders skip fetch for drafts; route params + list cache hold the state.
 const draftThreadIds = new Set<string>();
 let hydratedFromStorage = false;
+
+// isDraftThreadId() is a plain Set lookup, not React state -- components that
+// read it directly can render a stale "still draft" result forever if nothing
+// else happens to re-render them after markDraftThreadId/unmarkDraftThreadId
+// runs elsewhere (e.g. from the thread list's own effect). useIsDraftThreadId
+// below subscribes to this so callers re-render exactly when it changes.
+const draftThreadIdsListeners = new Set<() => void>();
+
+function notifyDraftThreadIdsChanged() {
+  for (const listener of draftThreadIdsListeners) listener();
+}
+
+function subscribeDraftThreadIdsChanged(listener: () => void) {
+  draftThreadIdsListeners.add(listener);
+  return () => {
+    draftThreadIdsListeners.delete(listener);
+  };
+}
 
 function isBrowserStorageAvailable() {
   try {
@@ -61,6 +81,7 @@ export function markDraftThreadId(threadId: string) {
   hydrateFromStorageOnce();
   draftThreadIds.add(threadId);
   persistToStorage();
+  notifyDraftThreadIdsChanged();
 }
 
 export function unmarkDraftThreadId(threadId: string) {
@@ -68,6 +89,7 @@ export function unmarkDraftThreadId(threadId: string) {
   hydrateFromStorageOnce();
   draftThreadIds.delete(threadId);
   persistToStorage();
+  notifyDraftThreadIdsChanged();
 }
 
 export function isDraftThreadId(threadId?: string | null): boolean {
@@ -77,6 +99,20 @@ export function isDraftThreadId(threadId?: string | null): boolean {
 
   hydrateFromStorageOnce();
   return draftThreadIds.has(threadId);
+}
+
+/**
+ * Reactive equivalent of isDraftThreadId() -- re-renders the caller when
+ * markDraftThreadId/unmarkDraftThreadId changes this threadId's status, even
+ * if that happens from an unrelated component (e.g. the thread list noticing
+ * a draft is now server-backed). Use this in any component whose render
+ * output depends on draft status; the plain function is fine for one-off
+ * checks inside event handlers or non-React code.
+ */
+export function useIsDraftThreadId(threadId?: string | null): boolean {
+  return useSyncExternalStore(subscribeDraftThreadIdsChanged, () =>
+    isDraftThreadId(threadId)
+  );
 }
 
 export function createDraftThreadId(): string {

--- a/src/shared/utils/threadId.ts
+++ b/src/shared/utils/threadId.ts
@@ -8,4 +8,5 @@ export {
   isDraftThreadId,
   markDraftThreadId,
   unmarkDraftThreadId,
+  useIsDraftThreadId,
 } from '@smartspace/chat-ui';

--- a/src/ui/comments_draw/sidebar-right.tsx
+++ b/src/ui/comments_draw/sidebar-right.tsx
@@ -31,7 +31,7 @@ import {
   SidebarHeader,
 } from '@/shared/ui/mui-compat/sidebar';
 import { Tooltip } from '@/shared/ui/mui-compat/tooltip';
-import { isDraftThreadId } from '@/shared/utils/threadId';
+import { useIsDraftThreadId } from '@/shared/utils/threadId';
 
 import type { MarkdownEditorHandle } from '@smartspace/chat-ui';
 import {
@@ -95,7 +95,7 @@ function renderContentWithMentions(
 
 export function SidebarRight() {
   const { threadId, workspaceId } = useRouteIds();
-  const isDraft = isDraftThreadId(threadId);
+  const isDraft = useIsDraftThreadId(threadId);
   const {
     data: rawComments,
     isLoading,


### PR DESCRIPTION
**What & why**
- On a brand-new thread, the comment panel stayed disabled after sending the first message, only a refresh or switching threads re-enabled it.
- The "is this thread still a draft" check was a plain, non-reactive Set lookup; the comment panel had no way to know when it changed elsewhere in the app.
- Added a `useSyncExternalStore`-based hook so the comment panel re-renders automatically the moment the thread stops being a draft.

**## Test plan**
- Create a new thread, send the first message, confirm the comment box enables within a couple seconds without refreshing or switching threads.
- Post a comment on that same freshly-created thread and confirm it submits.
- Confirm existing (non-draft) threads are unaffected — comment box is enabled immediately as before.

## Risk & rollback
Low risk — isolated to one hook and one call site; the underlying draft-tracking Set and its mark/unmark logic are unchanged, only a reactive subscription was added on top. Rollback: revert the commit.

## Linked work
https://creativeq-cast.monday.com/boards/5029212581/pulses/2795149017