### PR TITLE
fix(chat): keep every block's value when they share a flow output

### DIFF
--- a/packages/chat-ui/src/domains/messages/mapper.ts
+++ b/packages/chat-ui/src/domains/messages/mapper.ts
@@ -72,10 +72,13 @@ export function mapMessagesDtoToModels(dto: MessageDto[]): Message[] {
 
 /**
  * Merge a streaming delta into a message. `outputs` is a cumulative snapshot
- * keyed by `(name, type)` per the SSE protocol — when an output streams from
- * "He" → "Hel" → "Hello" we receive three deltas each carrying the full
- * text-so-far, so we replace by key rather than appending. Errors aren't
- * documented as cumulative, so we append them.
+ * keyed by value `id` — when an output streams from "He" → "Hel" → "Hello" we
+ * receive three deltas each carrying the full text-so-far under one id, so we
+ * replace by id rather than appending. Several blocks can be wired into a
+ * single flow output (five render blocks feeding one "Files" output, say);
+ * those arrive under the same NAME but different ids and must all survive,
+ * which is why the key is not `(name, type)`. Errors aren't documented as
+ * cumulative, so we append them.
  */
 export function applyDeltaToMessage(
   target: Message,
@@ -84,8 +87,12 @@ export function applyDeltaToMessage(
   if (!delta.outputs.length && !delta.errors.length) return target;
   const nextValues = (target.values ?? []).slice();
   for (const incoming of delta.outputs) {
-    const idx = nextValues.findIndex(
-      (v) => v.name === incoming.name && v.type === incoming.type
+    const idx = nextValues.findIndex((v) =>
+      // Values with no id come from a server that predates per-output ids;
+      // fall back to the old key so their chunks still replace in place.
+      incoming.id
+        ? v.id === incoming.id
+        : v.name === incoming.name && v.type === incoming.type
     );
     if (idx === -1) nextValues.push(incoming);
     else nextValues[idx] = incoming;

--- a/packages/chat-ui/src/messages/MessageItem.tsx
+++ b/packages/chat-ui/src/messages/MessageItem.tsx
@@ -141,17 +141,22 @@ export const MessageItem: FC<MessageItemProps> = ({
     return Number.isFinite(t) ? t : 0;
   };
 
-  // Sort and collapse duplicate (name, type) entries, retaining the LAST
-  // occurrence of each. Streaming responses can produce one OUTPUT value
-  // per chunk under the same (name, type); without this, each chunk
-  // renders as its own bubble (cumulative-text ladder).
+  // Sort and collapse repeats of the SAME value, retaining the last
+  // occurrence. Streaming responses can produce one OUTPUT value per chunk;
+  // without this, each chunk renders as its own bubble (cumulative-text
+  // ladder). Keyed on `id`, which the server holds still across a streaming
+  // output's chunks — NOT on (name, type), which cannot tell those chunks
+  // apart from several blocks wired into one flow output (five render blocks
+  // feeding a single "Files" output, say) and dropped all but the last file.
   const sortedValues = (message.values ?? [])
     .slice()
     .sort((a, b) => safeTime(a.createdAt) - safeTime(b.createdAt));
   const slotByKey = new Map<string, number>();
   const values: typeof sortedValues = [];
   for (const v of sortedValues) {
-    const key = `${v.name}|${v.type}`;
+    // Fall back to (name, type) for values with no id, so a chunk stream from
+    // an older server still collapses rather than laddering.
+    const key = v.id ? `id|${v.id}` : `nametype|${v.name}|${v.type}`;
     const existing = slotByKey.get(key);
     if (existing !== undefined) {
       values[existing] = v;

--- a/src/domains/messages/__tests__/sharedOutputValues.spec.ts
+++ b/src/domains/messages/__tests__/sharedOutputValues.spec.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Message, MessageValue } from '@smartspace/chat-ui';
+import { applyDeltaToMessage, MessageValueType } from '@smartspace/chat-ui';
+
+/**
+ * Several blocks can be wired into ONE flow output — five render blocks
+ * feeding a single "Files" output, say. Those values share a NAME but are
+ * independent, so merging deltas by (name, type) dropped all but the last
+ * file. Merging by value id keeps them apart while still collapsing the
+ * cumulative chunks of a streaming output, which reuse one id.
+ */
+
+const value = (
+  id: string,
+  name: string,
+  v: unknown,
+  createdAt = new Date('2026-08-07T02:28:13Z')
+): MessageValue => ({
+  id,
+  name,
+  type: MessageValueType.OUTPUT,
+  value: v,
+  channels: {},
+  createdAt,
+  createdBy: 'Toby Hayward',
+});
+
+const emptyMessage = (): Message => ({
+  id: 'message-1',
+  createdAt: new Date('2026-08-07T02:27:14Z'),
+  values: [],
+});
+
+const apply = (target: Message, outputs: MessageValue[]): Message =>
+  applyDeltaToMessage(target, { outputs, errors: [] });
+
+describe('applyDeltaToMessage', () => {
+  it('keeps every block wired into one flow output', () => {
+    let message = emptyMessage();
+
+    for (const [id, file] of [
+      ['out-docx', 'playground.docx'],
+      ['out-pdf', 'playground.pdf'],
+      ['out-html', 'playground.html'],
+      ['out-pptx', 'playground.pptx'],
+      ['out-xlsx', 'playground.xlsx'],
+    ] as const) {
+      message = apply(message, [value(id, 'Files', file)]);
+    }
+
+    expect(message.values?.map((v) => v.value)).toEqual([
+      'playground.docx',
+      'playground.pdf',
+      'playground.html',
+      'playground.pptx',
+      'playground.xlsx',
+    ]);
+  });
+
+  it('collapses the cumulative chunks of one streaming output', () => {
+    let message = emptyMessage();
+
+    for (const text of ['He', 'Hel', 'Hello']) {
+      message = apply(message, [value('out-response', 'response', text)]);
+    }
+
+    expect(message.values).toHaveLength(1);
+    expect(message.values?.[0].value).toBe('Hello');
+  });
+
+  it('separates a streamed response from files sharing one output', () => {
+    let message = emptyMessage();
+
+    message = apply(message, [value('out-docx', 'Files', 'playground.docx')]);
+    message = apply(message, [value('out-response', 'response', 'Gener')]);
+    message = apply(message, [value('out-pptx', 'Files', 'playground.pptx')]);
+    message = apply(message, [
+      value('out-response', 'response', 'Generated: 5 files'),
+    ]);
+
+    expect(message.values).toHaveLength(3);
+    expect(
+      message.values?.filter((v) => v.name === 'Files').map((v) => v.value)
+    ).toEqual(['playground.docx', 'playground.pptx']);
+    expect(message.values?.find((v) => v.name === 'response')?.value).toBe(
+      'Generated: 5 files'
+    );
+  });
+
+  it('falls back to name and type when a value carries no id', () => {
+    // An older server sends no per-value id; its chunks must still replace in
+    // place rather than laddering.
+    let message = emptyMessage();
+
+    for (const text of ['He', 'Hello']) {
+      message = apply(message, [
+        { ...value('', 'response', text), id: undefined as unknown as string },
+      ]);
+    }
+
+    expect(message.values).toHaveLength(1);
+    expect(message.values?.[0].value).toBe('Hello');
+  });
+});


### PR DESCRIPTION
## Problem

Several blocks can be wired into one flow output — five render blocks (docx / pdf / html / pptx / xlsx) feeding a single `Files` output, say. All five produced a file, but the chat showed one.

Two places collapsed on `(name, type)`:

- `applyDeltaToMessage` matched an incoming SSE delta against existing values by `(name, type)` and **replaced** rather than appended, so each arriving file overwrote the previous one live.
- `MessageItem` grouped values onto the same key when building bubbles, so even a reloaded thread rendered one bubble.

Both exist to fold the cumulative chunks of a streaming output (`"He"`, `"Hel"`, `"Hello"`) into one bubble. But `(name, type)` cannot tell those chunks apart from independent values that merely share a name.

## Fix

Both now key on the value `id`. The server holds that id still across a streaming output's chunks and gives each independent producer its own, so the streaming collapse still works and the files stop overwriting each other.

Values with no id fall back to `(name, type)`, so a stream from an older server still collapses rather than laddering.

## Tests

New spec covering five blocks on one output, streaming chunk collapse, both interleaved, and the no-id fallback. It imports from `@smartspace/chat-ui` (the built dist), so it exercises the real consumption path.

4 new tests; full suite 239 passed; chat-ui and app typecheck clean; lint clean.

## Ordering

This depends on the matching app-api change, which makes the server keep one `MessageValue` per logical output with a stable id. Merge and deploy that **first** — without it a streaming response arrives as chunks under different ids and would render one bubble per chunk.