### PR TITLE
ci: add gitleaks secret scanning

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,46 @@
+name: Secret scan
+
+on:
+  pull_request:
+  push:
+    branches: [develop, main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: secret-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        env:
+          VERSION: 8.30.1
+        run: |
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin gitleaks
+
+      - name: Scan new commits
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE: ${{ github.event.before }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "pull_request" ]; then
+            RANGE="$BASE_SHA..HEAD"
+          elif [ -n "$BEFORE" ] && [ "$BEFORE" != "0000000000000000000000000000000000000000" ]; then
+            RANGE="$BEFORE..$SHA"
+          else
+            RANGE="-1 $SHA"
+          fi
+          echo "Scanning: $RANGE"
+          gitleaks git --log-opts="$RANGE" --redact --no-banner

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,14 @@
+# Scans only the commits a pull request introduces. History predates the secret
+# cleanup and still holds leaked values, so a full scan would fail permanently.
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Build output, dependency trees and lockfiles"
+targets = ["path"]
+paths = [
+  '''(^|/)(bin|obj|dist|out|build)/''',
+  '''(^|/)(node_modules|\.venv|venv|\.nuget)/''',
+  '''(^|/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock|poetry\.lock|packages\.lock\.json)$''',
+]


### PR DESCRIPTION
Adds automated secret detection so a newly committed credential fails CI.

- Scans only the commits a pull request introduces. History predates the secret cleanup and still contains leaked values, so a full-history scan would fail permanently.
- gitleaks 8.30.1, pinned. `contents: read` only, and `--redact` so no secret can reach a CI log.
- Allowlists build output, dependency trees and lockfiles.

Verified before opening: detection fires on credentials known to be committed in this org, the allowlist suppresses the known entropy false positive, and this branch passes the check.